### PR TITLE
Fix controllers and cleanup tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/controllers/assinaturaController.js
+++ b/controllers/assinaturaController.js
@@ -1,5 +1,5 @@
-const { clientes } = require('../models/data');
+const { planos } = require('../models/data');
 
 exports.listarTodas = (req, res) => {
-  res.json(clientes);
+  res.json(planos);
 };

--- a/controllers/transacaoController.js
+++ b/controllers/transacaoController.js
@@ -3,8 +3,8 @@ const { clientes, planos } = require('../models/data');
 exports.registrar = (req, res) => {
   const { cpf, valor } = req.body;
 
-  if (!cpf || typeof valor !== 'number') {
-    return res.status(400).json({ error: 'CPF e valor são obrigatórios' });
+  if (!cpf || typeof valor !== 'number' || isNaN(valor)) {
+    return res.status(400).json({ error: 'CPF e valor são obrigatórios e o valor deve ser numérico' });
   }
 
   const cliente = clientes.find(c => c.cpf === cpf);

--- a/testes.http
+++ b/testes.http
@@ -1,37 +1,3 @@
-const { clientes, planos } = require('../models/data');
-
-exports.registrar = (req, res) => {
-  const { cpf, valor } = req.body;
-
-  if (!cpf || typeof valor !== 'number') {
-    return res.status(400).json({ error: 'CPF e valor são obrigatórios' });
-  }
-
-  const cliente = clientes.find(c => c.cpf === cpf);
-  if (!cliente) {
-    return res.status(404).json({ error: 'Cliente não encontrado' });
-  }
-
-  const plano = planos[cliente.plano];
-  if (!plano) {
-    return res.status(500).json({ error: 'Plano inválido' });
-  }
-
-  const descontoPercentual = plano.descontoLoja;
-  const valorDesconto = (valor * descontoPercentual) / 100;
-  const valorFinal = valor - valorDesconto;
-
-  const transacao = {
-    cliente: cliente.nome,
-    cpf: cliente.cpf,
-    plano: cliente.plano,
-    valorOriginal: valor,
-    descontoAplicado: `${descontoPercentual}%`,
-    valorFinal
-  };
-
-  res.json(transacao);
-};
 
 ### Teste de transação - plano Essencial
 POST http://localhost:3000/api/transacao


### PR DESCRIPTION
## Summary
- list plan options instead of clients in `assinaturaController`
- validate numeric values in `transacaoController`
- remove leftover code from `testes.http`
- ignore `node_modules`

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_688cc36d9954832ba18627348ec0d1a7