### PR TITLE
feat(supabase): integra supabase-js, .env e persistência de clientes/transações

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+.env
+.env.local

--- a/app.js
+++ b/app.js
@@ -15,10 +15,11 @@ const path = require('path');
 app.use(express.static(path.join(__dirname, 'public')));
 
 // Rotas
-app.use('/api', routes);
+app.use(routes);
 
 console.log("✅ Passou por todos os middlewares... pronto pra escutar");
 
 app.listen(PORT, () => {
-  console.log(`🔥 API Clube de Vantagens rodando em http://localhost:${PORT}`);
+  console.log(`API on http://localhost:${PORT}`);
+  console.log('Supabase conectado →', process.env.SUPABASE_URL);
 });

--- a/controllers/assinaturaController.js
+++ b/controllers/assinaturaController.js
@@ -1,5 +1,31 @@
-const { planos } = require('../models/data');
+const supabase = require('../supabaseClient');
 
-exports.listarTodas = (req, res) => {
-  res.json(planos);
+exports.consultarPorCpf = async (req, res) => {
+  const { cpf } = req.query;
+  if (!cpf) {
+    return res.status(400).json({ error: 'CPF é obrigatório' });
+  }
+  const { data: cliente, error } = await supabase
+    .from('clientes')
+    .select('*')
+    .eq('cpf', cpf)
+    .maybeSingle();
+  if (error) {
+    return res.status(500).json({ error: error.message });
+  }
+  if (!cliente) {
+    return res.status(404).json({ error: 'Cliente não encontrado' });
+  }
+  if (cliente.status !== 'ativo') {
+    return res.status(403).json({ error: 'Assinatura inativa' });
+  }
+  res.json(cliente);
+};
+
+exports.listarTodas = async (req, res) => {
+  const { data, error } = await supabase.from('clientes').select('*');
+  if (error) {
+    return res.status(500).json({ error: error.message });
+  }
+  res.json(data);
 };

--- a/controllers/transacaoController.js
+++ b/controllers/transacaoController.js
@@ -1,34 +1,53 @@
-const { clientes, planos } = require('../models/data');
+const supabase = require('../supabaseClient');
 
-exports.registrar = (req, res) => {
+const descontos = {
+  Essencial: 5,
+  Platinum: 10,
+  Black: 20
+};
+
+exports.registrar = async (req, res) => {
   const { cpf, valor } = req.body;
 
   if (!cpf || typeof valor !== 'number' || isNaN(valor)) {
     return res.status(400).json({ error: 'CPF e valor são obrigatórios e o valor deve ser numérico' });
   }
 
-  const cliente = clientes.find(c => c.cpf === cpf);
+  const { data: cliente, error: clienteError } = await supabase
+    .from('clientes')
+    .select('*')
+    .eq('cpf', cpf)
+    .maybeSingle();
+  if (clienteError) {
+    return res.status(500).json({ error: clienteError.message });
+  }
   if (!cliente) {
     return res.status(404).json({ error: 'Cliente não encontrado' });
   }
-
-  const plano = planos[cliente.plano];
-  if (!plano) {
-    return res.status(500).json({ error: 'Plano inválido' });
+  if (cliente.status !== 'ativo') {
+    return res.status(403).json({ error: 'Assinatura inativa' });
   }
 
-  const descontoPercentual = plano.descontoLoja;
+  const descontoPercentual = descontos[cliente.plano] || 0;
   const valorDesconto = (valor * descontoPercentual) / 100;
   const valorFinal = valor - valorDesconto;
 
-  const transacao = {
+  const { error: insertError } = await supabase.from('transacoes').insert({
+    cpf,
+    valor_original: valor,
+    desconto_aplicado: `${descontoPercentual}%`,
+    valor_final: valorFinal
+  });
+  if (insertError) {
+    return res.status(500).json({ error: insertError.message });
+  }
+
+  res.json({
     cliente: cliente.nome,
-    cpf: cliente.cpf,
+    cpf,
     plano: cliente.plano,
     valorOriginal: valor,
     descontoAplicado: `${descontoPercentual}%`,
     valorFinal
-  };
-
-  res.json(transacao);
+  });
 };

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -1,0 +1,18 @@
+create table if not exists public.clientes (
+  id bigserial primary key,
+  nome text not null,
+  cpf text not null unique,
+  plano text not null,
+  data_adesao timestamp not null default now(),
+  status text not null
+);
+create table if not exists public.transacoes (
+  id bigserial primary key,
+  cpf text not null,
+  valor_original numeric(12,2) not null,
+  desconto_aplicado text not null,
+  valor_final numeric(12,2) not null,
+  data timestamp not null default now()
+);
+create index if not exists idx_clientes_cpf on public.clientes (cpf);
+create index if not exists idx_transacoes_cpf on public.transacoes (cpf);

--- a/package.json
+++ b/package.json
@@ -4,13 +4,16 @@
   "description": "",
   "main": "app.js",
   "scripts": {
-    "start": "node app.js"
+    "start": "node app.js",
+    "dev": "nodemon app.js",
+    "test:api": "node ./tests/ping.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "@supabase/supabase-js": "^2.45.0"
   }
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,15 +1,14 @@
 const express = require('express');
 const router = express.Router();
 
-const clienteController = require('../controllers/clienteController');
 const assinaturaController = require('../controllers/assinaturaController');
 const transacaoController = require('../controllers/transacaoController');
 
-// Buscar cliente por CPF
-router.get('/cliente/:cpf', clienteController.buscarPorCpf);
+// Consultar cliente por CPF
+router.get('/assinaturas', assinaturaController.consultarPorCpf);
 
-// Listar todas assinaturas
-router.get('/assinaturas', assinaturaController.listarTodas);
+// Listar todas as assinaturas
+router.get('/assinaturas/listar', assinaturaController.listarTodas);
 
 // Registrar transação
 router.post('/transacao', transacaoController.registrar);

--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -1,0 +1,88 @@
+let createClient;
+try {
+  ({ createClient } = require('@supabase/supabase-js'));
+} catch (e) {
+  console.warn('supabase-js not installed, using fetch fallback');
+  createClient = (url, anon) => {
+    const headers = {
+      apikey: anon,
+      Authorization: `Bearer ${anon}`,
+      'Content-Type': 'application/json'
+    };
+    return {
+      from(table) {
+        return {
+          select(columns = '*') {
+            const params = new URLSearchParams({ select: columns });
+            const baseUrl = `${url}/rest/v1/${table}?${params}`;
+            const fetchData = async (finalUrl = baseUrl) => {
+              const resp = await fetch(finalUrl, { headers });
+              if (!resp.ok) {
+                return { data: null, error: { message: await resp.text() } };
+              }
+              const data = await resp.json();
+              return { data, error: null };
+            };
+            const builder = {
+              eq(column, value) {
+                params.append(column, `eq.${value}`);
+                const eqUrl = `${url}/rest/v1/${table}?${params}`;
+                return {
+                  maybeSingle: async () => {
+                    const { data, error } = await fetchData(eqUrl);
+                    return { data: data[0] || null, error };
+                  }
+                };
+              },
+              limit(count) {
+                params.append('limit', count);
+                const limitUrl = `${url}/rest/v1/${table}?${params}`;
+                return {
+                  then(resolve, reject) {
+                    fetchData(limitUrl).then(resolve, reject);
+                  }
+                };
+              },
+              then(resolve, reject) {
+                fetchData().then(resolve, reject);
+              }
+            };
+            return builder;
+          },
+          insert: async (payload) => {
+            const resp = await fetch(`${url}/rest/v1/${table}`, {
+              method: 'POST',
+              headers,
+              body: JSON.stringify(payload)
+            });
+            if (!resp.ok) {
+              return { data: null, error: { message: await resp.text() } };
+            }
+            const data = await resp.json();
+            return { data, error: null };
+          }
+        };
+      }
+    };
+  };
+}
+
+try {
+  require('dotenv').config();
+} catch (e) {
+  const fs = require('fs');
+  const path = require('path');
+  const envPath = path.resolve(process.cwd(), '.env');
+  if (fs.existsSync(envPath)) {
+    for (const line of fs.readFileSync(envPath, 'utf8').split('\n')) {
+      const match = line.match(/^([^=]+)=(.*)$/);
+      if (match) process.env[match[1]] = match[2];
+    }
+  }
+}
+
+if (!process.env.SUPABASE_URL || !process.env.SUPABASE_ANON) {
+  throw new Error('Vars SUPABASE_URL/SUPABASE_ANON ausentes do .env');
+}
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_ANON);
+module.exports = supabase;

--- a/testes.http
+++ b/testes.http
@@ -1,27 +1,11 @@
+### Consulta cliente
+GET http://localhost:3000/assinaturas?cpf=12345678900
 
-### Teste de transação - plano Essencial
-POST http://localhost:3000/api/transacao
+### Registrar transação
+POST http://localhost:3000/transacao
 Content-Type: application/json
 
 {
   "cpf": "12345678900",
-  "valor": 200
-}
-
-### Plano Platinum
-POST http://localhost:3000/api/transacao
-Content-Type: application/json
-
-{
-  "cpf": "98765432100",
-  "valor": 500
-}
-
-### Plano Black
-POST http://localhost:3000/api/transacao
-Content-Type: application/json
-
-{
-  "cpf": "11122233344",
-  "valor": 1000
+  "valor": 250.00
 }

--- a/tests/ping.js
+++ b/tests/ping.js
@@ -1,0 +1,10 @@
+const supabase = require('../supabaseClient');
+(async () => {
+  const { data, error } = await supabase.from('clientes').select('id').limit(1);
+  if (error) {
+    console.error('Erro Supabase:', error.message);
+    process.exit(1);
+  }
+  console.log('Supabase OK', data);
+  process.exit(0);
+})();


### PR DESCRIPTION
## Summary
- add Supabase client with fallback and env var checks
- wire controllers and routes for CPF lookup and transactions using Supabase
- document DB schema and basic Supabase ping test

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@supabase%2fsupabase-js)*
- `npm run start`
- `npm run test:api` *(fails: fetch failed, ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_689811a80af8832bb7dc4f378b46cf76