### PR TITLE
feat: add admin seed endpoint

### DIFF
--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -1,0 +1,34 @@
+const supabase = require('../supabaseClient');
+
+exports.seed = async (req, res) => {
+  const registros = [
+    { cpf: '11111111111', nome: 'Cliente Um', plano: 'Essencial', status: 'ativo' },
+    { cpf: '22222222222', nome: 'Cliente Dois', plano: 'Platinum', status: 'ativo' },
+    { cpf: '33333333333', nome: 'Cliente Três', plano: 'Black', status: 'ativo' }
+  ];
+
+  const cpfs = registros.map(r => r.cpf);
+
+  const { data: existentes, error: selectError } = await supabase
+    .from('clientes')
+    .select('cpf')
+    .in('cpf', cpfs);
+
+  if (selectError) {
+    return res.status(500).json({ error: selectError.message });
+  }
+
+  const { error: upsertError } = await supabase
+    .from('clientes')
+    .upsert(registros, { onConflict: 'cpf' });
+
+  if (upsertError) {
+    return res.status(500).json({ error: upsertError.message });
+  }
+
+  const existentesSet = new Set((existentes || []).map(e => e.cpf));
+  const inserted = registros.filter(r => !existentesSet.has(r.cpf)).length;
+  const updated = registros.length - inserted;
+
+  res.json({ ok: true, inserted, updated });
+};

--- a/middlewares/requireAdmin.js
+++ b/middlewares/requireAdmin.js
@@ -1,0 +1,9 @@
+const requireAdmin = (req, res, next) => {
+  const pin = req.headers['x-admin-pin'];
+  if (!pin || pin !== process.env.ADMIN_PIN) {
+    return res.status(401).json({ error: 'PIN inválido' });
+  }
+  next();
+};
+
+module.exports = requireAdmin;

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,6 +3,8 @@ const router = express.Router();
 
 const assinaturaController = require('../controllers/assinaturaController');
 const transacaoController = require('../controllers/transacaoController');
+const adminController = require('../controllers/adminController');
+const requireAdmin = require('../middlewares/requireAdmin');
 
 // Consultar cliente por CPF
 router.get('/assinaturas', assinaturaController.consultarPorCpf);
@@ -12,5 +14,8 @@ router.get('/assinaturas/listar', assinaturaController.listarTodas);
 
 // Registrar transação
 router.post('/transacao', transacaoController.registrar);
+
+// Seed clientes
+router.post('/admin/seed', requireAdmin, adminController.seed);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add middleware for admin PIN validation
- seed clientes via /admin/seed endpoint

## Testing
- `npm run test:api` *(fails: Vars SUPABASE_URL/SUPABASE_ANON ausentes do .env)*

------
https://chatgpt.com/codex/tasks/task_e_689880653820832b923355f76f05056e