### PR TITLE
feat: include payment status and due date

### DIFF
--- a/controllers/transacaoController.js
+++ b/controllers/transacaoController.js
@@ -28,6 +28,10 @@ exports.registrar = async (req, res) => {
     return res.status(403).json({ error: 'Assinatura inativa' });
   }
 
+  // Mock de status de pagamento e vencimento
+  const statusPagamento = 'em dia'; // TODO: integrar com dados reais do Supabase
+  const vencimento = '10/09/2025'; // TODO: integrar com dados reais do Supabase
+
   const descontoPercentual = descontos[cliente.plano] || 0;
   const valorDesconto = (valor * descontoPercentual) / 100;
   const valorFinal = valor - valorDesconto;
@@ -48,6 +52,8 @@ exports.registrar = async (req, res) => {
     plano: cliente.plano,
     valorOriginal: valor,
     descontoAplicado: `${descontoPercentual}%`,
-    valorFinal
+    valorFinal,
+    statusPagamento,
+    vencimento
   });
 };

--- a/public/index.html
+++ b/public/index.html
@@ -119,6 +119,8 @@
           <p>Plano: <strong>${data.plano}</strong></p>
           <p>Desconto Aplicado: ${data.descontoAplicado}</p>
           <p>Valor Final: ${valorFmt}</p>
+          <p>Status do Pagamento: ${data.statusPagamento}</p>
+          <p>Vencimento: ${data.vencimento}</p>
         `;
       } catch (err) {
         alert('Erro ao processar: ' + err.message);


### PR DESCRIPTION
## Summary
- expose mock statusPagamento and vencimento in transacao response
- show payment status and due date in frontend result block

## Testing
- `npm run test:api` *(fails: Vars SUPABASE_URL/SUPABASE_ANON ausentes do .env)*

------
https://chatgpt.com/codex/tasks/task_e_68988ac4fcdc832bbf11309abea4e9c8