### PR TITLE
inclui nome do cliente no retorno de transação

### DIFF
--- a/controllers/transacaoController.js
+++ b/controllers/transacaoController.js
@@ -15,7 +15,7 @@ exports.registrar = async (req, res) => {
 
   const { data: cliente, error: clienteError } = await supabase
     .from('clientes')
-    .select('*')
+    .select('cpf, nome, plano, status')
     .eq('cpf', cpf)
     .maybeSingle();
   if (clienteError) {
@@ -47,7 +47,7 @@ exports.registrar = async (req, res) => {
   }
 
   res.json({
-    cliente: cliente.nome,
+    nome: cliente.nome,
     cpf,
     plano: cliente.plano,
     valorOriginal: valor,

--- a/public/index.html
+++ b/public/index.html
@@ -116,6 +116,7 @@
         const data = await res.json();
         const valorFmt = data.valorFinal.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
         resultadoEl.innerHTML = `
+          <p>Cliente: <strong>${data.nome}</strong></p>
           <p>Plano: <strong>${data.plano}</strong></p>
           <p>Desconto Aplicado: ${data.descontoAplicado}</p>
           <p>Valor Final: ${valorFmt}</p>


### PR DESCRIPTION
## Summary
- retorna nome do cliente no POST /transacao
- exibe o nome do cliente no resultado do front-end

## Testing
- `npm run test:api` *(fails: Vars SUPABASE_URL/SUPABASE_ANON ausentes do .env)*

------
https://chatgpt.com/codex/tasks/task_e_6898a7dd26fc832ba9cefe5744892bed