### PR TITLE
Expose transaction metadata to clients

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -42,6 +42,9 @@
         <div id="row-valor" class="hidden"><span>Valor Final:</span> <strong id="out-valor">—</strong></div>
         <div><span>Status do Pagamento:</span> <strong id="out-status">—</strong></div>
         <div><span>Vencimento:</span> <strong id="out-venc">—</strong></div>
+        <div id="row-tx" class="row-meta hidden">
+          <span id="out-tx"></span>
+        </div>
       </section>
     </main>
 

--- a/public/main.js
+++ b/public/main.js
@@ -184,6 +184,7 @@ async function onConsultar(e){
       data = await res.json();
       renderResultado(data, { showFinance:false });
     }
+    renderTxMeta({});
   } catch (err){
     showToast('error', err.message || 'Erro ao consultar');
   } finally {
@@ -209,7 +210,9 @@ async function onRegistrar(e){
     if (!res.ok) throw new Error('Erro ao registrar');
     const data = await res.json();
     renderResultado(data, { showFinance:true });
-    showToast('success','Transação registrada');
+    const horaLocal = new Date(data.created_at || Date.now()).toLocaleString('pt-BR');
+    showToast('success', `Transação #${data.id} registrada às ${horaLocal}`);
+    renderTxMeta(data);
   } catch (err){
     showToast('error', err.message || 'Erro ao registrar');
   } finally {
@@ -232,3 +235,16 @@ function init() {
 }
 
 document.addEventListener('DOMContentLoaded', init);
+
+function renderTxMeta(data){
+  const elRow = document.getElementById('row-tx');
+  const elOut = document.getElementById('out-tx');
+  if (data && data.id){
+    const dt = new Date(data.created_at || Date.now()).toLocaleString('pt-BR');
+    elOut.textContent = `#${data.id} · ${dt}`;
+    elRow.classList.remove('hidden');
+  } else {
+    elOut.textContent = '';
+    elRow.classList.add('hidden');
+  }
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -23,7 +23,7 @@
 }
 
 .hidden {
-  display:none;
+  display:none!important;
 }
 
 body {


### PR DESCRIPTION
## Summary
- include helper functions and store transactions with id and timestamp
- show toast with transaction id/time and display meta row in card
- ensure `.hidden` utility always hides elements

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:api` *(fails: Vars SUPABASE_URL/SUPABASE_ANON ausentes do .env)*

------
https://chatgpt.com/codex/tasks/task_e_689905f26c68832b9d162c9ebcc13841