### PR TITLE
feat: add admin transaction reports with CSV download

### DIFF
--- a/controllers/reportController.js
+++ b/controllers/reportController.js
@@ -1,0 +1,158 @@
+const supabase = require('../supabaseClient');
+
+const DAY = 24 * 60 * 60 * 1000;
+function parseISOorNull(s) {
+  try {
+    if (!s) return null;
+    const d = new Date(s);
+    return isNaN(d) ? null : d;
+  } catch (_) {
+    return null;
+  }
+}
+function periodFromQuery(q) {
+  const to = parseISOorNull(q.to) || new Date();
+  const from = parseISOorNull(q.from) || new Date(to.getTime() - 30 * DAY);
+  return { from, to };
+}
+function asISOdate(d) {
+  return d.toISOString();
+}
+
+exports.resumo = async (req, res) => {
+  const { from, to } = periodFromQuery(req.query);
+  const { data, error } = await supabase
+    .from('transacoes')
+    .select('cpf,cliente_nome,plano,valor_bruto,valor_final')
+    .gte('created_at', from.toISOString())
+    .lte('created_at', to.toISOString());
+  if (error) return res.status(500).json({ error: error.message });
+
+  const totalTransacoes = data.length;
+  let totalBruto = 0;
+  let totalLiquido = 0;
+  let totalDescontos = 0;
+  const planos = {};
+  const clientes = {};
+
+  for (const tx of data) {
+    const bruto = Number(tx.valor_bruto) || 0;
+    const liquido = Number(tx.valor_final) || 0;
+    const desconto = bruto - liquido;
+
+    totalBruto += bruto;
+    totalLiquido += liquido;
+    totalDescontos += desconto;
+
+    if (!planos[tx.plano])
+      planos[tx.plano] = {
+        plano: tx.plano,
+        qtd: 0,
+        bruto: 0,
+        descontos: 0,
+        liquido: 0,
+      };
+    const p = planos[tx.plano];
+    p.qtd++;
+    p.bruto += bruto;
+    p.descontos += desconto;
+    p.liquido += liquido;
+
+    if (!clientes[tx.cpf])
+      clientes[tx.cpf] = {
+        cpf: tx.cpf,
+        nome: tx.cliente_nome,
+        qtd: 0,
+        bruto: 0,
+        descontos: 0,
+        liquido: 0,
+      };
+    const c = clientes[tx.cpf];
+    c.qtd++;
+    c.bruto += bruto;
+    c.descontos += desconto;
+    c.liquido += liquido;
+  }
+
+  const round = (n) => Number(n.toFixed(2));
+  const porPlano = Object.values(planos).map((p) => ({
+    plano: p.plano,
+    qtd: p.qtd,
+    bruto: round(p.bruto),
+    descontos: round(p.descontos),
+    liquido: round(p.liquido),
+  }));
+  const porCliente = Object.values(clientes).map((c) => ({
+    cpf: c.cpf,
+    nome: c.nome,
+    qtd: c.qtd,
+    bruto: round(c.bruto),
+    descontos: round(c.descontos),
+    liquido: round(c.liquido),
+  }));
+
+  return res.json({
+    periodo: { from: asISOdate(from), to: asISOdate(to) },
+    totalTransacoes,
+    totalBruto: round(totalBruto),
+    totalDescontos: round(totalDescontos),
+    totalLiquido: round(totalLiquido),
+    porPlano,
+    porCliente,
+  });
+};
+
+exports.csv = async (req, res) => {
+  const { from, to } = periodFromQuery(req.query);
+  const q = supabase
+    .from('transacoes')
+    .select(
+      'id,created_at,cpf,cliente_nome,plano,valor_bruto,desconto_aplicado,valor_final,origem'
+    )
+    .gte('created_at', from.toISOString())
+    .lte('created_at', to.toISOString());
+
+  if (req.query.cpf) q.eq('cpf', req.query.cpf);
+  if (req.query.plano) q.eq('plano', req.query.plano);
+
+  const { data, error } = await q;
+  if (error) return res.status(500).json({ error: error.message });
+
+  const header =
+    'id,created_at,cpf,cliente_nome,plano,valor_bruto,desconto_aplicado,valor_final,origem';
+  const escape = (v) => {
+    if (v === null || v === undefined) return '""';
+    return '"' + String(v).replace(/"/g, '""') + '"';
+  };
+  const lines = data.map((row) =>
+    [
+      row.id,
+      row.created_at,
+      row.cpf,
+      escape(row.cliente_nome),
+      escape(row.plano),
+      row.valor_bruto,
+      row.desconto_aplicado,
+      row.valor_final,
+      escape(row.origem),
+    ].join(',')
+  );
+  const csv = [header, ...lines].join('\n');
+
+  const pad = (d) => d.toISOString().slice(0, 10).replace(/-/g, '');
+  res.setHeader('Content-Type', 'text/csv');
+  res.setHeader(
+    'Content-Disposition',
+    `attachment; filename="transacoes-${pad(from)}-${pad(to)}.csv"`
+  );
+  res.send(csv);
+};
+
+module.exports = {
+  DAY,
+  parseISOorNull,
+  periodFromQuery,
+  asISOdate,
+  resumo: exports.resumo,
+  csv: exports.csv,
+};

--- a/middlewares/requireAdmin.js
+++ b/middlewares/requireAdmin.js
@@ -7,3 +7,4 @@ const requireAdmin = (req, res, next) => {
 };
 
 module.exports = requireAdmin;
+module.exports.requireAdmin = requireAdmin;

--- a/public/relatorios.html
+++ b/public/relatorios.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Relatórios - Clube de Vantagens</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <div class="shell">
+    <header class="header" role="banner">
+      <h1>Relatórios</h1>
+    </header>
+
+    <main class="panel" id="main-content">
+      <div class="field">
+        <label class="label" for="pin">PIN admin</label>
+        <input type="password" id="pin" class="input" placeholder="PIN admin" />
+      </div>
+      <div class="field">
+        <label class="label" for="from">De</label>
+        <input type="date" id="from" class="input" />
+      </div>
+      <div class="field">
+        <label class="label" for="to">Até</label>
+        <input type="date" id="to" class="input" />
+      </div>
+      <div class="field">
+        <label class="label" for="cpf">Filtrar CPF (opcional)</label>
+        <input type="text" id="cpf" class="input" placeholder="Filtrar CPF (opcional)" />
+      </div>
+      <div class="field">
+        <label class="label" for="plano">Plano</label>
+        <select id="plano" class="input">
+          <option value="">Todos</option>
+          <option>Essencial</option>
+          <option>Platinum</option>
+          <option>Black</option>
+        </select>
+      </div>
+      <div class="actions">
+        <button type="button" id="btn-resumo" class="btn btn--primary">Gerar Resumo</button>
+        <button type="button" id="btn-csv" class="btn btn--outline">Baixar CSV</button>
+      </div>
+
+      <section id="cards" class="card">
+        <div><span>Total transações:</span> <strong id="out-total">0</strong></div>
+        <div><span>Total bruto:</span> <strong id="out-bruto">R$ 0,00</strong></div>
+        <div><span>Total descontos:</span> <strong id="out-desc">R$ 0,00</strong></div>
+        <div><span>Total líquido:</span> <strong id="out-liq">R$ 0,00</strong></div>
+      </section>
+
+      <section class="card">
+        <h2>Por Plano</h2>
+        <table id="tbl-planos">
+          <thead>
+            <tr>
+              <th>Plano</th><th>Qtd</th><th>Bruto</th><th>Descontos</th><th>Líquido</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </section>
+
+      <section class="card">
+        <h2>Por Cliente</h2>
+        <table id="tbl-clientes">
+          <thead>
+            <tr>
+              <th>CPF</th><th>Nome</th><th>Qtd</th><th>Bruto</th><th>Descontos</th><th>Líquido</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </section>
+
+      <p><a href="/">Voltar ao painel</a></p>
+    </main>
+
+    <footer class="footer">
+      <p>v0.1.0 — Ambiente de Teste — Loja X</p>
+    </footer>
+  </div>
+
+  <script src="/relatorios.js"></script>
+</body>
+</html>

--- a/public/relatorios.js
+++ b/public/relatorios.js
@@ -1,0 +1,104 @@
+function getPin() {
+  const el = document.getElementById('pin');
+  let pin = el.value.trim() || sessionStorage.getItem('admin-pin') || '';
+  if (pin) {
+    sessionStorage.setItem('admin-pin', pin);
+    if (!el.value) el.value = pin;
+  }
+  return pin;
+}
+
+function buildQuery() {
+  const params = new URLSearchParams();
+  const from = document.getElementById('from').value;
+  const to = document.getElementById('to').value;
+  if (from) params.set('from', from);
+  if (to) params.set('to', to);
+  const cpf = document.getElementById('cpf').value.trim();
+  if (cpf) params.set('cpf', cpf);
+  const plano = document.getElementById('plano').value;
+  if (plano) params.set('plano', plano);
+  return params.toString();
+}
+
+function formatBRL(n) {
+  return new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+  }).format(Number(n) || 0);
+}
+
+async function fetchResumo() {
+  const pin = getPin();
+  if (!pin) return alert('Informe o PIN');
+  const q = buildQuery();
+  const res = await fetch(`/admin/relatorios/resumo?${q}`, {
+    headers: { 'x-admin-pin': pin },
+  });
+  if (!res.ok) return alert('Erro ao gerar resumo');
+  const data = await res.json();
+  renderResumo(data);
+}
+
+async function downloadCSV() {
+  const pin = getPin();
+  if (!pin) return alert('Informe o PIN');
+  const q = buildQuery();
+  const res = await fetch(`/admin/relatorios/transacoes.csv?${q}`, {
+    headers: { 'x-admin-pin': pin },
+  });
+  if (!res.ok) return alert('Erro ao baixar');
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  const cd = res.headers.get('Content-Disposition') || '';
+  const m = cd.match(/filename="?([^";]+)"?/);
+  a.download = m ? m[1] : 'transacoes.csv';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+function renderResumo(data) {
+  document.getElementById('out-total').textContent = data.totalTransacoes;
+  document.getElementById('out-bruto').textContent = formatBRL(data.totalBruto);
+  document.getElementById('out-desc').textContent = formatBRL(data.totalDescontos);
+  document.getElementById('out-liq').textContent = formatBRL(data.totalLiquido);
+
+  const tbPlanos = document.querySelector('#tbl-planos tbody');
+  tbPlanos.innerHTML = '';
+  data.porPlano.forEach((p) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${p.plano}</td><td>${p.qtd}</td><td>${formatBRL(
+      p.bruto
+    )}</td><td>${formatBRL(p.descontos)}</td><td>${formatBRL(
+      p.liquido
+    )}</td>`;
+    tbPlanos.appendChild(tr);
+  });
+
+  const tbClientes = document.querySelector('#tbl-clientes tbody');
+  tbClientes.innerHTML = '';
+  data.porCliente.forEach((c) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${c.cpf}</td><td>${c.nome}</td><td>${c.qtd}</td><td>${formatBRL(
+      c.bruto
+    )}</td><td>${formatBRL(c.descontos)}</td><td>${formatBRL(c.liquido)}</td>`;
+    tbClientes.appendChild(tr);
+  });
+}
+
+function init() {
+  const to = new Date();
+  const from = new Date(to.getTime() - 30 * 24 * 60 * 60 * 1000);
+  document.getElementById('to').value = to.toISOString().slice(0, 10);
+  document.getElementById('from').value = from.toISOString().slice(0, 10);
+  const saved = sessionStorage.getItem('admin-pin');
+  if (saved) document.getElementById('pin').value = saved;
+  document.getElementById('btn-resumo').addEventListener('click', fetchResumo);
+  document.getElementById('btn-csv').addEventListener('click', downloadCSV);
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/server.js
+++ b/server.js
@@ -6,7 +6,8 @@ require('dotenv').config();
 const assinaturaController = require('./controllers/assinaturaController');
 const transacaoController = require('./controllers/transacaoController');
 const adminController = require('./controllers/adminController');
-const requireAdmin = require('./middlewares/requireAdmin');
+const report = require('./controllers/reportController');
+const { requireAdmin } = require('./middlewares/requireAdmin');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -29,6 +30,8 @@ app.get('/transacao/preview', transacaoController.preview);
 app.post('/transacao', transacaoController.registrar);
 app.post('/admin/seed', requireAdmin, adminController.seed);
 app.post('/admin/clientes/bulk', requireAdmin, adminController.bulkClientes);
+app.get('/admin/relatorios/resumo', requireAdmin, report.resumo);
+app.get('/admin/relatorios/transacoes.csv', requireAdmin, report.csv);
 
 console.log('✅ Passou por todos os middlewares... pronto pra escutar');
 


### PR DESCRIPTION
## Summary
- add report controller with summary and CSV exports
- expose admin report routes guarded by PIN middleware
- add simple frontend to query reports and download CSV

## Testing
- `SUPABASE_URL=http://localhost SUPABASE_ANON=anon npm run test:api` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68991ac8918c832b8335432b430db2ae