### PR TITLE
feat: manage leads

### DIFF
--- a/controllers/leadController.js
+++ b/controllers/leadController.js
@@ -1,0 +1,158 @@
+const supabase = require('../supabaseClient');
+const PLANOS = new Set(['Essencial', 'Platinum', 'Black']);
+const onlyDigits = s => (String(s||'').match(/\d/g) || []).join('');
+function isEmail(s){ return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(s||'')); }
+
+// simple in-memory rate limit: 5 requests per 5min per IP
+const rateData = {};
+
+exports.publicCreate = async (req, res) => {
+  try {
+    const ip = req.ip || req.connection.remoteAddress;
+    const now = Date.now();
+    const arr = rateData[ip] || [];
+    const recent = arr.filter(t => now - t < 5 * 60 * 1000);
+    recent.push(now);
+    rateData[ip] = recent;
+    if (recent.length > 5) {
+      return res.status(429).json({ error: 'rate limit' });
+    }
+
+    const { nome, cpf, email, telefone, plano, origem, token } = req.body || {};
+    const nomeClean = (nome || '').toString().trim();
+    const cpfClean = onlyDigits(cpf);
+    const emailClean = email ? String(email).trim() : null;
+    const telClean = telefone ? onlyDigits(telefone) : null;
+
+    const errors = [];
+    if (!nomeClean) errors.push('nome obrigatório');
+    if (cpfClean.length !== 11) errors.push('cpf inválido');
+    if (!PLANOS.has(plano)) errors.push('plano inválido');
+    if (emailClean && !isEmail(emailClean)) errors.push('email inválido');
+    if (errors.length) return res.status(400).json({ error: errors.join(', ') });
+
+    if (process.env.RECAPTCHA_SECRET && token) {
+      try {
+        const params = new URLSearchParams();
+        params.set('secret', process.env.RECAPTCHA_SECRET);
+        params.set('response', token);
+        params.set('remoteip', ip);
+        const resp = await fetch('https://www.google.com/recaptcha/api/siteverify', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: params.toString(),
+        });
+        const json = await resp.json();
+        if (!json.success) {
+          return res.status(400).json({ error: 'recaptcha inválido' });
+        }
+      } catch (e) {
+        return res.status(400).json({ error: 'falha recaptcha' });
+      }
+    }
+
+    const { data, error } = await supabase
+      .from('leads')
+      .insert([{ nome: nomeClean, cpf: cpfClean, email: emailClean, telefone: telClean, plano, origem: origem || null, status: 'novo' }])
+      .select('id')
+      .single();
+
+    if (error) return res.status(500).json({ error: error.message });
+    return res.json({ ok: true, id: data.id });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+};
+
+exports.adminList = async (req, res) => {
+  try {
+    const { status, plano, q, limit = 100, offset = 0 } = req.query;
+    const lim = Math.min(parseInt(limit, 10) || 100, 1000);
+    const off = parseInt(offset, 10) || 0;
+    let query = supabase.from('leads').select('*', { count: 'exact' });
+    if (status) query = query.eq('status', status);
+    if (plano) query = query.eq('plano', plano);
+    if (q) {
+      const like = `%${q.trim()}%`;
+      query = query.or(`nome.ilike.${like},email.ilike.${like},telefone.ilike.${like},cpf.ilike.${like}`);
+    }
+    const { data, error, count } = await query
+      .order('created_at', { ascending: false })
+      .range(off, off + lim - 1);
+    if (error) return res.status(500).json({ error: error.message });
+    return res.json({ rows: data, total: count || 0 });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+};
+
+exports.adminExportCsv = async (req, res) => {
+  try {
+    const { status, plano, q, limit = 1000, offset = 0 } = req.query;
+    const lim = Math.min(parseInt(limit, 10) || 1000, 10000);
+    const off = parseInt(offset, 10) || 0;
+    let query = supabase
+      .from('leads')
+      .select('id,created_at,nome,cpf,email,telefone,plano,origem,status');
+    if (status) query = query.eq('status', status);
+    if (plano) query = query.eq('plano', plano);
+    if (q) {
+      const like = `%${q.trim()}%`;
+      query = query.or(`nome.ilike.${like},email.ilike.${like},telefone.ilike.${like},cpf.ilike.${like}`);
+    }
+    const { data, error } = await query
+      .order('created_at', { ascending: false })
+      .range(off, off + lim - 1);
+    if (error) return res.status(500).json({ error: error.message });
+    const header = 'id,created_at,nome,cpf,email,telefone,plano,origem,status';
+    const lines = (data || []).map(r => {
+      return [r.id, r.created_at, r.nome, r.cpf, r.email || '', r.telefone || '', r.plano, r.origem || '', r.status]
+        .map(v => '"' + String(v || '').replace(/"/g, '""') + '"')
+        .join(',');
+    });
+    const csv = [header, ...lines].join('\n');
+    res.setHeader('Content-Type', 'text/csv');
+    res.setHeader('Content-Disposition', 'attachment; filename="leads.csv"');
+    return res.send(csv);
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+};
+
+exports.adminApprove = async (req, res) => {
+  try {
+    const { id, plano } = req.body || {};
+    if (!id) return res.status(400).json({ error: 'id obrigatório' });
+    const { data: lead, error: leadErr } = await supabase
+      .from('leads')
+      .select('*')
+      .eq('id', id)
+      .single();
+    if (leadErr || !lead) return res.status(404).json({ error: 'lead não encontrado' });
+    const finalPlano = plano || lead.plano;
+    if (!PLANOS.has(finalPlano)) return res.status(400).json({ error: 'plano inválido' });
+    const upsert = { cpf: lead.cpf, nome: lead.nome, plano: finalPlano, status: 'ativo' };
+    const { error: upsertErr } = await supabase.from('clientes').upsert(upsert, { onConflict: 'cpf' });
+    if (upsertErr) return res.status(500).json({ error: upsertErr.message });
+    const { error: updErr } = await supabase.from('leads').update({ status: 'aprovado', plano: finalPlano }).eq('id', id);
+    if (updErr) return res.status(500).json({ error: updErr.message });
+    return res.json({ ok: true, cliente: { cpf: lead.cpf, nome: lead.nome, plano: finalPlano } });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+};
+
+exports.adminDiscard = async (req, res) => {
+  try {
+    const { id, notes } = req.body || {};
+    if (!id) return res.status(400).json({ error: 'id obrigatório' });
+    const { error } = await supabase
+      .from('leads')
+      .update({ status: 'descartado', notes: notes || null })
+      .eq('id', id);
+    if (error) return res.status(500).json({ error: error.message });
+    return res.json({ ok: true });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+};

--- a/public/leads-admin.html
+++ b/public/leads-admin.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Leads - Admin</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <div class="shell">
+    <header class="header" role="banner">
+      <h1>Leads</h1>
+    </header>
+
+    <main class="panel" id="main-content">
+      <div class="field">
+        <label class="label" for="pin">PIN admin</label>
+        <input type="password" id="pin" class="input" placeholder="PIN admin" />
+      </div>
+      <div class="field">
+        <label class="label" for="status">Status</label>
+        <select id="status" class="input">
+          <option value="">Todos</option>
+          <option>novo</option>
+          <option>aprovado</option>
+          <option>descartado</option>
+        </select>
+      </div>
+      <div class="field">
+        <label class="label" for="plano">Plano</label>
+        <select id="plano" class="input">
+          <option value="">Todos</option>
+          <option>Essencial</option>
+          <option>Platinum</option>
+          <option>Black</option>
+        </select>
+      </div>
+      <div class="field">
+        <label class="label" for="q">Busca</label>
+        <input type="text" id="q" class="input" placeholder="Nome, email, telefone ou CPF" />
+      </div>
+      <div class="actions">
+        <button type="button" id="btn-buscar" class="btn btn--primary">Buscar</button>
+        <button type="button" id="btn-csv" class="btn btn--outline">Exportar CSV</button>
+      </div>
+
+      <table id="tbl-leads">
+        <thead>
+          <tr>
+            <th>Nome</th><th>CPF</th><th>Email</th><th>Telefone</th><th>Plano</th><th>Origem</th><th>Status</th><th>Ações</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+
+      <p><a href="/">Voltar ao painel</a></p>
+    </main>
+
+    <footer class="footer">
+      <p>v0.1.0 — Ambiente de Teste — Loja X</p>
+    </footer>
+  </div>
+  <script src="/leads-admin.js" defer></script>
+</body>
+</html>

--- a/public/leads-admin.js
+++ b/public/leads-admin.js
@@ -1,0 +1,110 @@
+function getPin() {
+  const el = document.getElementById('pin');
+  let pin = el.value.trim() || sessionStorage.getItem('admin-pin') || '';
+  if (pin) {
+    sessionStorage.setItem('admin-pin', pin);
+    if (!el.value) el.value = pin;
+  }
+  return pin;
+}
+
+function buildQuery() {
+  const params = new URLSearchParams();
+  const status = document.getElementById('status').value;
+  const plano = document.getElementById('plano').value;
+  const q = document.getElementById('q').value.trim();
+  if (status) params.set('status', status);
+  if (plano) params.set('plano', plano);
+  if (q) params.set('q', q);
+  return params.toString();
+}
+
+async function fetchLeads() {
+  const pin = getPin();
+  if (!pin) return alert('Informe o PIN');
+  const q = buildQuery();
+  const res = await fetch(`/admin/leads?${q}`, {
+    headers: { 'x-admin-pin': pin },
+  });
+  if (!res.ok) return alert('Erro ao buscar');
+  const data = await res.json();
+  renderTable(data.rows || []);
+}
+
+function renderTable(rows) {
+  const tbody = document.querySelector('#tbl-leads tbody');
+  tbody.innerHTML = '';
+  rows.forEach((r) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${r.nome}</td><td>${r.cpf}</td><td>${r.email || ''}</td><td>${r.telefone || ''}</td><td>${r.plano}</td><td>${r.origem || ''}</td><td>${r.status}</td><td>${r.status === 'novo' ? '<button class="btn-approve" data-id="' + r.id + '">Aprovar</button> <button class="btn-discard" data-id="' + r.id + '">Descartar</button>' : ''}</td>`;
+    tbody.appendChild(tr);
+  });
+  tbody.querySelectorAll('.btn-approve').forEach((btn) => {
+    btn.addEventListener('click', () => approve(btn.dataset.id));
+  });
+  tbody.querySelectorAll('.btn-discard').forEach((btn) => {
+    btn.addEventListener('click', () => discard(btn.dataset.id));
+  });
+}
+
+async function approve(id) {
+  const pin = getPin();
+  if (!pin) return alert('Informe o PIN');
+  const res = await fetch('/admin/leads/approve', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-admin-pin': pin },
+    body: JSON.stringify({ id }),
+  });
+  if (!res.ok) return alert('Erro ao aprovar');
+  alert('Lead aprovado');
+  fetchLeads();
+}
+
+async function discard(id) {
+  const pin = getPin();
+  if (!pin) return alert('Informe o PIN');
+  const notes = prompt('Motivo do descarte?') || '';
+  const res = await fetch('/admin/leads/discard', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-admin-pin': pin },
+    body: JSON.stringify({ id, notes }),
+  });
+  if (!res.ok) return alert('Erro ao descartar');
+  alert('Lead descartado');
+  fetchLeads();
+}
+
+async function exportCsv() {
+  const pin = getPin();
+  if (!pin) return alert('Informe o PIN');
+  const q = buildQuery();
+  const res = await fetch(`/admin/leads.csv?${q}`, {
+    headers: { 'x-admin-pin': pin },
+  });
+  if (!res.ok) return alert('Erro ao exportar');
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'leads.csv';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+let searchTimer = null;
+function handleSearch() {
+  clearTimeout(searchTimer);
+  searchTimer = setTimeout(fetchLeads, 400);
+}
+
+function init() {
+  const saved = sessionStorage.getItem('admin-pin');
+  if (saved) document.getElementById('pin').value = saved;
+  document.getElementById('btn-buscar').addEventListener('click', fetchLeads);
+  document.getElementById('btn-csv').addEventListener('click', exportCsv);
+  document.getElementById('q').addEventListener('input', handleSearch);
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ const assinaturaController = require('./controllers/assinaturaController');
 const transacaoController = require('./controllers/transacaoController');
 const adminController = require('./controllers/adminController');
 const report = require('./controllers/reportController');
+const lead = require('./controllers/leadController');
 const { requireAdmin } = require('./middlewares/requireAdmin');
 
 const app = express();
@@ -32,6 +33,14 @@ app.post('/admin/seed', requireAdmin, adminController.seed);
 app.post('/admin/clientes/bulk', requireAdmin, adminController.bulkClientes);
 app.get('/admin/relatorios/resumo', requireAdmin, report.resumo);
 app.get('/admin/relatorios/transacoes.csv', requireAdmin, report.csv);
+// público (landing)
+app.post('/public/lead', express.json(), lead.publicCreate);
+
+// admin (PIN)
+app.get('/admin/leads', requireAdmin, lead.adminList);
+app.get('/admin/leads.csv', requireAdmin, lead.adminExportCsv);
+app.post('/admin/leads/approve', requireAdmin, lead.adminApprove);
+app.post('/admin/leads/discard', requireAdmin, lead.adminDiscard);
 
 console.log('✅ Passou por todos os middlewares... pronto pra escutar');
 


### PR DESCRIPTION
## Summary
- add lead management controller and routes
- add simple admin UI to review leads

## Testing
- `npm run test:api` *(fails: Vars SUPABASE_URL/SUPABASE_ANON ausentes do .env)*
- `curl -X POST http://localhost:3000/public/lead -H "Content-Type: application/json" -d '{"nome":"Maria Lead","cpf":"222.222.222-22","email":"maria@ex.com","telefone":"11999998888","plano":"Platinum","origem":"landing"}'` *(error: TypeError: fetch failed)*
- `curl -s -H "x-admin-pin: 2468" "http://localhost:3000/admin/leads?status=novo&limit=10"` *(error: TypeError: fetch failed)*
- `curl -s -X POST -H "x-admin-pin: 2468" -H "Content-Type: application/json" -d '{"id":"00000000-0000-0000-0000-000000000000"}' http://localhost:3000/admin/leads/approve` *(error: lead não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68992443ca04832ba7afefc7aea6445f