### PR TITLE
feat: tornar Mercado Pago opcional

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,11 +16,7 @@ const PORT = process.env.PORT || 3000;
 
 // Middleware
 app.use(cors());
-// Usa JSON para quase todas as rotas, exceto o webhook do Mercado Pago
-app.use((req, res, next) => {
-  if (req.originalUrl === '/mp/webhook') return next();
-  return express.json({ limit: '1mb' })(req, res, next);
-});
+app.use(express.json({ limit: '1mb' }));
 app.use(express.static(path.join(__dirname, 'public')));
 
 // Healthcheck
@@ -48,9 +44,9 @@ app.post('/admin/leads/approve', requireAdmin, lead.adminApprove);
 app.post('/admin/leads/discard', requireAdmin, lead.adminDiscard);
 
 // Mercado Pago
+app.get('/mp/status', mp.status);
 app.post('/mp/checkout', express.json(), mp.createCheckout);
-// Usamos express.raw para capturar o corpo bruto e validar a assinatura do webhook
-app.post('/mp/webhook', express.raw({ type: '*/*' }), mp.webhook);
+app.post('/mp/webhook', mp.webhook);
 
 console.log('✅ Passou por todos os middlewares... pronto pra escutar');
 


### PR DESCRIPTION
## Summary
- add lazy Mercado Pago loading with status endpoint and graceful fallbacks
- expose /mp/status route and simplify webhook parsing

## Testing
- `SUPABASE_URL=http://localhost SUPABASE_ANON=anon npm run test:api`

------
https://chatgpt.com/codex/tasks/task_e_68992d984770832b965b12359ed439a5