### PR TITLE
Add internal ID support and label generation

### DIFF
--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -120,3 +120,50 @@ exports.bulkClientes = async (req, res) => {
     return res.status(500).json({ error: err.message });
   }
 };
+
+function gerarIdInterno() {
+  const digits = '23456789';
+  let out = 'C';
+  for (let i = 0; i < 7; i++) {
+    out += digits[Math.floor(Math.random() * digits.length)];
+  }
+  return out;
+}
+
+async function gerarIdUnico() {
+  while (true) {
+    const id = gerarIdInterno();
+    const { data, error } = await supabase
+      .from('clientes')
+      .select('id')
+      .eq('id_interno', id)
+      .maybeSingle();
+    if (!error && !data) return id;
+  }
+}
+
+exports.generateIds = async (req, res) => {
+  try {
+    const { data: clientes, error } = await supabase
+      .from('clientes')
+      .select('id')
+      .is('id_interno', null);
+    if (error) {
+      return res.status(500).json({ error: error.message });
+    }
+
+    let updated = 0;
+    for (const cli of clientes || []) {
+      const novoId = await gerarIdUnico();
+      const { error: updErr } = await supabase
+        .from('clientes')
+        .update({ id_interno: novoId })
+        .eq('id', cli.id);
+      if (!updErr) updated += 1;
+    }
+
+    res.json({ updated });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};

--- a/controllers/assinaturaController.js
+++ b/controllers/assinaturaController.js
@@ -1,15 +1,16 @@
 const supabase = require('../supabaseClient');
 
-exports.consultarPorCpf = async (req, res) => {
-  const { cpf } = req.query;
-  if (!cpf) {
-    return res.status(400).json({ error: 'CPF é obrigatório' });
+exports.consultarPorIdentificador = async (req, res) => {
+  const { cpf, id } = req.query;
+  let query;
+  if (cpf && /^[0-9]{11}$/.test(cpf)) {
+    query = supabase.from('clientes').select('*').eq('cpf', cpf).maybeSingle();
+  } else if (id && /^C[0-9]{7}$/i.test(id)) {
+    query = supabase.from('clientes').select('*').eq('id_interno', id.toUpperCase()).maybeSingle();
+  } else {
+    return res.status(400).json({ error: 'CPF ou ID inválido' });
   }
-  const { data: cliente, error } = await supabase
-    .from('clientes')
-    .select('*')
-    .eq('cpf', cpf)
-    .maybeSingle();
+  const { data: cliente, error } = await query;
   if (error) {
     return res.status(500).json({ error: error.message });
   }

--- a/controllers/transacaoController.js
+++ b/controllers/transacaoController.js
@@ -5,20 +5,33 @@ const descontoPorPlano = (p) => descontos[p] ?? 0;
 const valorFinalDe = (v, d) => Number((v * (1 - d / 100)).toFixed(2));
 
 exports.preview = async (req, res) => {
-  const { cpf, valor } = req.query;
+  const { cpf, id, valor } = req.query;
   const valorNum = Number(valor);
 
-  if (!/^[0-9]{11}$/.test(cpf) || !Number.isFinite(valorNum) || valorNum <= 0) {
+  if ((!cpf && !id) || !Number.isFinite(valorNum) || valorNum <= 0) {
     return res
       .status(400)
-      .json({ error: 'CPF e valor são obrigatórios e o valor deve ser numérico' });
+      .json({ error: 'identificador e valor são obrigatórios e o valor deve ser numérico' });
   }
 
-  const { data: cliente, error: clienteError } = await supabase
-    .from('clientes')
-    .select('cpf, nome, plano, status')
-    .eq('cpf', cpf)
-    .maybeSingle();
+  let query;
+  if (cpf && /^[0-9]{11}$/.test(cpf)) {
+    query = supabase
+      .from('clientes')
+      .select('cpf, nome, plano, status')
+      .eq('cpf', cpf)
+      .maybeSingle();
+  } else if (id && /^C[0-9]{7}$/i.test(id)) {
+    query = supabase
+      .from('clientes')
+      .select('cpf, nome, plano, status, id_interno')
+      .eq('id_interno', id.toUpperCase())
+      .maybeSingle();
+  } else {
+    return res.status(400).json({ error: 'identificador inválido' });
+  }
+
+  const { data: cliente, error: clienteError } = await query;
   if (clienteError) {
     return res.status(500).json({ error: clienteError.message });
   }
@@ -43,20 +56,33 @@ exports.preview = async (req, res) => {
 };
 
 exports.registrar = async (req, res) => {
-  const { cpf, valor } = req.body;
+  const { cpf, id, valor } = req.body;
   const valorNum = Number(valor);
 
-  if (!/^[0-9]{11}$/.test(cpf) || !Number.isFinite(valorNum) || valorNum <= 0) {
+  if ((!cpf && !id) || !Number.isFinite(valorNum) || valorNum <= 0) {
     return res
       .status(400)
-      .json({ error: 'CPF e valor são obrigatórios e o valor deve ser numérico' });
+      .json({ error: 'identificador e valor são obrigatórios e o valor deve ser numérico' });
   }
 
-  const { data: cliente, error: clienteError } = await supabase
-    .from('clientes')
-    .select('cpf, nome, plano, status')
-    .eq('cpf', cpf)
-    .maybeSingle();
+  let query;
+  if (cpf && /^[0-9]{11}$/.test(cpf)) {
+    query = supabase
+      .from('clientes')
+      .select('cpf, nome, plano, status')
+      .eq('cpf', cpf)
+      .maybeSingle();
+  } else if (id && /^C[0-9]{7}$/i.test(id)) {
+    query = supabase
+      .from('clientes')
+      .select('cpf, nome, plano, status, id_interno')
+      .eq('id_interno', id.toUpperCase())
+      .maybeSingle();
+  } else {
+    return res.status(400).json({ error: 'identificador inválido' });
+  }
+
+  const { data: cliente, error: clienteError } = await query;
   if (clienteError) {
     return res.status(500).json({ error: clienteError.message });
   }
@@ -71,7 +97,7 @@ exports.registrar = async (req, res) => {
   const valorFinal = valorFinalDe(valorNum, desconto);
 
   const payload = {
-    cpf,
+    cpf: cliente.cpf,
     cliente_nome: cliente.nome,
     plano: cliente.plano,
     valor_bruto: valorNum,

--- a/public/etiquetas.html
+++ b/public/etiquetas.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Etiquetas</title>
+  <link rel="stylesheet" href="/styles.css">
+  <style>
+    .etiquetas { display:grid; grid-template-columns:repeat(3,1fr); gap:8px; margin-top:20px; }
+    .etiqueta { border:1px solid #000; padding:4px; font-size:12px; break-inside: avoid; }
+    .etiqueta .id { font-weight:bold; }
+    .etiqueta .cpf { font-size:10px; }
+    .etiqueta svg { width:100%; height:40px; }
+    .etiqueta .qr { width:64px; height:64px; margin-top:4px; }
+    @media print { body * { visibility:hidden; } .etiquetas, .etiquetas * { visibility:visible; } .print-btn { display:none; } }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/jsbarcode@3.11.5/dist/JsBarcode.all.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/qrcodejs@1.0.0/qrcode.min.js"></script>
+</head>
+<body>
+  <div class="container">
+    <header class="header" role="banner">
+      <a href="/" class="logo">Clube de Vantagens</a>
+      <nav class="nav">
+        <a href="/">Painel</a>
+        <a href="/relatorios.html">Relatórios</a>
+        <a href="/etiquetas.html">Etiquetas</a>
+        <a href="/leads-admin.html">Leads (Admin)</a>
+      </nav>
+    </header>
+    <main class="panel">
+      <table id="tab-clientes" class="table">
+        <thead><tr><th>Nome</th><th>CPF</th><th>ID interno</th><th>Ações</th></tr></thead>
+        <tbody></tbody>
+      </table>
+      <div id="etiquetas" class="etiquetas"></div>
+    </main>
+  </div>
+  <script src="/etiquetas.js"></script>
+</body>
+</html>

--- a/public/etiquetas.js
+++ b/public/etiquetas.js
@@ -1,0 +1,32 @@
+async function carregar(){
+  const res = await fetch('/assinaturas/listar');
+  const clientes = await res.json();
+  const tbody = document.querySelector('#tab-clientes tbody');
+  clientes.forEach(cli => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${cli.nome}</td><td>${cli.cpf}</td><td>${cli.id_interno||''}</td>` +
+      `<td><button class="btn btn--small btn-code">Gerar Code128</button> <button class="btn btn--small btn-qr">Gerar QR</button></td>`;
+    tr.querySelector('.btn-code').addEventListener('click', ()=>gerarEtiqueta(cli));
+    tr.querySelector('.btn-qr').addEventListener('click', ()=>gerarEtiqueta(cli));
+    tbody.appendChild(tr);
+  });
+}
+
+function gerarEtiqueta(cli){
+  if(!cli.id_interno) return;
+  const container = document.getElementById('etiquetas');
+  const div = document.createElement('div');
+  div.className = 'etiqueta';
+  div.innerHTML = `<div class="nome">${cli.nome}</div>`+
+    `<div class="id">${cli.id_interno}</div>`+
+    `<div class="cpf">${cli.cpf}</div>`+
+    `<svg class="barcode"></svg>`+
+    `<div class="qr"></div>`+
+    `<button class="btn print-btn">Imprimir</button>`;
+  container.appendChild(div);
+  JsBarcode(div.querySelector('.barcode'), cli.id_interno, {format:'code128', displayValue:false, width:2, height:40});
+  new QRCode(div.querySelector('.qr'), {text: cli.id_interno, width:64, height:64});
+  div.querySelector('.print-btn').addEventListener('click', ()=>window.print());
+}
+
+document.addEventListener('DOMContentLoaded', carregar);

--- a/public/index.html
+++ b/public/index.html
@@ -28,8 +28,8 @@
     <main class="panel" id="main-content">
       <form id="form-transacao" novalidate>
         <div class="field">
-          <label for="cpf" class="label">CPF</label>
-          <input id="cpf" type="text" class="input" autocomplete="off" />
+          <label for="cpf" class="label">CPF ou ID interno</label>
+          <input id="cpf" type="text" class="input" autocomplete="off" placeholder="111.111.111-11 ou C1234567" />
         </div>
         <div class="field money-input">
           <label class="label" for="valor">Valor</label>
@@ -80,8 +80,8 @@
       </div>
 
       <p class="hint">
-        • <strong>Leitor (bipe):</strong> aponte para a etiqueta do CPF e bipar. <br>
-        • <strong>QR Code:</strong> use a câmera do PC/celular para ler o QR do CPF.
+        • <strong>Leitor (bipe):</strong> aponte para a etiqueta do ID interno e bipar. <br>
+        • <strong>QR Code:</strong> use a câmera do PC/celular para ler o QR do ID interno.
       </p>
     </section>
 

--- a/public/leitores
+++ b/public/leitores
@@ -1,0 +1,1 @@
+Leitor (bipe) usa Code128 (ID interno). QR funciona por câmera.

--- a/server.js
+++ b/server.js
@@ -26,13 +26,14 @@ app.get('/health', (req, res) => {
 });
 
 // Rotas
-app.get('/assinaturas', assinaturaController.consultarPorCpf);
+app.get('/assinaturas', assinaturaController.consultarPorIdentificador);
 app.get('/assinaturas/listar', assinaturaController.listarTodas);
 // simula a transação sem registrar
 app.get('/transacao/preview', transacaoController.preview);
 app.post('/transacao', transacaoController.registrar);
 app.post('/admin/seed', requireAdmin, adminController.seed);
 app.post('/admin/clientes/bulk', requireAdmin, adminController.bulkClientes);
+app.post('/admin/clientes/generate-ids', requireAdmin, adminController.generateIds);
 app.get('/admin/relatorios/resumo', requireAdmin, report.resumo);
 app.get('/admin/relatorios/transacoes.csv', requireAdmin, report.csv);
 app.get('/admin/metrics', requireAdmin, metrics.resume);


### PR DESCRIPTION
## Summary
- generate and assign unique internal IDs for clients
- allow CPF or internal ID lookup in subscriptions and transactions
- add label printing page with Code128 and QR codes for internal IDs

## Testing
- `npm run test:api` *(fails: Cannot find module 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68993ff30fe4832bb7fc7faf92058303