### PR TITLE
feat: improve settings dialog UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -96,47 +96,129 @@
       <p>v0.1.0 — Ambiente de Teste — Loja X</p>
     </footer>
   </div>
-  <dialog id="settingsDialog" class="settings-dialog">
-    <form id="settingsForm">
-      <select id="pref-readerMode">
-        <option value="manual">Manual</option>
-        <option value="wedge">Leitor (bipe)</option>
-        <option value="qr">QR Code (câmera)</option>
-      </select>
-      <label><input type="checkbox" id="pref-autoConsultOnScan"> Auto-consultar ao ler</label>
-      <label><input type="checkbox" id="pref-autoRegisterAfterConsult"> Auto-registrar após consultar</label>
-      <label><input type="checkbox" id="pref-focusValueAfterConsult"> Focar no Valor após consultar</label>
-      <label><input type="checkbox" id="pref-beepOnScan"> Beep ao ler</label>
-      <label><input type="checkbox" id="pref-clearCpfAfterRegister"> Limpar CPF após registrar</label>
-      <label><input type="checkbox" id="pref-keepValueAfterRegister"> Manter Valor após registrar</label>
-      <label>Câmera (QR)
-        <select id="pref-qrCameraId"><option value="">Padrão do navegador</option></select>
-      </label>
-      <label>Debounce do leitor (ms)
-        <input type="number" id="pref-wedgeDebounceMs" min="0" step="10" value="40">
-      </label>
-      <label>Tamanho mínimo p/ disparo
-        <input type="number" id="pref-scanMinLength" min="4" step="1" value="11">
-      </label>
-      <details><summary>Avançado</summary>
-        <label>Padrão de ID interno (regex)
-          <input type="text" id="pref-idPattern" value="^C\\d{7}$">
-        </label>
-      </details>
-      <div class="card">
-        <div class="row">
-          <button type="button" id="btn-test-wedge" class="btn btn--outline">Testar leitor (bipe)</button>
-          <button type="button" id="btn-test-qr" class="btn btn--outline">Testar QR</button>
-        </div>
-        <pre id="test-output" class="test-output" aria-live="polite"></pre>
-      </div>
-      <div class="row end">
-        <button type="button" id="btn-reset-prefs" class="btn btn--ghost">Resetar padrão</button>
-        <button type="button" id="btn-close-settings" class="btn btn--ghost">Fechar</button>
-        <button type="submit" class="btn btn--primary">Salvar</button>
-      </div>
-    </form>
-  </dialog>
+    <dialog id="settingsDialog" class="settings-dialog" role="dialog" aria-labelledby="settingsTitle">
+      <form id="settingsForm" method="dialog" class="settings">
+        <header class="dialog-header">
+          <h2 id="settingsTitle" class="dialog-title">Configurações</h2>
+          <button type="button" id="btn-close-settings" class="icon-btn" aria-label="Fechar">✕</button>
+        </header>
+
+        <section class="section">
+          <h3 class="section-title">Comportamento</h3>
+          <div class="form-grid-2">
+            <label class="field">
+              <span>Modo padrão</span>
+              <select id="pref-readerMode" class="input">
+                <option value="manual">Manual</option>
+                <option value="wedge">Leitor (bipe)</option>
+                <option value="qr">QR Code (câmera)</option>
+              </select>
+              <small class="help">Escolhe o modo carregado ao abrir o painel.</small>
+            </label>
+
+            <label class="field">
+              <span>Debounce do leitor (ms)</span>
+              <input id="pref-wedgeDebounceMs" type="number" min="0" step="10" value="40" class="input" />
+              <small class="help">Evita ruído do leitor “bipe”.</small>
+            </label>
+
+            <label class="field">
+              <span>Tamanho mínimo p/ disparo</span>
+              <input id="pref-scanMinLength" type="number" min="4" step="1" value="11" class="input" />
+              <small class="help">Ex.: 11 para CPF.</small>
+            </label>
+          </div>
+
+          <div class="switches">
+            <label class="switch">
+              <input id="pref-autoConsultOnScan" type="checkbox" />
+              <span class="slider" aria-hidden="true"></span>
+              <span class="switch-label">Auto-consultar ao ler</span>
+            </label>
+            <label class="switch">
+              <input id="pref-beepOnScan" type="checkbox" />
+              <span class="slider" aria-hidden="true"></span>
+              <span class="switch-label">Beep ao ler</span>
+            </label>
+          </div>
+        </section>
+
+        <hr class="divider" />
+
+        <section class="section">
+          <h3 class="section-title">Pós-ação</h3>
+          <div class="switches">
+            <label class="switch">
+              <input id="pref-autoRegisterAfterConsult" type="checkbox" />
+              <span class="slider" aria-hidden="true"></span>
+              <span class="switch-label">Auto-registrar após consultar</span>
+            </label>
+            <label class="switch">
+              <input id="pref-focusValueAfterConsult" type="checkbox" />
+              <span class="slider" aria-hidden="true"></span>
+              <span class="switch-label">Focar no Valor após consultar</span>
+            </label>
+            <label class="switch">
+              <input id="pref-clearCpfAfterRegister" type="checkbox" />
+              <span class="slider" aria-hidden="true"></span>
+              <span class="switch-label">Limpar CPF após registrar</span>
+            </label>
+            <label class="switch">
+              <input id="pref-keepValueAfterRegister" type="checkbox" />
+              <span class="slider" aria-hidden="true"></span>
+              <span class="switch-label">Manter Valor após registrar</span>
+            </label>
+          </div>
+        </section>
+
+        <hr class="divider" />
+
+        <section class="section">
+          <h3 class="section-title">Leitor (bipe)</h3>
+          <p class="help">Use etiquetas com ID interno ou CPF. O leitor funciona como teclado.</p>
+          <div class="row gap">
+            <button type="button" id="btn-test-wedge" class="btn btn--outline">Testar leitor (bipe)</button>
+          </div>
+        </section>
+
+        <section class="section">
+          <h3 class="section-title">QR Code (câmera)</h3>
+          <div class="form-grid-2">
+            <label class="field">
+              <span>Câmera</span>
+              <select id="pref-qrCameraId" class="input">
+                <option value="">Padrão do navegador</option>
+              </select>
+              <small class="help">Escolha a câmera para o leitor de QR.</small>
+            </label>
+          </div>
+          <div class="row gap">
+            <button type="button" id="btn-test-qr" class="btn btn--outline">Testar QR</button>
+          </div>
+        </section>
+
+        <details class="section">
+          <summary class="section-title">Avançado</summary>
+          <label class="field">
+            <span>Padrão de ID interno (regex)</span>
+            <input id="pref-idPattern" type="text" class="input" value="^C\d{7}$" />
+            <small class="help">Ex.: C1234567 → ^C\d{7}$</small>
+          </label>
+        </details>
+
+        <section class="section">
+          <h3 class="section-title">Teste</h3>
+          <pre id="test-output" class="test-output" aria-live="polite"></pre>
+        </section>
+
+        <footer class="dialog-footer">
+          <button type="button" id="btn-reset-prefs" class="btn btn--ghost">Resetar padrão</button>
+          <div class="spacer"></div>
+          <button type="button" class="btn btn--ghost" id="btn-close-settings-footer">Fechar</button>
+          <button type="submit" class="btn btn--primary">Salvar</button>
+        </footer>
+      </form>
+    </dialog>
 
   <script src="/libs/html5-qrcode.min.js" defer></script>
   <script src="/settings.js" defer></script>

--- a/public/main.js
+++ b/public/main.js
@@ -444,8 +444,6 @@ function init(){
   document.getElementById('qr-start').addEventListener('click', startQrMode);
   document.getElementById('qr-stop').addEventListener('click', stopQrMode);
 
-  document.getElementById('btn-settings').addEventListener('click', openSettingsDialog);
-  document.getElementById('btn-close-settings').addEventListener('click', () => document.getElementById('settingsDialog').close());
   document.getElementById('btn-reset-prefs').addEventListener('click', () => {
     Settings.save(Settings.defaults);
     Settings.apply(Settings.defaults);
@@ -473,3 +471,30 @@ function init(){
 }
 
 document.addEventListener('DOMContentLoaded', init);
+
+// Focus-trap e ESC para o dialog de configurações
+(function(){
+  const dlg = document.getElementById('settingsDialog');
+  const closeBtns = [document.getElementById('btn-close-settings'), document.getElementById('btn-close-settings-footer')].filter(Boolean);
+  closeBtns.forEach(b => b && b.addEventListener('click', () => dlg.close()));
+
+  document.getElementById('btn-settings')?.addEventListener('click', async () =>{
+    await openSettingsDialog();
+    // foco inicial no primeiro control
+    const first = dlg.querySelector('select, input, button');
+    if(first) setTimeout(()=>first.focus(), 0);
+  });
+
+  dlg.addEventListener('keydown', (e)=>{
+    if(e.key === 'Escape'){ e.preventDefault(); dlg.close(); }
+    if(e.key === 'Tab'){
+      // trap simples
+      const focusables = dlg.querySelectorAll('a,button,select,input,textarea,[tabindex]:not([tabindex="-1"])');
+      const list = Array.from(focusables).filter(el=>!el.disabled && el.offsetParent !== null);
+      if(list.length === 0) return;
+      const first = list[0], last = list[list.length-1];
+      if(e.shiftKey && document.activeElement === first){ e.preventDefault(); last.focus(); }
+      else if(!e.shiftKey && document.activeElement === last){ e.preventDefault(); first.focus(); }
+    }
+  });
+})();

--- a/public/styles.css
+++ b/public/styles.css
@@ -181,3 +181,45 @@ body {
 
 @media (min-width:768px){ .actions{flex-wrap:nowrap;} .nav{gap:1.5rem;} }
 @media print { .header, .footer, .toasts { display:none!important; } .card{box-shadow:none;} }
+.settings-dialog::backdrop{ background: rgba(0,0,0,.35); }
+.settings-dialog{ border:0; border-radius:20px; padding:0; max-width:760px; width:92%; background:var(--card); color:var(--ink); box-shadow:0 12px 40px rgba(0,0,0,.25); }
+.dialog-header{ display:flex; align-items:center; justify-content:space-between; padding:16px 20px; border-bottom:1px solid var(--muted); }
+.dialog-title{ font-size:1.15rem; margin:0; }
+.icon-btn{ border:0; background:transparent; font-size:1.2rem; line-height:1; cursor:pointer; color:var(--ink); opacity:.7; }
+.icon-btn:hover{ opacity:1; }
+
+.settings{ padding:0; }
+.section{ padding:16px 20px; }
+.section + .section{ padding-top:8px; }
+.section-title{ margin:0 0 10px; font-size:1rem; font-weight:600; }
+.divider{ border:none; border-top:1px solid var(--muted); margin:0; }
+
+.form-grid-2{ display:grid; grid-template-columns:1fr; gap:12px; }
+@media (min-width: 820px){
+  .form-grid-2{ grid-template-columns:1fr 1fr; }
+}
+.field{ display:flex; flex-direction:column; gap:6px; }
+.input{ width:100%; height:42px; padding:10px 12px; border:1px solid var(--muted); border-radius:10px; background:var(--card); color:var(--ink); }
+.input:focus{ outline:none; border-color:var(--primary); box-shadow:0 0 0 3px color-mix(in oklab, var(--primary) 18%, transparent); }
+.help{ font-size:.85rem; color:var(--muted-ink); }
+
+.row{ display:flex; align-items:center; }
+.gap{ gap:10px; }
+
+.dialog-footer{ display:flex; align-items:center; gap:10px; padding:14px 20px; border-top:1px solid var(--muted); background:color-mix(in oklab, var(--card) 85%, var(--muted) 15%); border-bottom-left-radius:20px; border-bottom-right-radius:20px; }
+.spacer{ flex:1; }
+
+/* Switches (toggles) */
+.switches{ display:grid; grid-template-columns:1fr; gap:10px; margin-top:6px; }
+@media (min-width: 820px){
+  .switches{ grid-template-columns:1fr 1fr; }
+}
+.switch{ display:flex; align-items:center; gap:10px; cursor:pointer; user-select:none; }
+.switch input{ appearance:none; width:44px; height:26px; margin:0; position:relative; border-radius:999px; background:var(--muted); outline:none; transition:.2s; }
+.switch input:checked{ background:var(--primary); }
+.switch .slider{ position:absolute; width:20px; height:20px; margin-left:3px; border-radius:50%; background:#fff; transform:translateX(0); transition:transform .2s; box-shadow:0 1px 3px rgba(0,0,0,.25); }
+.switch input:checked + .slider{ transform:translateX(18px); }
+.switch-label{ color:var(--ink); }
+
+/* Test box */
+.test-output{ background:var(--bg); border:1px solid var(--muted); padding:10px; border-radius:12px; min-height:70px; max-height:180px; overflow:auto; }


### PR DESCRIPTION
## Summary
- revamp settings dialog with sections, switches, and structured layout
- add styles for grid form, switch toggles, and dialog layout
- implement focus trap and ESC closing for settings modal

## Testing
- `npm test` *(fails: Missing script: "test" )*
- `npm run test:api`


------
https://chatgpt.com/codex/tasks/task_e_6899eb575f5c832ba6ac65a426a6418f