### PR TITLE
chore: add deployment config and docs

### DIFF
--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -1,0 +1,25 @@
+# Deploy no Railway e Vercel
+
+## Railway
+1. Criar novo projeto → **Deploy from GitHub** → escolher este repositório.
+2. Em **Variables**, adicionar:
+   - `SUPABASE_URL=...`
+   - `SUPABASE_ANON=...`
+   - `ADMIN_PIN=...`
+   - (opcional) `MP_ACCESS_TOKEN=...` (para usar Mercado Pago depois)
+3. Deploy automático. Copiar o domínio gerado (ex.: `https://xxxxx.up.railway.app`).
+
+## Vercel
+1. **New Project** → **Import Git** → escolher este repositório.
+2. Framework: `Other`. Não precisa build; o front é estático em `/public`.
+3. Antes do deploy, editar `vercel.json` no Git e trocar `YOUR-RAILWAY-APP.up.railway.app` pelo domínio do Railway.
+4. Deploy. Teste abrindo o site (Vercel) e usando a página inicial. As chamadas `/transacao`, etc. serão reescritas para o domínio do Railway.
+
+## Checklist
+- `/health` no domínio da Vercel deve responder `{"ok": true}` (via rewrite).
+- Na UI, consultar CPF e registrar transação → conferir tabela `transacoes` no Supabase.
+
+## Domínio customizado
+- Na Vercel → **Settings → Domains** → adicionar o domínio do cliente.
+- Se quiser `www` + raiz, configurar os registros `CNAME`/`A` conforme instruções da Vercel.
+

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <title>Página não encontrada</title>
+  <style>
+    body { font-family: sans-serif; text-align: center; padding-top: 50px; }
+    a { color: #0070f3; }
+  </style>
+</head>
+<body>
+  <h1>404 - Página não encontrada</h1>
+  <p><a href="/">Voltar ao painel</a></p>
+</body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,26 @@
+{
+  "version": 2,
+  "cleanUrls": true,
+  "trailingSlash": false,
+  "headers": [
+    {
+      "source": "/(.*)\\.(css|js|png|jpg|svg|woff2)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ],
+  "rewrites": [
+    { "source": "/health", "destination": "https://YOUR-RAILWAY-APP.up.railway.app/health" },
+    { "source": "/transacao", "destination": "https://YOUR-RAILWAY-APP.up.railway.app/transacao" },
+    { "source": "/transacao/preview", "destination": "https://YOUR-RAILWAY-APP.up.railway.app/transacao/preview" },
+    { "source": "/assinaturas", "destination": "https://YOUR-RAILWAY-APP.up.railway.app/assinaturas" },
+    { "source": "/assinaturas/by-id", "destination": "https://YOUR-RAILWAY-APP.up.railway.app/assinaturas/by-id" },
+    { "source": "/public/lead", "destination": "https://YOUR-RAILWAY-APP.up.railway.app/public/lead" },
+    { "source": "/admin/:path*", "destination": "https://YOUR-RAILWAY-APP.up.railway.app/admin/:path*" },
+    { "source": "/mp/:path*", "destination": "https://YOUR-RAILWAY-APP.up.railway.app/mp/:path*" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add vercel rewrites for backend routes
- document Railway and Vercel setup
- provide static 404 page for better UX

## Testing
- `npm run test:api`

------
https://chatgpt.com/codex/tasks/task_e_689a110d08b0832b8398ab660dd3aad5