### PR TITLE
feat: add deploy status checks

### DIFF
--- a/controllers/statusController.js
+++ b/controllers/statusController.js
@@ -1,0 +1,24 @@
+const supabase = require('../supabaseClient');
+
+exports.info = async (req, res) => {
+  res.json({
+    ok: true,
+    version: 'v0.1.0',
+    env: process.env.NODE_ENV || 'unknown',
+    time: new Date().toISOString()
+  });
+};
+
+exports.pingSupabase = async (req, res) => {
+  try {
+    const { data, error, count } = await supabase
+      .from('clientes')
+      .select('cpf', { count: 'exact', head: true })
+      .limit(1);
+
+    if (error) throw error;
+    res.json({ ok: true, count: count ?? null });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err.message });
+  }
+};

--- a/public/deploy-check.html
+++ b/public/deploy-check.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>Deploy Check</title>
+  <link rel="stylesheet" href="./styles.css"/>
+  <style>
+    .check { border:1px solid var(--muted); border-radius:12px; padding:16px; margin:10px 0; background:var(--card); }
+    .row { display:flex; gap:8px; align-items:center; justify-content:space-between; }
+    .tag{ display:inline-block; padding:.2rem .5rem; border-radius:999px; font-size:.8rem; }
+    .pass{ background:#e9f7ee; color:#0a7c2f; }
+    .fail{ background:#ffeceb; color:#7a0000; }
+    .warn{ background:#fff7e6; color:#7a4a00; }
+    .muted{ color:var(--muted-ink); font-size:.9rem; }
+    .grid{ display:grid; gap:12px; }
+    .grid-2{ grid-template-columns:1fr; }
+    @media(min-width:900px){ .grid-2{ grid-template-columns:1fr 1fr; } }
+    .input{ height:42px; border:1px solid var(--muted); border-radius:10px; padding:10px 12px; width:100%; }
+    .btn{ padding:10px 14px; border-radius:10px; border:1px solid var(--muted); background:var(--bg); cursor:pointer; }
+    .btn--primary{ background:var(--primary); color:#fff; border-color:var(--primary); }
+    pre { white-space:pre-wrap; background:var(--bg); border:1px solid var(--muted); padding:10px; border-radius:10px; }
+    .footer { margin-top:12px; display:flex; gap:10px; }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <h1>Verificação de Deploy</h1>
+    <p class="muted">Use esta página logo após publicar (Vercel + Railway).</p>
+
+    <section class="check">
+      <div class="grid grid-2">
+        <label>
+          <div>PIN admin</div>
+          <input id="pin" class="input" type="password" placeholder="****"/>
+        </label>
+        <label>
+          <div>CPF de teste (opcional)</div>
+          <input id="cpf" class="input" type="text" placeholder="111.111.111-11"/>
+        </label>
+      </div>
+      <div class="footer">
+        <button id="run" class="btn btn--primary">Rodar testes</button>
+        <button id="copy" class="btn">Copiar relatório</button>
+      </div>
+    </section>
+
+    <section id="out"></section>
+  </main>
+
+  <script src="./libs/papaparse.min.js" defer></script><!-- ignorar se não existir -->
+  <script src="./deploy-check.js" defer></script>
+</body>
+</html>

--- a/public/deploy-check.js
+++ b/public/deploy-check.js
@@ -1,0 +1,78 @@
+(function(){
+  const out = document.getElementById('out');
+  const pinEl = document.getElementById('pin');
+  const cpfEl = document.getElementById('cpf');
+  const btnRun = document.getElementById('run');
+  const btnCopy = document.getElementById('copy');
+
+  const tests = [];
+  function log(title, ok, detail){
+    const div = document.createElement('div');
+    div.className = 'check';
+    div.innerHTML = `
+      <div class="row">
+        <strong>${title}</strong>
+        <span class="tag ${ok?'pass':'fail'}">${ok?'PASS':'FAIL'}</span>
+      </div>
+      ${detail ? `<div class="muted" style="margin-top:6px">${detail}</div>` : ''}
+    `;
+    out.appendChild(div);
+    tests.push({ title, ok, detail });
+  }
+
+  async function json(url, init={}){
+    const r = await fetch(url, init);
+    const t = await r.text();
+    try { return { ok: r.ok, data: JSON.parse(t) }; }
+    catch { return { ok: r.ok, data: t }; }
+  }
+
+  function normCpf(s){ return (s||'').replace(/\D/g,'').slice(0,11); }
+
+  async function run(){
+    tests.length = 0; out.innerHTML = '';
+    const pin = pinEl.value.trim();
+
+    // 1) /health via rewrite (Vercel → Railway)
+    {
+      const r = await json('/health');
+      log('Rewrite /health → Railway', r.ok && r.data && r.data.ok === true, JSON.stringify(r.data));
+    }
+
+    // 2) /status/info direto
+    {
+      const r = await json('/status/info');
+      log('API /status/info', r.ok && r.data && r.data.ok === true, JSON.stringify(r.data));
+    }
+
+    // 3) Supabase ping (rota admin)
+    if(pin){
+      const r = await json('/admin/status/ping-supabase', { headers: { 'x-admin-pin': pin }});
+      log('Supabase ping (admin)', r.ok && r.data && r.data.ok === true, JSON.stringify(r.data));
+    } else {
+      log('Supabase ping (admin)', false, 'Informe o PIN admin para testar.');
+    }
+
+    // 4) Assinaturas por CPF (se informado)
+    const cpf = normCpf(cpfEl.value);
+    if(cpf.length === 11){
+      const r = await json(`/assinaturas?cpf=${cpf}`);
+      const ok = r.ok && r.data && (r.data.plano || r.data.cliente || r.data.status);
+      log('Consulta de assinatura por CPF', !!ok, JSON.stringify(r.data));
+    } else {
+      log('Consulta de assinatura por CPF', false, 'CPF de teste não informado (opcional).');
+    }
+
+    // 5) Preview de transação (valor de R$ 1,23)
+    {
+      const r = await json('/transacao/preview?cpf=00000000000&valor=1.23');
+      log('Preview de transação', r.ok, JSON.stringify(r.data));
+    }
+  }
+
+  btnRun.addEventListener('click', run);
+  btnCopy.addEventListener('click', ()=>{
+    const txt = tests.map(t => `- ${t.ok?'[PASS]':'[FAIL]'} ${t.title}${t.detail?` → ${t.detail}`:''}`).join('\n');
+    navigator.clipboard.writeText(txt).then(()=> alert('Relatório copiado!'));
+  });
+})();

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ const clientes = require('./controllers/clientesController');
 const { requireAdmin } = require('./middlewares/requireAdmin');
 const mp = require('./controllers/mpController');
 const metrics = require('./controllers/metricsController');
+const status = require('./controllers/statusController');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -25,6 +26,12 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.get('/health', (req, res) => {
   res.json({ ok: true, version: 'v0.1.0' });
 });
+
+// status público simples
+app.get('/status/info', status.info);
+
+// status com PIN (usa requireAdmin)
+app.get('/admin/status/ping-supabase', requireAdmin, status.pingSupabase);
 
 // Rotas
 app.get('/assinaturas', assinaturaController.consultarPorIdentificador);


### PR DESCRIPTION
## Summary
- add backend status endpoints and Supabase ping
- add deploy check HTML page with JS tests

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:api`

------
https://chatgpt.com/codex/tasks/task_e_689a1b804f7c832b955119da4969ae11