### PR TITLE
chore: unify UI chrome and admin PIN

### DIFF
--- a/public/config.html
+++ b/public/config.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Configurações - Clube de Vantagens</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <header id="topbar"></header>
+
+  <main class="panel" id="main-content">
+    <h1>Configurações</h1>
+    <section id="pin-area" class="card"></section>
+    <p>Página de configurações em construção.</p>
+  </main>
+
+  <footer id="site-footer"></footer>
+  <script src="./ui.js" defer></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', ()=>{
+      UI.mountChrome({ active:'config' });
+      UI.pinControls(document.getElementById('pin-area'));
+    });
+  </script>
+</body>
+</html>

--- a/public/deploy-check.html
+++ b/public/deploy-check.html
@@ -24,16 +24,16 @@
   </style>
 </head>
 <body>
+  <header id="topbar"></header>
+
   <main class="shell">
     <h1>Verificação de Deploy</h1>
     <p class="muted">Use esta página logo após publicar (Vercel + Railway).</p>
 
+    <section id="pin-area" class="card"></section>
+
     <section class="check">
       <div class="grid grid-2">
-        <label>
-          <div>PIN admin</div>
-          <input id="pin" class="input" type="password" placeholder="****"/>
-        </label>
         <label>
           <div>CPF de teste (opcional)</div>
           <input id="cpf" class="input" type="text" placeholder="111.111.111-11"/>
@@ -48,6 +48,14 @@
     <section id="out"></section>
   </main>
 
+  <footer id="site-footer"></footer>
+  <script src="./ui.js" defer></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', ()=>{
+      UI.mountChrome();
+      UI.pinControls(document.getElementById('pin-area'));
+    });
+  </script>
   <script src="./libs/papaparse.min.js" defer></script><!-- ignorar se não existir -->
   <script src="./deploy-check.js" defer></script>
 </body>

--- a/public/deploy-check.js
+++ b/public/deploy-check.js
@@ -1,6 +1,5 @@
 (function(){
   const out = document.getElementById('out');
-  const pinEl = document.getElementById('pin');
   const cpfEl = document.getElementById('cpf');
   const btnRun = document.getElementById('run');
   const btnCopy = document.getElementById('copy');
@@ -31,7 +30,7 @@
 
   async function run(){
     tests.length = 0; out.innerHTML = '';
-    const pin = pinEl.value.trim();
+    const pin = UI.getPin();
 
     // 1) /health via rewrite (Vercel → Railway)
     {
@@ -47,8 +46,11 @@
 
     // 3) Supabase ping (rota admin)
     if(pin){
-      const r = await json('/admin/status/ping-supabase', { headers: { 'x-admin-pin': pin }});
-      log('Supabase ping (admin)', r.ok && r.data && r.data.ok === true, JSON.stringify(r.data));
+      const r = await UI.adminFetch('/admin/status/ping-supabase');
+      const t = await r.text();
+      let data;
+      try{ data = JSON.parse(t); }catch(_){ data = t; }
+      log('Supabase ping (admin)', r.ok && data && data.ok === true, JSON.stringify(data));
     } else {
       log('Supabase ping (admin)', false, 'Informe o PIN admin para testar.');
     }

--- a/public/etiquetas.html
+++ b/public/etiquetas.html
@@ -18,24 +18,23 @@
   <script src="https://cdn.jsdelivr.net/npm/qrcodejs@1.0.0/qrcode.min.js"></script>
 </head>
 <body>
-  <div class="container">
-    <header class="header" role="banner">
-      <a href="/" class="logo">Clube de Vantagens</a>
-      <nav class="nav">
-        <a href="/">Painel</a>
-        <a href="/relatorios.html">Relatórios</a>
-        <a href="/etiquetas.html">Etiquetas</a>
-        <a href="/leads-admin.html">Leads (Admin)</a>
-      </nav>
-    </header>
-    <main class="panel">
+  <header id="topbar"></header>
+
+  <main class="panel">
       <table id="tab-clientes" class="table">
         <thead><tr><th>Nome</th><th>CPF</th><th>ID interno</th><th>Ações</th></tr></thead>
         <tbody></tbody>
       </table>
       <div id="etiquetas" class="etiquetas"></div>
-    </main>
-  </div>
-  <script src="/etiquetas.js"></script>
+  </main>
+
+  <footer id="site-footer"></footer>
+  <script src="./ui.js" defer></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', ()=>{
+      UI.mountChrome({ active:'etiquetas' });
+    });
+  </script>
+  <script src="/etiquetas.js" defer></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -7,25 +7,9 @@
   <link rel="stylesheet" href="/styles.css">
 </head>
 <body>
-  <div class="container">
-    <header class="header" role="banner">
-      <a href="/" class="logo">Clube de Vantagens</a>
-      <nav class="nav">
-        <a href="/">Painel</a>
-        <a href="/relatorios.html">Relatórios</a>
-        <a href="/etiquetas.html">Etiquetas</a>
-        <a href="/leads-admin.html">Leads (Admin)</a>
-      </nav>
-      <div class="header-actions">
-        <div class="status">
-          <span id="api-status" class="status-dot status-dot--warn"></span>
-          <span id="api-status-text">instável</span>
-        </div>
-        <button id="btn-theme" class="btn btn--outline">⚙ Aparência</button>
-        <button id="btn-settings" class="btn btn--ghost">⚙ Configurações</button>
-      </div>
-    </header>
+  <header id="topbar"></header>
 
+  <div class="container">
     <main class="panel" id="main-content">
       <form id="form-transacao" novalidate>
         <section class="form-grid">
@@ -100,12 +84,9 @@
     </section>
 
     <div id="toasts" class="toasts" aria-live="polite" aria-atomic="true"></div>
-
-    <footer class="footer">
-      <p>v0.1.0 — Ambiente de Teste — Loja X</p>
-    </footer>
   </div>
-    <dialog id="settingsDialog" class="settings-dialog" role="dialog" aria-labelledby="settingsTitle">
+
+  <dialog id="settingsDialog" class="settings-dialog" role="dialog" aria-labelledby="settingsTitle">
       <form id="settingsForm" method="dialog" class="settings">
         <header class="dialog-header">
           <h2 id="settingsTitle" class="dialog-title">Configurações</h2>
@@ -228,7 +209,13 @@
         </footer>
       </form>
     </dialog>
-
+  <footer id="site-footer"></footer>
+  <script src="./ui.js" defer></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', ()=>{
+      UI.mountChrome({ active:'painel' });
+    });
+  </script>
   <script src="/libs/html5-qrcode.min.js" defer></script>
   <script src="/settings.js" defer></script>
   <script src="/main.js" defer></script>

--- a/public/leads-admin.html
+++ b/public/leads-admin.html
@@ -7,22 +7,12 @@
   <link rel="stylesheet" href="/styles.css">
 </head>
 <body>
-  <div class="shell">
-    <header class="header" role="banner">
-      <h1>Leads</h1>
-    </header>
+  <header id="topbar"></header>
 
-    <main class="panel" id="main-content">
+  <main class="panel" id="main-content">
       <div id="msg" class="msg" hidden></div>
+      <section id="pin-area" class="card"></section>
       <form id="filters">
-        <div class="field">
-          <label class="label">PIN admin <span id="pin-status" class="badge">aguardando</span></label>
-          <div class="pinline">
-            <input type="password" id="pin" placeholder="PIN admin" autocomplete="off" />
-            <button type="button" id="toggle-pin" class="btn btn--ghost" aria-label="Mostrar/ocultar PIN">👁</button>
-            <button type="button" id="validar-pin" class="btn">Validar PIN</button>
-          </div>
-        </div>
         <div class="field">
           <label class="label" for="status">Status</label>
           <select id="status" class="input">
@@ -63,10 +53,14 @@
       <p><a href="/">Voltar ao painel</a></p>
     </main>
 
-    <footer class="footer">
-      <p>v0.1.0 — Ambiente de Teste — Loja X</p>
-    </footer>
-  </div>
+  <footer id="site-footer"></footer>
+  <script src="./ui.js" defer></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', ()=>{
+      UI.mountChrome({ active:'leads' });
+      UI.pinControls(document.getElementById('pin-area'));
+    });
+  </script>
   <script src="/leads-admin.js" defer></script>
 </body>
 </html>

--- a/public/main.js
+++ b/public/main.js
@@ -315,8 +315,15 @@ async function checkApiStatus(){
   }
 }
 function setStatusDot(state){
-  const dot = document.getElementById('api-status');
-  dot.className = 'status-dot ' + (state==='ok'?'status-dot--ok':state==='warn'?'status-dot--warn':'status-dot--down');
+  const sb = document.getElementById('status-badge');
+  if(!sb) return;
+  if(state==='ok'){
+    sb.textContent = 'online';
+    sb.dataset.status = 'online';
+  }else{
+    sb.textContent = 'instável';
+    sb.dataset.status = 'warn';
+  }
 }
 
 function renderResultado(data, { showFinance=false } = {}){
@@ -470,7 +477,7 @@ function onSettingsSubmit(e){
 
 function init(){
   applyTheme();
-  document.getElementById('btn-theme').addEventListener('click', toggleTheme);
+  document.getElementById('btn-appearance').addEventListener('click', (e)=>{ e.preventDefault(); toggleTheme(); });
   document.getElementById('btn-consultar').addEventListener('click', onConsultar);
   document.getElementById('btn-registrar').addEventListener('click', onRegistrar);
   document.addEventListener('keydown', (e) => {

--- a/public/relatorios.html
+++ b/public/relatorios.html
@@ -7,23 +7,10 @@
   <link rel="stylesheet" href="/styles.css">
 </head>
 <body>
-  <div class="container">
-    <header class="header" role="banner">
-      <a href="/" class="logo">Clube de Vantagens</a>
-      <nav class="nav">
-        <a href="/">Painel</a>
-        <a href="/relatorios.html">Relatórios</a>
-        <a href="/etiquetas.html">Etiquetas</a>
-        <a href="/leads-admin.html">Leads (Admin)</a>
-      </nav>
-      <button id="btn-theme" class="btn btn--outline">⚙ Aparência</button>
-    </header>
+  <header id="topbar"></header>
 
-    <main class="panel" id="main-content">
-      <div class="field">
-        <label class="label" for="pin">PIN admin</label>
-        <input type="password" id="pin" class="input" placeholder="PIN admin" />
-      </div>
+  <main class="panel" id="main-content">
+      <section id="pin-area" class="card"></section>
       <div class="field">
         <label class="label" for="from">De</label>
         <input type="date" id="from" class="input" />
@@ -84,13 +71,16 @@
       <p><a href="/">Voltar ao painel</a></p>
     </main>
 
-    <div id="toasts" class="toasts" aria-live="polite" aria-atomic="true"></div>
+  <div id="toasts" class="toasts" aria-live="polite" aria-atomic="true"></div>
 
-    <footer class="footer">
-      <p>v0.1.0 — Ambiente de Teste — Loja X</p>
-    </footer>
-  </div>
-
-  <script src="/relatorios.js"></script>
+  <footer id="site-footer"></footer>
+  <script src="./ui.js" defer></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', ()=>{
+      UI.mountChrome({ active:'relatorios' });
+      UI.pinControls(document.getElementById('pin-area'));
+    });
+  </script>
+  <script src="/relatorios.js" defer></script>
 </body>
 </html>

--- a/public/relatorios.js
+++ b/public/relatorios.js
@@ -17,13 +17,7 @@ function showToast({type='info', text=''}){
 }
 
 function getPin() {
-  const el = document.getElementById('pin');
-  let pin = el.value.trim() || sessionStorage.getItem('admin-pin') || '';
-  if (pin) {
-    sessionStorage.setItem('admin-pin', pin);
-    if (!el.value) el.value = pin;
-  }
-  return pin;
+  return UI.getPin();
 }
 
 function buildQuery() {
@@ -53,9 +47,7 @@ async function fetchResumo() {
   setLoadingSummary(true);
   setLoadingTable(true);
   try{
-    const res = await fetch(`/admin/relatorios/resumo?${q}`, {
-      headers: { 'x-admin-pin': pin },
-    });
+    const res = await UI.adminFetch(`/admin/relatorios/resumo?${q}`);
     if (!res.ok) throw new Error('Erro ao gerar resumo');
     const data = await res.json();
     renderResumo(data);
@@ -71,9 +63,7 @@ async function downloadCSV() {
   const pin = getPin();
   if (!pin) return showToast({type:'error', text:'Informe o PIN'});
   const q = buildQuery();
-  const res = await fetch(`/admin/relatorios/transacoes.csv?${q}`, {
-    headers: { 'x-admin-pin': pin },
-  });
+  const res = await UI.adminFetch(`/admin/relatorios/transacoes.csv?${q}`);
   if (!res.ok) return showToast({type:'error', text:'Erro ao baixar'});
   const blob = await res.blob();
   const url = URL.createObjectURL(blob);
@@ -139,10 +129,8 @@ function init() {
   const from = new Date(to.getTime() - 30 * 24 * 60 * 60 * 1000);
   document.getElementById('to').value = to.toISOString().slice(0, 10);
   document.getElementById('from').value = from.toISOString().slice(0, 10);
-  const saved = sessionStorage.getItem('admin-pin');
-  if (saved) document.getElementById('pin').value = saved;
   applyTheme();
-  document.getElementById('btn-theme').addEventListener('click', toggleTheme);
+  document.getElementById('btn-appearance').addEventListener('click', (e)=>{ e.preventDefault(); toggleTheme(); });
   document.getElementById('btn-resumo').addEventListener('click', fetchResumo);
   document.getElementById('btn-csv').addEventListener('click', downloadCSV);
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -239,3 +239,23 @@ body {
 @media (min-width: 920px){
   #cpf{ max-width: 420px; }
 }
+.topbar{ display:flex; align-items:center; justify-content:space-between; gap:16px; padding:12px 8px; position:sticky; top:0; background:var(--bg); z-index:10; border-bottom:1px solid var(--muted); }
+.brand{ display:flex; align-items:center; gap:10px; font-weight:700; }
+.brand .dot{ width:10px; height:10px; border-radius:999px; background:var(--primary); display:inline-block; }
+.brand-title{ color:var(--ink); text-decoration:none; }
+.mainnav{ display:flex; gap:10px; flex-wrap:wrap; }
+.mainnav a{ padding:8px 12px; border-radius:10px; text-decoration:none; color:var(--ink); }
+.mainnav a.active{ background:var(--primary); color:#fff; }
+.tools{ display:flex; gap:8px; align-items:center; }
+.badge{ padding:.2rem .6rem; border-radius:999px; font-size:.85rem; background:var(--card); border:1px solid var(--muted); }
+.badge--ok{ background:#e9f7ee; border-color:#b8e2c5; color:#0a7c2f; }
+.badge--warn{ background:#fff4e8; border-color:#ffd7aa; color:#7a4a00; }
+.badge--muted{ color:var(--muted-ink); }
+.footer{ padding:20px 8px; color:var(--muted-ink); text-align:center; }
+
+.pinrow{ display:grid; gap:8px; }
+.pinbox{ display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
+.btn{ padding:8px 12px; border-radius:10px; border:1px solid var(--muted); background:var(--bg); cursor:pointer; }
+.btn--secondary{ background:var(--primary); color:#fff; border-color:var(--primary); }
+.btn--ghost{ background:transparent; }
+@media (max-width:700px){ .mainnav{ overflow:auto; } }

--- a/public/ui.js
+++ b/public/ui.js
@@ -1,0 +1,120 @@
+(() => {
+  const NAV = [
+    { id:'painel',      href:'/',                label:'Painel' },
+    { id:'relatorios',  href:'/relatorios.html', label:'Relatórios' },
+    { id:'etiquetas',   href:'/etiquetas.html',  label:'Etiquetas' },
+    { id:'leads',       href:'/leads-admin.html',label:'Leads (Admin)' },
+    { id:'config',      href:'/config.html',     label:'Config' }
+  ];
+
+  const ls = window.localStorage;
+  function getPin(){ return ls.getItem('adminPin') || ''; }
+  function setPin(v){ v ? ls.setItem('adminPin', v) : ls.removeItem('adminPin'); }
+  async function adminFetch(url, opts = {}){
+    const pin = getPin();
+    const headers = new Headers(opts.headers || {});
+    if(pin) headers.set('x-admin-pin', pin);
+    return fetch(url, { ...opts, headers });
+  }
+
+  async function pingStatus(el){
+    try{
+      const r = await fetch('/health', { cache:'no-store' });
+      const ok = r.ok;
+      el.textContent = ok ? 'online' : 'instável';
+      el.dataset.status = ok ? 'online' : 'warn';
+      return ok;
+    }catch(_){
+      el.textContent = 'instável';
+      el.dataset.status = 'warn';
+      return false;
+    }
+  }
+
+  function mountChrome({ active } = {}){
+    const top = document.getElementById('topbar') || (() => {
+      const h = document.createElement('header');
+      h.id='topbar';
+      document.body.prepend(h);
+      return h;
+    })();
+    const foot = document.getElementById('site-footer') || (() => {
+      const f = document.createElement('footer');
+      f.id='site-footer';
+      document.body.append(f);
+      return f;
+    })();
+
+    top.innerHTML = `
+      <div class="topbar">
+        <div class="brand">
+          <span class="dot"></span>
+          <a class="brand-title" href="/">Clube de Vantagens</a>
+        </div>
+        <nav class="mainnav" aria-label="Principal">
+          ${NAV.map(n=>`<a data-id="${n.id}" href="${n.href}">${n.label}</a>`).join('')}
+        </nav>
+        <div class="tools">
+          <span id="status-badge" class="badge">instável</span>
+          <a class="btn btn--ghost" href="#" id="btn-appearance">⚙ Aparência</a>
+          <a class="btn btn--ghost" href="/config.html">⚙ Configurações</a>
+        </div>
+      </div>
+    `;
+    top.querySelectorAll('.mainnav a').forEach(a=>{
+      if(a.dataset.id === active) a.classList.add('active');
+    });
+
+    const sb = document.getElementById('status-badge');
+    pingStatus(sb);
+
+    foot.innerHTML = `<div class="footer">v0.1.0 — Ambiente de Teste — Loja X</div>`;
+
+    document.addEventListener('keydown', (e)=>{
+      if(e.key==='/' && !e.target.closest('input,textarea')){
+        const first = document.querySelector('input');
+        if(first) first.focus();
+        e.preventDefault();
+      }
+    });
+  }
+
+  function pinControls(container){
+    container.innerHTML = `
+      <div class="pinrow">
+        <label for="pin-admin">PIN admin</label>
+        <div class="pinbox">
+          <input id="pin-admin" type="password" class="input" placeholder="****" value="${getPin()}" />
+          <button id="pin-toggle" class="btn btn--ghost" type="button" title="Mostrar/ocultar">👁</button>
+          <button id="pin-validate" class="btn btn--secondary" type="button">Validar PIN</button>
+          <span id="pin-status" class="badge badge--muted">aguardando</span>
+        </div>
+      </div>
+    `;
+    const input = container.querySelector('#pin-admin');
+    const toggle = container.querySelector('#pin-toggle');
+    const btn = container.querySelector('#pin-validate');
+    const b = container.querySelector('#pin-status');
+
+    toggle.addEventListener('click', ()=>{
+      input.type = input.type === 'password' ? 'text':'password';
+    });
+    input.addEventListener('change', ()=> setPin(input.value.trim()));
+    btn.addEventListener('click', async ()=>{
+      setPin(input.value.trim());
+      b.textContent = 'validando...';
+      b.className = 'badge';
+      try{
+        const r = await adminFetch('/admin/status/ping-supabase');
+        const ok = r.ok;
+        b.textContent = ok ? 'válido' : 'inválido';
+        b.className = 'badge ' + (ok ? 'badge--ok':'badge--warn');
+      }catch(_){
+        b.textContent = 'erro';
+        b.className = 'badge badge--warn';
+      }
+    });
+  }
+
+  window.UI = { mountChrome, pinControls, adminFetch, getPin, setPin };
+})();


### PR DESCRIPTION
## Summary
- add reusable `ui.js` with header/footer mounting, admin PIN helpers, and shortcut support
- style top bar, badges, buttons and PIN controls in `styles.css`
- integrate new layout and PIN controls across public pages and switch admin fetches to `UI.adminFetch`

## Testing
- `npm run test:api`


------
https://chatgpt.com/codex/tasks/task_e_689a1f502090832bbb4d93b685f69e5f