### PR TITLE
fix: remove inline scripts and guard DOM access

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Clube de Vantagens</title>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; script-src 'self';">
   <link rel="stylesheet" href="/styles.css">
 </head>
 <body>
@@ -44,7 +45,7 @@
       </form>
 
       <section id="resultado" class="card result">
-        <div><span>Cliente:</span> <strong id="out-nome">—</strong></div>
+        <div><span>Cliente:</span> <strong id="out-name">—</strong></div>
         <div><span>Plano:</span> <strong id="out-plano">—</strong></div>
         <div id="row-desc" class="hidden"><span>Desconto Aplicado:</span> <strong id="out-desc">—</strong></div>
         <div id="row-valor" class="hidden"><span>Valor Final:</span> <strong id="out-valor">—</strong></div>
@@ -210,14 +211,7 @@
       </form>
     </dialog>
   <footer id="site-footer"></footer>
-  <script src="./ui.js" defer></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', ()=>{
-      UI.mountChrome({ active:'painel' });
-    });
-  </script>
-  <script src="/libs/html5-qrcode.min.js" defer></script>
-  <script src="/settings.js" defer></script>
+  <script src="/libs/html5-qrcode.min.js"></script>
   <script src="/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enforce CSP by removing inline scripts and adding explicit meta
- consolidate UI and settings logic into main.js with DOM-ready init
- add null checks and CPF validation to avoid runtime errors

## Testing
- `npm test` (fails: Missing script)
- `npm run test:api` (fails: TypeError: Invalid URL)


------
https://chatgpt.com/codex/tasks/task_e_689a988ea110832b873f24566ae36827