### PR TITLE
feat: parse money and validate transactions

### DIFF
--- a/controllers/transacaoController.js
+++ b/controllers/transacaoController.js
@@ -3,25 +3,43 @@ const { assertSupabase } = require('../supabaseClient');
 
 const descontos = { Essencial: 5, Platinum: 10, Black: 20 };
 const descontoPorPlano = (p) => descontos[p] ?? 0;
-const valorFinalDe = (v, d) => Number((v * (1 - d / 100)).toFixed(2));
+
+function parseMoneyToCents(v) {
+  if (v == null) return NaN;
+  let s = String(v)
+    .replace(/[R$\s]/g, '')
+    .trim();
+  if (!s) return NaN;
+  if (s.includes(',')) {
+    s = s.replace(/\./g, '').replace(/,/g, '.');
+  }
+  const n = Number(s);
+  if (!Number.isFinite(n) || n <= 0) return NaN;
+  return Math.round(n * 100);
+}
 
 exports.preview = async (req, res) => {
   if (!assertSupabase(res)) return;
   const { cpf, id, valor } = req.query;
-  const valorNum = Number(valor);
 
-  if ((!cpf && !id) || !Number.isFinite(valorNum) || valorNum <= 0) {
-    return res
-      .status(400)
-      .json({ error: 'identificador e valor são obrigatórios e o valor deve ser numérico' });
+  const valorCentavos = parseMoneyToCents(valor);
+  if ((!cpf && !id)) {
+    return res.status(400).json({ ok: false, error: 'IDENTIFICADOR_OBRIGATORIO' });
+  }
+  if (Number.isNaN(valorCentavos)) {
+    return res.status(400).json({ ok: false, error: 'VALOR_INVALIDO' });
   }
 
   let query;
-  if (cpf && /^[0-9]{11}$/.test(cpf)) {
+  if (cpf) {
+    const cpfDigits = cpf.replace(/\D/g, '');
+    if (cpfDigits.length !== 11) {
+      return res.status(400).json({ ok: false, error: 'CPF_INVALIDO' });
+    }
     query = supabase
       .from('clientes')
       .select('cpf, nome, plano, status')
-      .eq('cpf', cpf)
+      .eq('cpf', cpfDigits)
       .maybeSingle();
   } else if (id && /^C[0-9]{7}$/i.test(id)) {
     query = supabase
@@ -30,22 +48,23 @@ exports.preview = async (req, res) => {
       .eq('id_interno', id.toUpperCase())
       .maybeSingle();
   } else {
-    return res.status(400).json({ error: 'identificador inválido' });
+    return res.status(400).json({ ok: false, error: 'IDENTIFICADOR_INVALIDO' });
   }
 
   const { data: cliente, error: clienteError } = await query;
   if (clienteError) {
-    return res.status(500).json({ error: clienteError.message });
+    return res.status(500).json({ ok: false, error: clienteError.message });
   }
   if (!cliente) {
-    return res.status(404).json({ error: 'Cliente não encontrado' });
+    return res.status(404).json({ ok: false, error: 'Cliente não encontrado' });
   }
   if (cliente.status !== 'ativo') {
-    return res.status(400).json({ error: 'Assinatura inativa' });
+    return res.status(400).json({ ok: false, error: 'Assinatura inativa' });
   }
 
   const desconto = descontoPorPlano(cliente.plano);
-  const valorFinal = valorFinalDe(valorNum, desconto);
+  const valorFinalCentavos = Math.round(valorCentavos * (1 - desconto / 100));
+  const valorFinal = valorFinalCentavos / 100;
 
   return res.json({
     nome: cliente.nome,
@@ -59,75 +78,65 @@ exports.preview = async (req, res) => {
 
 exports.registrar = async (req, res) => {
   if (!assertSupabase(res)) return;
-  const { cpf, id, valor } = req.body;
-  const valorNum = Number(valor);
+  const { cpf, valor } = req.body;
 
-  if ((!cpf && !id) || !Number.isFinite(valorNum) || valorNum <= 0) {
-    return res
-      .status(400)
-      .json({ error: 'identificador e valor são obrigatórios e o valor deve ser numérico' });
+  const valorCentavos = parseMoneyToCents(valor);
+  if (Number.isNaN(valorCentavos)) {
+    return res.status(400).json({ ok: false, error: 'VALOR_INVALIDO' });
   }
 
-  let query;
-  if (cpf && /^[0-9]{11}$/.test(cpf)) {
-    query = supabase
-      .from('clientes')
-      .select('cpf, nome, plano, status')
-      .eq('cpf', cpf)
-      .maybeSingle();
-  } else if (id && /^C[0-9]{7}$/i.test(id)) {
-    query = supabase
-      .from('clientes')
-      .select('cpf, nome, plano, status, id_interno')
-      .eq('id_interno', id.toUpperCase())
-      .maybeSingle();
-  } else {
-    return res.status(400).json({ error: 'identificador inválido' });
+  const cpfDigits = (cpf || '').replace(/\D/g, '');
+  if (cpfDigits.length !== 11) {
+    return res.status(400).json({ ok: false, error: 'CPF_INVALIDO' });
   }
 
-  const { data: cliente, error: clienteError } = await query;
+  const { data: cliente, error: clienteError } = await supabase
+    .from('clientes')
+    .select('cpf, nome, plano, status')
+    .eq('cpf', cpfDigits)
+    .maybeSingle();
   if (clienteError) {
-    return res.status(500).json({ error: clienteError.message });
+    return res.status(500).json({ ok: false, error: 'DB_ERROR', detail: clienteError.message });
   }
   if (!cliente) {
-    return res.status(404).json({ error: 'Cliente não encontrado' });
+    return res.status(404).json({ ok: false, error: 'Cliente não encontrado' });
   }
   if (cliente.status !== 'ativo') {
-    return res.status(400).json({ error: 'Assinatura inativa' });
+    return res.status(400).json({ ok: false, error: 'Assinatura inativa' });
   }
 
   const desconto = descontoPorPlano(cliente.plano);
-  const valorFinal = valorFinalDe(valorNum, desconto);
+  const valorFinalCentavos = Math.round(valorCentavos * (1 - desconto / 100));
 
   const payload = {
     cpf: cliente.cpf,
     cliente_nome: cliente.nome,
     plano: cliente.plano,
-    valor_bruto: valorNum,
+    valor_bruto: valorCentavos / 100,
     desconto_aplicado: desconto,
-    valor_final: valorFinal,
+    valor_final: valorFinalCentavos / 100,
     origem: 'caixa',
   };
 
-  const { data: inserted, error: insertError } = await supabase
-    .from('transacoes')
-    .insert(payload)
-    .select()
-    .single();
+  try {
+    const { data: inserted, error: insertError } = await supabase
+      .from('transacoes')
+      .insert(payload)
+      .select()
+      .single();
+    if (insertError) throw insertError;
 
-  if (insertError) {
-    return res.status(500).json({ error: insertError.message });
+    return res.json({
+      ok: true,
+      valorCentavos,
+      descontoAplicado: desconto,
+      valorFinalCentavos,
+      transacao: inserted,
+    });
+  } catch (error) {
+    return res
+      .status(500)
+      .json({ ok: false, error: 'DB_ERROR', detail: error.message });
   }
-
-  return res.json({
-    id: inserted.id,
-    created_at: inserted.created_at,
-    nome: cliente.nome,
-    plano: cliente.plano,
-    descontoAplicado: desconto,
-    valorFinal,
-    statusPagamento: 'em dia',
-    vencimento: '10/09/2025',
-  });
 };
 


### PR DESCRIPTION
## Summary
- add parseMoneyToCents to handle Brazilian currency formats
- apply money parser to preview and registrar with stricter CPF/value validation
- wrap transaction insert in try/catch and return detailed responses

## Testing
- `npm run test:api` *(fails: TypeError: supabase.from is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689b87b41534832ba843a4840730ce85