### PR TITLE
Add transaction preview endpoint and conditional Mercado Pago routes

### DIFF
--- a/controllers/mpController.js
+++ b/controllers/mpController.js
@@ -1,4 +1,7 @@
+const express = require('express');
 const MP = require('mercadopago');
+
+const router = express.Router();
 
 function envFlags() {
   return {
@@ -16,7 +19,7 @@ function ensureEnv(res) {
   return true;
 }
 
-exports.status = async (_req, res) => {
+async function status(_req, res) {
   if (!ensureEnv(res)) return;
   try {
     const mp = new MP({ accessToken: process.env.MP_ACCESS_TOKEN });
@@ -28,14 +31,20 @@ exports.status = async (_req, res) => {
     console.error('MP_STATUS_ERR', err);
     res.status(err?.status || 502).json({ ok: false, reason: 'mp_error' });
   }
-};
+}
 
-exports.createCheckout = async (_req, res) => {
+async function createCheckout(_req, res) {
   if (!ensureEnv(res)) return;
   res.status(501).json({ ok: false, reason: 'not_implemented' });
-};
+}
 
-exports.webhook = async (_req, res) => {
+async function webhook(_req, res) {
   res.sendStatus(200);
-};
+}
+
+router.get('/status', status);
+router.post('/checkout', express.json(), createCheckout);
+router.post('/webhook', webhook);
+
+module.exports = router;
 

--- a/routes/transacao.js
+++ b/routes/transacao.js
@@ -3,6 +3,7 @@ const router = express.Router();
 
 const ctrl = require('../controllers/transacaoController');
 
+router.get('/preview', ctrl.preview);
 router.post('/', ctrl.criar);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- conditionally load Mercado Pago controller and register its routes
- support dynamic CORS and trust proxy settings
- add `/transacao/preview` and simplified transaction creation logic

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:api` *(fails: TypeError: supabase.from is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689bfaf19a90832bacbcca8a621fe2d1