### PR TITLE
Require consulta before preview and registration

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -294,3 +294,13 @@ button:disabled, .btn[disabled] {
 /* Utilitários de layout */
 .container-page { max-width: 1000px; margin: 0 auto; padding: 16px; }
 .page-title { font-size: 1.25rem; font-weight: 600; margin: 12px 0 16px; }
+
+/* Melhor contraste quando desabilitado (especialmente no "Consultar") */
+button[disabled],
+.btn-disabled {
+  color: #6b7280 !important;      /* gray-500 */
+  background: #f9fafb !important; /* gray-50 */
+  border-color: #e5e7eb !important;/* gray-200 */
+  cursor: not-allowed;
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- Require successful consulta via `/assinaturas` before previewing or registering transactions
- Reset resumo and disable registrar while requests are pending or when preview fails
- Improve disabled button contrast for better visibility

## Testing
- `npm run test:api` *(fails: supabase.from is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689c03be2924832b9dbdef31f39eed65