### PR TITLE
Add Mercado Pago checkout test script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "express": "^4.18.2",
         "express-rate-limit": "^7.1.0",
         "helmet": "^7.1.0",
-        "mercadopago": "^2.0.0"
+        "mercadopago": "^2.0.0",
+        "node-fetch": "^2.7.0"
       },
       "devDependencies": {
         "morgan": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "express": "^4.18.2",
     "express-rate-limit": "^7.1.0",
     "helmet": "^7.1.0",
-    "mercadopago": "^2.0.0"
+    "mercadopago": "^2.0.0",
+    "node-fetch": "^2.7.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.10",

--- a/test-mp.js
+++ b/test-mp.js
@@ -1,0 +1,58 @@
+const fetch = require('node-fetch');
+
+// Base URL da API, lida da variável de ambiente
+const API_URL = process.env.API_URL;
+
+if (!API_URL) {
+  console.error('Defina a variável de ambiente API_URL');
+  process.exit(1);
+}
+
+(async () => {
+  try {
+    // 1. Cria uma transação
+    const transacaoRes = await fetch(`${API_URL}/transacao`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        cpf: '12345678900',
+        plano: 'platinum',
+        valor_original: 100,
+        descricao: 'Assinatura Platinum'
+      })
+    });
+
+    if (!transacaoRes.ok) {
+      const txt = await transacaoRes.text();
+      throw new Error(`Erro ao criar transação: ${transacaoRes.status} ${txt}`);
+    }
+
+    const transacao = await transacaoRes.json();
+    const id = transacao.id;
+    if (!id) throw new Error('Resposta de transação sem id');
+
+    // 2. Cria o checkout do Mercado Pago usando o id como externalReference
+    const checkoutRes = await fetch(`${API_URL}/mp/checkout`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ externalReference: id })
+    });
+
+    if (!checkoutRes.ok) {
+      const txt = await checkoutRes.text();
+      throw new Error(`Erro ao criar checkout: ${checkoutRes.status} ${txt}`);
+    }
+
+    const checkout = await checkoutRes.json();
+    const link = checkout.init_point;
+    if (!link) throw new Error('init_point não retornado');
+
+    // 3. Exibe o link do checkout
+    console.log('Checkout criado com sucesso:');
+    console.log(link);
+    process.exit(0);
+  } catch (err) {
+    console.error('Falha no teste:', err.message);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add `test-mp.js` script to create a transaction and Mercado Pago checkout using `node-fetch`
- declare `node-fetch` dependency for the script

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:api` *(fails: TypeError: supabase.from is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689c0ecdc4d0832b8d73780a96398a53