### PR TITLE
Integrate Mercado Pago checkout and webhook

### DIFF
--- a/controllers/mpController.js
+++ b/controllers/mpController.js
@@ -1,5 +1,7 @@
 const express = require('express');
 const MP = require('mercadopago');
+const supabase = require('../supabaseClient');
+const { assertSupabase } = supabase;
 
 const router = express.Router();
 
@@ -19,11 +21,15 @@ function ensureEnv(res) {
   return true;
 }
 
+function mpClient() {
+  return new MP.MercadoPagoConfig({ accessToken: process.env.MP_ACCESS_TOKEN });
+}
+
 async function status(_req, res) {
   if (!ensureEnv(res)) return;
   try {
-    const mp = new MP({ accessToken: process.env.MP_ACCESS_TOKEN });
-    const info = await mp.users.get({});
+    const user = new MP.User(mpClient());
+    const info = await user.get();
     const collector_id = info && (info.id || info.collector_id || process.env.MP_COLLECTOR_ID);
     const live = typeof info?.live_mode === 'boolean' ? info.live_mode : false;
     res.json({ ok: true, collector_id, live });
@@ -33,12 +39,95 @@ async function status(_req, res) {
   }
 }
 
-async function createCheckout(_req, res) {
+async function createCheckout(req, res) {
   if (!ensureEnv(res)) return;
-  res.status(501).json({ ok: false, reason: 'not_implemented' });
+  if (!assertSupabase(res)) return;
+  try {
+    const { externalReference } = req.body || {};
+    if (!externalReference) {
+      return res.status(400).json({ ok: false, reason: 'missing_external_reference' });
+    }
+
+    const { data: tx, error: txErr } = await supabase
+      .from('transacoes')
+      .select('id, valor_final, valor_original, cliente_nome, cpf, plano')
+      .eq('id', externalReference)
+      .maybeSingle();
+    if (txErr) return res.status(500).json({ ok: false, reason: 'db_error' });
+    if (!tx) return res.status(404).json({ ok: false, reason: 'not_found' });
+
+    const amount = Number(tx.valor_final || tx.valor_original || 0);
+    const pref = new MP.Preference(mpClient());
+    const preference = await pref.create({
+      body: {
+        items: [
+          {
+            title: `Pagamento ${tx.cliente_nome || ''}`.trim() || 'Pagamento',
+            quantity: 1,
+            unit_price: amount,
+            currency_id: 'BRL',
+          },
+        ],
+        external_reference: String(externalReference),
+        notification_url: `${process.env.APP_BASE_URL || ''}/mp/webhook?secret=${process.env.MP_WEBHOOK_SECRET}`,
+        back_urls: {
+          success: process.env.APP_BASE_URL || '',
+          failure: process.env.APP_BASE_URL || '',
+          pending: process.env.APP_BASE_URL || '',
+        },
+        auto_return: 'approved',
+      },
+    });
+
+    const link = preference.init_point || preference.sandbox_init_point;
+
+    await supabase
+      .from('transacoes')
+      .update({
+        mp_preference_id: preference.id,
+        link_pagamento: link,
+        status_pagamento: 'pendente',
+      })
+      .eq('id', externalReference);
+
+    res.json({ ok: true, init_point: link, preference_id: preference.id });
+  } catch (err) {
+    console.error('MP_CHECKOUT_ERR', err);
+    res.status(502).json({ ok: false, reason: 'mp_error' });
+  }
 }
 
-async function webhook(_req, res) {
+async function webhook(req, res) {
+  if (req.query.secret !== process.env.MP_WEBHOOK_SECRET) return res.sendStatus(401);
+  if (!assertSupabase(res)) return;
+  try {
+    const id = req.body?.data?.id || req.body?.id;
+    if (!id) return res.sendStatus(200);
+    const payment = new MP.Payment(mpClient());
+    const info = await payment.get({ id });
+    if (info?.status === 'approved') {
+      const ref = info.external_reference;
+      if (ref) {
+        const { data: tx } = await supabase
+          .from('transacoes')
+          .select('cpf')
+          .eq('id', ref)
+          .maybeSingle();
+        await supabase
+          .from('transacoes')
+          .update({ status_pagamento: 'approved', mp_payment_id: info.id })
+          .eq('id', ref);
+        if (tx?.cpf) {
+          await supabase
+            .from('clientes')
+            .update({ status_pagamento: 'em dia' })
+            .eq('cpf', tx.cpf);
+        }
+      }
+    }
+  } catch (err) {
+    console.error('MP_WEBHOOK_ERR', err);
+  }
   res.sendStatus(200);
 }
 

--- a/public/main.js
+++ b/public/main.js
@@ -644,7 +644,13 @@ async function registrar(){
   try {
     const cpf = getCpf();
     const valor = getValorBRL();
-    await api('/transacao', { method:'POST', body: JSON.stringify({ cpf, valor }) });
+    const tx = await api('/transacao', { method:'POST', body: JSON.stringify({ cpf, valor }) });
+    if (tx?.id){
+      try {
+        const chk = await api('/mp/checkout', { method:'POST', body: JSON.stringify({ externalReference: tx.id }) });
+        if (chk?.init_point) window.open(chk.init_point, '_blank');
+      } catch(err){ console.warn('Falha ao iniciar pagamento', err); }
+    }
     showToast('Registrado com sucesso!');
   } catch(e) {
     showToast(`Erro ao registrar: ${e.message}`);


### PR DESCRIPTION
## Summary
- add Mercado Pago checkout creation saving preference and payment link
- handle Mercado Pago webhooks validating secret and updating records
- start payment flow from frontend after transaction registration

## Testing
- `npm run test:api` *(fails: supabase.from is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689c10a12208832b86b931f6bdcd3a13