### PR TITLE
Adiciona testes para assinaturas, leads e métricas

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
+    "test": "jest",
     "test:api": "node ./tests/ping.js",
     "vercel:prepare": "node scripts/patch-vercel.js",
     "build:meta": "echo \"ok\""
@@ -26,6 +27,8 @@
   },
   "devDependencies": {
     "nodemon": "^3.1.10",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
   }
 }

--- a/tests/assinaturas.test.js
+++ b/tests/assinaturas.test.js
@@ -1,0 +1,72 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../supabaseClient', () => ({
+  from: jest.fn(),
+  assertSupabase: () => true,
+}));
+
+const supabase = require('../supabaseClient');
+const assinaturaController = require('../controllers/assinaturaController');
+
+const app = express();
+app.get('/assinaturas', assinaturaController.consultarPorIdentificador);
+
+describe('Rotas de assinaturas', () => {
+  beforeEach(() => {
+    supabase.from.mockReset();
+  });
+
+  test('retorna dados para cliente ativo', async () => {
+    supabase.from.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({
+        data: { nome: 'João', plano: 'Essencial', status: 'ativo' },
+        error: null,
+      }),
+    });
+
+    const res = await request(app)
+      .get('/assinaturas')
+      .query({ cpf: '12345678901' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('nome', 'João');
+  });
+
+  test('cpf inválido retorna 400', async () => {
+    const res = await request(app)
+      .get('/assinaturas')
+      .query({ cpf: '123' });
+    expect(res.status).toBe(400);
+  });
+
+  test('cliente não encontrado retorna 404', async () => {
+    supabase.from.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+    });
+    const res = await request(app)
+      .get('/assinaturas')
+      .query({ cpf: '12345678901' });
+    expect(res.status).toBe(404);
+  });
+
+  test('erro do banco retorna 500', async () => {
+    supabase.from.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({
+        data: null,
+        error: { message: 'db error' },
+      }),
+    });
+    const res = await request(app)
+      .get('/assinaturas')
+      .query({ cpf: '12345678901' });
+    expect(res.status).toBe(500);
+  });
+});
+

--- a/tests/leads.test.js
+++ b/tests/leads.test.js
@@ -1,0 +1,80 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../supabaseClient', () => ({
+  from: jest.fn(),
+  assertSupabase: () => true,
+}));
+
+const supabase = require('../supabaseClient');
+const leadController = require('../controllers/leadController');
+const requireAdmin = require('../middlewares/requireAdmin');
+
+const app = express();
+app.use(express.json());
+app.post('/public/lead', leadController.publicCreate);
+app.get('/admin/leads', requireAdmin, leadController.adminList);
+
+describe('Rotas de leads', () => {
+  beforeEach(() => {
+    supabase.from.mockReset();
+    process.env.ADMIN_PIN = '1234';
+  });
+
+  test('cria lead público com sucesso', async () => {
+    supabase.from.mockReturnValue({
+      insert: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: { id: 1 }, error: null }),
+    });
+
+    const res = await request(app)
+      .post('/public/lead')
+      .send({ nome: 'João', cpf: '12345678901', plano: 'Essencial' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('id', 1);
+  });
+
+  test('validação falha retorna 400', async () => {
+    const res = await request(app)
+      .post('/public/lead')
+      .send({ cpf: '123', plano: 'Essencial' });
+    expect(res.status).toBe(400);
+  });
+
+  test('rota admin exige pin', async () => {
+    const res = await request(app).get('/admin/leads');
+    expect(res.status).toBe(401);
+  });
+
+  test('lista leads com pin válido', async () => {
+    supabase.from.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      range: jest.fn().mockResolvedValue({ data: [{ id: 1 }], error: null, count: 1 }),
+      eq: jest.fn().mockReturnThis(),
+      or: jest.fn().mockReturnThis(),
+    });
+    const res = await request(app)
+      .get('/admin/leads')
+      .set('x-admin-pin', '1234');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('rows');
+  });
+
+  test('erro do banco na listagem admin retorna 500', async () => {
+    supabase.from.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      range: jest.fn().mockResolvedValue({ data: null, error: { message: 'db' }, count: 0 }),
+      eq: jest.fn().mockReturnThis(),
+      or: jest.fn().mockReturnThis(),
+    });
+    const res = await request(app)
+      .get('/admin/leads')
+      .set('x-admin-pin', '1234');
+    expect(res.status).toBe(500);
+  });
+});
+

--- a/tests/metrics.test.js
+++ b/tests/metrics.test.js
@@ -1,0 +1,69 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../supabaseClient', () => ({
+  from: jest.fn(),
+  assertSupabase: () => true,
+}));
+
+const supabase = require('../supabaseClient');
+const metricsController = require('../controllers/metricsController');
+const requireAdmin = require('../middlewares/requireAdmin');
+
+const app = express();
+app.get('/admin/metrics', requireAdmin, metricsController.resume);
+
+describe('Rotas de métricas', () => {
+  beforeEach(() => {
+    supabase.from.mockReset();
+    process.env.ADMIN_PIN = '1234';
+  });
+
+  test('exige PIN de administrador', async () => {
+    const res = await request(app).get('/admin/metrics');
+    expect(res.status).toBe(401);
+  });
+
+  test('retorna resumo com sucesso', async () => {
+    supabase.from.mockImplementation((table) => {
+      if (table === 'clientes') {
+        return {
+          select: jest.fn().mockResolvedValue({
+            data: [{ status: 'ativo' }, { status: 'inativo' }],
+            error: null,
+          }),
+        };
+      }
+      if (table === 'transacoes') {
+        return {
+          select: jest.fn().mockReturnThis(),
+          gte: jest.fn().mockReturnThis(),
+          lte: jest.fn().mockResolvedValue({ data: [], error: null }),
+        };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .get('/admin/metrics')
+      .set('x-admin-pin', '1234');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('clientes');
+  });
+
+  test('erro ao consultar banco retorna 500', async () => {
+    supabase.from.mockImplementation((table) => {
+      if (table === 'clientes') {
+        return {
+          select: jest.fn().mockResolvedValue({ data: null, error: { message: 'db' } }),
+        };
+      }
+    });
+
+    const res = await request(app)
+      .get('/admin/metrics')
+      .set('x-admin-pin', '1234');
+    expect(res.status).toBe(500);
+  });
+});
+


### PR DESCRIPTION
## Summary
- adiciona Jest e Supertest ao projeto
- cria testes para rotas de assinaturas, leads e métricas com mocks do Supabase
- cobre cenários de erro e permissões administrativas

## Testing
- `npm test` *(falhou: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c12b8f688832b86328cb681d83a18