### PR TITLE
chore: validate critical environment variables

### DIFF
--- a/config/env.js
+++ b/config/env.js
@@ -1,0 +1,24 @@
+const { z } = require('zod');
+require('dotenv').config();
+
+const envSchema = z.object({
+  SUPABASE_URL: z.string().url(),
+  SUPABASE_ANON: z.string().min(1),
+  ADMIN_PIN: z.string().min(1),
+  MP_ACCESS_TOKEN: z.string().min(1),
+  MP_COLLECTOR_ID: z.string().min(1),
+  MP_WEBHOOK_SECRET: z.string().min(1),
+  APP_BASE_URL: z.string().url().optional(),
+  ALLOWED_ORIGIN: z.string().optional(),
+  RECAPTCHA_SECRET: z.string().optional(),
+  PORT: z.string().optional(),
+  NODE_ENV: z.string().optional(),
+});
+
+const env = envSchema.safeParse(process.env);
+if (!env.success) {
+  console.error('❌ Invalid environment variables', env.error.format());
+  throw new Error('Invalid environment variables');
+}
+
+module.exports = env.data;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "express-rate-limit": "^7.1.0",
     "helmet": "^7.1.0",
     "mercadopago": "^2.0.0",
-    "node-fetch": "^2.7.0"
+    "node-fetch": "^2.7.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "nodemon": "^3.1.10",

--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const path = require('path');
-require('dotenv').config();
+require('./config/env');
 
 const helmet = require('helmet');
 const rateLimit = require('express-rate-limit');


### PR DESCRIPTION
## Summary
- add config/env.js with zod schema to validate Supabase, admin PIN and Mercado Pago tokens
- load env validation before server start
- declare zod dependency

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/zod)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c1406b26c832ba5052ce4230b7f3e