### PR TITLE
refactor: centralize id generation

### DIFF
--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -1,5 +1,6 @@
 const supabase = require('../supabaseClient');
 const { assertSupabase } = require('../supabaseClient');
+const { gerarIdInterno, gerarIdUnico } = require('../utils/idGenerator');
 
 function sanitizeCpf(s = '') {
   return (s.match(/\d/g) || []).join('');
@@ -126,27 +127,6 @@ exports.bulkClientes = async (req, res) => {
   }
 };
 
-function gerarIdInterno() {
-  const digits = '23456789';
-  let out = 'C';
-  for (let i = 0; i < 7; i++) {
-    out += digits[Math.floor(Math.random() * digits.length)];
-  }
-  return out;
-}
-
-async function gerarIdUnico() {
-  while (true) {
-    const id = gerarIdInterno();
-    const { data, error } = await supabase
-      .from('clientes')
-      .select('id')
-      .eq('id_interno', id)
-      .maybeSingle();
-    if (!error && !data) return id;
-  }
-}
-
 exports.generateIds = async (req, res) => {
   try {
     if (!assertSupabase(res)) return;
@@ -160,7 +140,7 @@ exports.generateIds = async (req, res) => {
 
     let updated = 0;
     for (const cli of clientes || []) {
-      const novoId = await gerarIdUnico();
+      const novoId = await gerarIdUnico(supabase);
       const { error: updErr } = await supabase
         .from('clientes')
         .update({ id_interno: novoId })

--- a/controllers/clientesController.js
+++ b/controllers/clientesController.js
@@ -1,5 +1,6 @@
 const supabase = require('../supabaseClient');
 const { assertSupabase } = require('../supabaseClient');
+const { gerarIdInterno, gerarIdUnico } = require('../utils/idGenerator');
 
 function sanitizeCpf(s = '') {
   return (s.match(/\d/g) || []).join('');
@@ -162,27 +163,6 @@ exports.remove = async (req, res) => {
   }
 };
 
-function gerarIdInterno() {
-  const digits = '23456789';
-  let out = 'C';
-  for (let i = 0; i < 7; i++) {
-    out += digits[Math.floor(Math.random() * digits.length)];
-  }
-  return out;
-}
-
-async function gerarIdUnico() {
-  while (true) {
-    const id = gerarIdInterno();
-    const { data } = await supabase
-      .from('clientes')
-      .select('id_interno')
-      .eq('id_interno', id)
-      .maybeSingle();
-    if (!data) return id;
-  }
-}
-
 exports.generateIds = async (req, res) => {
   try {
     if (!assertSupabase(res)) return;
@@ -194,7 +174,7 @@ exports.generateIds = async (req, res) => {
 
     let updated = 0;
     for (const cli of clientes || []) {
-      const novo = await gerarIdUnico();
+      const novo = await gerarIdUnico(supabase);
       const { error: upErr } = await supabase
         .from('clientes')
         .update({ id_interno: novo })

--- a/utils/idGenerator.js
+++ b/utils/idGenerator.js
@@ -1,0 +1,22 @@
+function gerarIdInterno() {
+  const digits = '23456789';
+  let out = 'C';
+  for (let i = 0; i < 7; i++) {
+    out += digits[Math.floor(Math.random() * digits.length)];
+  }
+  return out;
+}
+
+async function gerarIdUnico(supabase) {
+  while (true) {
+    const id = gerarIdInterno();
+    const { data, error } = await supabase
+      .from('clientes')
+      .select('id')
+      .eq('id_interno', id)
+      .maybeSingle();
+    if (!error && !data) return id;
+  }
+}
+
+module.exports = { gerarIdInterno, gerarIdUnico };


### PR DESCRIPTION
## Summary
- centralize ID generation in utils/idGenerator.js
- use shared ID utilities in admin and client controllers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c18298bb0832b82ad12091dddd176