### PR TITLE
Add tests for transactions and Mercado Pago status

### DIFF
--- a/tests/mp.test.js
+++ b/tests/mp.test.js
@@ -1,0 +1,43 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../supabaseClient', () => ({
+  from: jest.fn(),
+  assertSupabase: () => true,
+}));
+
+const mockGet = jest.fn();
+jest.mock('mercadopago', () => ({
+  MercadoPagoConfig: jest.fn(),
+  User: jest.fn().mockImplementation(() => ({ get: mockGet })),
+}));
+
+const mpController = require('../controllers/mpController');
+const app = express();
+app.use('/mp', mpController);
+
+describe('MP status', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    delete process.env.MP_ACCESS_TOKEN;
+    delete process.env.MP_COLLECTOR_ID;
+  });
+
+  test('retorna 503 sem variáveis de ambiente', async () => {
+    const res = await request(app).get('/mp/status');
+    expect(res.status).toBe(503);
+    expect(res.body).toHaveProperty('reason', 'missing_env');
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  test('retorna status quando variáveis presentes', async () => {
+    process.env.MP_ACCESS_TOKEN = 'token';
+    process.env.MP_COLLECTOR_ID = '123';
+    mockGet.mockResolvedValue({ id: 456, live_mode: true });
+
+    const res = await request(app).get('/mp/status');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('collector_id', 456);
+    expect(res.body).toHaveProperty('live', true);
+  });
+});

--- a/tests/transacoes.test.js
+++ b/tests/transacoes.test.js
@@ -1,0 +1,151 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../supabaseClient', () => ({
+  from: jest.fn(),
+  assertSupabase: () => true,
+}));
+
+const supabase = require('../supabaseClient');
+const transacaoController = require('../controllers/transacaoController');
+
+const app = express();
+app.use(express.json());
+app.use('/transacao', transacaoController);
+
+describe('Rotas de transações', () => {
+  beforeEach(() => {
+    supabase.from.mockReset();
+  });
+
+  describe('GET /transacao/preview', () => {
+    test('retorna preview com desconto', async () => {
+      supabase.from.mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        maybeSingle: jest.fn().mockResolvedValue({
+          data: { nome: 'João', plano: 'Essencial' },
+          error: null,
+        }),
+      });
+
+      const res = await request(app)
+        .get('/transacao/preview')
+        .query({ cpf: '12345678901', valor: '100,00' });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('descontoPercent', 5);
+      expect(res.body).toHaveProperty('valorFinal', 95);
+    });
+
+    test('dados inválidos retornam 400', async () => {
+      const res = await request(app)
+        .get('/transacao/preview')
+        .query({ cpf: 'abc', valor: '100' });
+      expect(res.status).toBe(400);
+    });
+
+    test('cliente não encontrado retorna 404', async () => {
+      supabase.from.mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+      });
+
+      const res = await request(app)
+        .get('/transacao/preview')
+        .query({ cpf: '12345678901', valor: '100' });
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('POST /transacao', () => {
+    test('cria transação com sucesso', async () => {
+      supabase.from.mockImplementation((table) => {
+        if (table === 'clientes') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            maybeSingle: jest.fn().mockResolvedValue({
+              data: { nome: 'João', plano: 'Premium' },
+              error: null,
+            }),
+          };
+        }
+        if (table === 'transacoes') {
+          return {
+            insert: jest.fn().mockReturnThis(),
+            select: jest.fn().mockReturnThis(),
+            maybeSingle: jest.fn().mockResolvedValue({
+              data: { id: 1 },
+              error: null,
+            }),
+          };
+        }
+        return {};
+      });
+
+      const res = await request(app)
+        .post('/transacao')
+        .send({ cpf: '12345678901', valor: 100 });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('id', 1);
+      expect(res.body).toHaveProperty('valor_final', 90);
+    });
+
+    test('dados inválidos retornam 400', async () => {
+      const res = await request(app)
+        .post('/transacao')
+        .send({ cpf: 'abc', valor: 100 });
+      expect(res.status).toBe(400);
+    });
+
+    test('cliente não encontrado retorna 404', async () => {
+      supabase.from.mockImplementation((table) => ({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+      }));
+
+      const res = await request(app)
+        .post('/transacao')
+        .send({ cpf: '12345678901', valor: 100 });
+
+      expect(res.status).toBe(404);
+    });
+
+    test('erro ao salvar retorna 500', async () => {
+      supabase.from.mockImplementation((table) => {
+        if (table === 'clientes') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            maybeSingle: jest.fn().mockResolvedValue({
+              data: { nome: 'João', plano: 'Essencial' },
+              error: null,
+            }),
+          };
+        }
+        if (table === 'transacoes') {
+          return {
+            insert: jest.fn().mockReturnThis(),
+            select: jest.fn().mockReturnThis(),
+            maybeSingle: jest.fn().mockResolvedValue({
+              data: null,
+              error: { message: 'db error' },
+            }),
+          };
+        }
+        return {};
+      });
+
+      const res = await request(app)
+        .post('/transacao')
+        .send({ cpf: '12345678901', valor: 100 });
+
+      expect(res.status).toBe(500);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for transaction preview and creation, mocking Supabase operations
- test Mercado Pago status endpoint with and without required env vars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c19267a24832b91ba68f169768dee