### PR TITLE
Atualiza descontos e remove plano Premium

### DIFF
--- a/controllers/transacaoController.js
+++ b/controllers/transacaoController.js
@@ -28,8 +28,8 @@ async function getClienteByCpf(cpf) {
 }
 
 function calcularDesconto(plano, valor) {
-  // regra simples: Essencial 5%, Premium 10%, Platinum 10% (ajuste se quiser)
-  const mapa = { Essencial: 5, Premium: 10, Platinum: 10 };
+  // regra simples: Essencial 5%, Platinum 10%, Black 15% (ajuste se quiser)
+  const mapa = { Essencial: 5, Platinum: 10, Black: 15 };
   const pct = mapa[plano] || 0;
   const valorFinal = Number((valor * (1 - pct/100)).toFixed(2));
   return { pct, valorFinal };

--- a/tests/transacoes.test.js
+++ b/tests/transacoes.test.js
@@ -71,7 +71,7 @@ describe('Rotas de transações', () => {
             select: jest.fn().mockReturnThis(),
             eq: jest.fn().mockReturnThis(),
             maybeSingle: jest.fn().mockResolvedValue({
-              data: { nome: 'João', plano: 'Premium' },
+              data: { nome: 'João', plano: 'Black' },
               error: null,
             }),
           };
@@ -95,7 +95,7 @@ describe('Rotas de transações', () => {
 
       expect(res.status).toBe(200);
       expect(res.body).toHaveProperty('id', 1);
-      expect(res.body).toHaveProperty('valor_final', 90);
+      expect(res.body).toHaveProperty('valor_final', 85);
     });
 
     test('dados inválidos retornam 400', async () => {


### PR DESCRIPTION
## Summary
- atualizar calculo de desconto para Essencial 5%, Platinum 10% e Black 15%
- remover referencias ao plano Premium
- ajustar teste de transacao para plano Black

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c20edb72c832b9b4b2829e841fd21