### PR TITLE
refactor: centralize client ID generation

### DIFF
--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -1,6 +1,6 @@
 const supabase = require('../supabaseClient');
 const { assertSupabase } = require('../supabaseClient');
-const { gerarIdInterno, gerarIdUnico } = require('../utils/idGenerator');
+const generateClientIds = require('../utils/generateClientIds');
 
 function sanitizeCpf(s = '') {
   return (s.match(/\d/g) || []).join('');
@@ -132,24 +132,7 @@ exports.bulkClientes = async (req, res, next) => {
 exports.generateIds = async (req, res, next) => {
   try {
     if (!assertSupabase(res)) return;
-    const { data: clientes, error } = await supabase
-      .from('clientes')
-      .select('id')
-      .is('id_interno', null);
-    if (error) {
-      return next(error);
-    }
-
-    let updated = 0;
-    for (const cli of clientes || []) {
-      const novoId = await gerarIdUnico(supabase);
-      const { error: updErr } = await supabase
-        .from('clientes')
-        .update({ id_interno: novoId })
-        .eq('id', cli.id);
-      if (!updErr) updated += 1;
-    }
-
+    const updated = await generateClientIds();
     res.json({ updated });
   } catch (err) {
     next(err);

--- a/controllers/clientesController.js
+++ b/controllers/clientesController.js
@@ -1,6 +1,6 @@
 const supabase = require('../supabaseClient');
 const { assertSupabase } = require('../supabaseClient');
-const { gerarIdInterno, gerarIdUnico } = require('../utils/idGenerator');
+const generateClientIds = require('../utils/generateClientIds');
 
 function sanitizeCpf(s = '') {
   return (s.match(/\d/g) || []).join('');
@@ -182,21 +182,7 @@ exports.remove = async (req, res, next) => {
 exports.generateIds = async (req, res, next) => {
   try {
     if (!assertSupabase(res)) return;
-    const { data: clientes, error } = await supabase
-      .from('clientes')
-      .select('cpf')
-      .is('id_interno', null);
-    if (error) return next(error);
-
-    let updated = 0;
-    for (const cli of clientes || []) {
-      const novo = await gerarIdUnico(supabase);
-      const { error: upErr } = await supabase
-        .from('clientes')
-        .update({ id_interno: novo })
-        .eq('cpf', cli.cpf);
-      if (!upErr) updated++;
-    }
+    const updated = await generateClientIds();
     return res.json({ updated });
   } catch (err) {
     return next(err);

--- a/utils/generateClientIds.js
+++ b/utils/generateClientIds.js
@@ -1,0 +1,24 @@
+const supabase = require('../supabaseClient');
+const { gerarIdUnico } = require('./idGenerator');
+
+async function generateClientIds() {
+  const { data: clientes, error } = await supabase
+    .from('clientes')
+    .select('id')
+    .is('id_interno', null);
+  if (error) throw error;
+
+  let updated = 0;
+  for (const cli of clientes || []) {
+    const novoId = await gerarIdUnico(supabase);
+    const { error: updErr } = await supabase
+      .from('clientes')
+      .update({ id_interno: novoId })
+      .eq('id', cli.id);
+    if (!updErr) updated += 1;
+  }
+
+  return updated;
+}
+
+module.exports = generateClientIds;


### PR DESCRIPTION
## Summary
- add reusable `generateClientIds` utility to populate missing `id_interno`
- refactor admin and client controllers to use shared ID generator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c24f5e3c8832b9e17404a7f84c6c0