### PR TITLE
Add Jest tests for clientes and report controllers

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "jest",
+    "test": "jest tests",
     "test:api": "node ./tests/ping.js",
     "vercel:prepare": "node scripts/patch-vercel.js",
     "build:meta": "echo \"ok\"",

--- a/tests/clientes.test.js
+++ b/tests/clientes.test.js
@@ -1,0 +1,222 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../supabaseClient', () => ({
+  from: jest.fn(),
+  assertSupabase: () => true,
+}));
+
+jest.mock('../utils/generateClientIds', () => jest.fn());
+
+const supabase = require('../supabaseClient');
+const generateClientIds = require('../utils/generateClientIds');
+const clientesController = require('../controllers/clientesController');
+
+const app = express();
+app.use(express.json());
+app.get('/clientes', clientesController.list);
+app.post('/clientes', clientesController.upsertOne);
+app.post('/clientes/bulk', clientesController.bulkUpsert);
+app.delete('/clientes/:cpf', clientesController.remove);
+app.post('/clientes/generate-ids', clientesController.generateIds);
+
+beforeEach(() => {
+  supabase.from.mockReset();
+  generateClientIds.mockReset();
+});
+
+describe('Clientes Controller', () => {
+  test('list retorna dados com sucesso', async () => {
+    supabase.from.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      or: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnValue({
+        range: jest
+          .fn()
+          .mockResolvedValue({ data: [{ cpf: '1' }], error: null, count: 1 }),
+      }),
+    });
+
+    const res = await request(app).get('/clientes');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ rows: [{ cpf: '1' }], total: 1 });
+  });
+
+  test('list erro do banco retorna 500', async () => {
+    supabase.from.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      or: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnValue({
+        range: jest.fn().mockResolvedValue({ data: null, error: { message: 'db' } }),
+      }),
+    });
+
+    const res = await request(app).get('/clientes');
+    expect(res.status).toBe(500);
+  });
+
+  test('upsertOne sucesso', async () => {
+    supabase.from.mockReturnValue({
+      upsert: jest.fn().mockReturnValue({
+        select: jest.fn().mockResolvedValue({
+          data: [{ cpf: '12345678901', nome: 'Fulano' }],
+          error: null,
+        }),
+      }),
+    });
+
+    const res = await request(app)
+      .post('/clientes')
+      .send({
+        cpf: '12345678901',
+        nome: 'Fulano',
+        plano: 'Essencial',
+        status: 'ativo',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('ok', true);
+  });
+
+  test('upsertOne validação falha retorna 400', async () => {
+    const res = await request(app)
+      .post('/clientes')
+      .send({ cpf: '123', nome: '', plano: 'Essencial', status: 'ativo' });
+
+    expect(res.status).toBe(400);
+    expect(supabase.from).not.toHaveBeenCalled();
+  });
+
+  test('upsertOne erro do banco retorna 500', async () => {
+    supabase.from.mockReturnValue({
+      upsert: jest.fn().mockReturnValue({
+        select: jest
+          .fn()
+          .mockResolvedValue({ data: null, error: { message: 'db' } }),
+      }),
+    });
+
+    const res = await request(app)
+      .post('/clientes')
+      .send({
+        cpf: '12345678901',
+        nome: 'Fulano',
+        plano: 'Essencial',
+        status: 'ativo',
+      });
+
+    expect(res.status).toBe(500);
+  });
+
+  test('bulkUpsert sucesso', async () => {
+    let call = 0;
+    supabase.from.mockImplementation(() => {
+      if (call++ === 0) {
+        return {
+          select: jest.fn().mockReturnThis(),
+          in: jest.fn().mockResolvedValue({ data: [], error: null }),
+        };
+      }
+      return {
+        upsert: jest.fn().mockResolvedValue({ error: null }),
+      };
+    });
+
+    const res = await request(app)
+      .post('/clientes/bulk')
+      .send({
+        clientes: [
+          {
+            cpf: '12345678901',
+            nome: 'Fulano',
+            plano: 'Essencial',
+            status: 'ativo',
+          },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ inserted: 1, updated: 0, invalid: 0, duplicates: 0 });
+  });
+
+  test('bulkUpsert lista vazia retorna 400', async () => {
+    const res = await request(app)
+      .post('/clientes/bulk')
+      .send({ clientes: [] });
+    expect(res.status).toBe(400);
+    expect(supabase.from).not.toHaveBeenCalled();
+  });
+
+  test('bulkUpsert erro do banco retorna 500', async () => {
+    let call = 0;
+    supabase.from.mockImplementation(() => {
+      if (call++ === 0) {
+        return {
+          select: jest.fn().mockReturnThis(),
+          in: jest
+            .fn()
+            .mockResolvedValue({ data: null, error: { message: 'db' } }),
+        };
+      }
+      return {};
+    });
+
+    const res = await request(app)
+      .post('/clientes/bulk')
+      .send({
+        clientes: [
+          {
+            cpf: '12345678901',
+            nome: 'Fulano',
+            plano: 'Essencial',
+            status: 'ativo',
+          },
+        ],
+      });
+
+    expect(res.status).toBe(500);
+  });
+
+  test('remove sucesso', async () => {
+    supabase.from.mockReturnValue({
+      delete: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockResolvedValue({ error: null }),
+    });
+
+    const res = await request(app).delete('/clientes/12345678901');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  test('remove cpf inválido retorna 400', async () => {
+    const res = await request(app).delete('/clientes/abc');
+    expect(res.status).toBe(400);
+    expect(supabase.from).not.toHaveBeenCalled();
+  });
+
+  test('remove erro do banco retorna 500', async () => {
+    supabase.from.mockReturnValue({
+      delete: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockResolvedValue({ error: { message: 'db' } }),
+    });
+
+    const res = await request(app).delete('/clientes/12345678901');
+    expect(res.status).toBe(500);
+  });
+
+  test('generateIds sucesso', async () => {
+    generateClientIds.mockResolvedValue(5);
+    const res = await request(app).post('/clientes/generate-ids');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ updated: 5 });
+  });
+
+  test('generateIds erro retorna 500', async () => {
+    generateClientIds.mockRejectedValue(new Error('db'));
+    const res = await request(app).post('/clientes/generate-ids');
+    expect(res.status).toBe(500);
+  });
+});
+

--- a/tests/report.test.js
+++ b/tests/report.test.js
@@ -1,0 +1,106 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../supabaseClient', () => ({
+  from: jest.fn(),
+  assertSupabase: () => true,
+}));
+
+jest.mock('../services/transacoesMetrics', () => ({
+  periodFromQuery: jest.fn(() => ({
+    from: new Date('2024-01-01T00:00:00Z'),
+    to: new Date('2024-01-31T00:00:00Z'),
+  })),
+  iso: jest.fn((d) => d.toISOString()),
+  aggregate: jest.fn(() => ({
+    qtdTransacoes: 1,
+    bruto: 100,
+    descontos: 10,
+    liquido: 90,
+    porPlano: {},
+    porCliente: {},
+  })),
+}));
+
+const supabase = require('../supabaseClient');
+const reportController = require('../controllers/reportController');
+
+const app = express();
+app.get('/relatorios/resumo', reportController.resumo);
+app.get('/relatorios/csv', reportController.csv);
+
+beforeEach(() => {
+  supabase.from.mockReset();
+});
+
+describe('Report Controller', () => {
+  test('resumo retorna métricas', async () => {
+    const query = {
+      select: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      lte: jest.fn().mockReturnThis(),
+      then: (resolve) => resolve({ data: [], error: null }),
+    };
+    supabase.from.mockReturnValue(query);
+
+    const res = await request(app).get('/relatorios/resumo');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('totalBruto', 100);
+  });
+
+  test('resumo erro do banco retorna 500', async () => {
+    const query = {
+      select: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      lte: jest.fn().mockReturnThis(),
+      then: (resolve) => resolve({ data: null, error: { message: 'db' } }),
+    };
+    supabase.from.mockReturnValue(query);
+
+    const res = await request(app).get('/relatorios/resumo');
+    expect(res.status).toBe(500);
+  });
+
+  test('csv retorna conteúdo', async () => {
+    const row = {
+      id: 1,
+      created_at: '2024-01-01',
+      cpf: '123',
+      cliente_nome: 'Fulano',
+      plano: 'Essencial',
+      valor_bruto: 10,
+      desconto_aplicado: 0,
+      valor_final: 10,
+      origem: 'web',
+    };
+    const query = {
+      select: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      lte: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      then: (resolve) => resolve({ data: [row], error: null }),
+    };
+    supabase.from.mockReturnValue(query);
+
+    const res = await request(app).get('/relatorios/csv');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/csv/);
+    expect(res.text).toContain('id,created_at,cpf');
+    expect(res.text).toContain('Fulano');
+  });
+
+  test('csv erro do banco retorna 500', async () => {
+    const query = {
+      select: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      lte: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      then: (resolve) => resolve({ data: null, error: { message: 'db' } }),
+    };
+    supabase.from.mockReturnValue(query);
+
+    const res = await request(app).get('/relatorios/csv');
+    expect(res.status).toBe(500);
+  });
+});
+


### PR DESCRIPTION
## Summary
- test: run Jest on tests directory
- test: cover clientes controller with success, validation, and error cases
- test: cover report controller CSV and resumo endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c290b7150832b847eca5c975a2b74