### PR TITLE
feat: adicionar metodo_pagamento aos clientes

### DIFF
--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -9,9 +9,27 @@ function sanitizeCpf(s = '') {
 exports.seed = async (req, res, next) => {
   if (!assertSupabase(res)) return;
   const registros = [
-    { cpf: '11111111111', nome: 'Cliente Um', plano: 'Essencial', status: 'ativo' },
-    { cpf: '22222222222', nome: 'Cliente Dois', plano: 'Platinum', status: 'ativo' },
-    { cpf: '33333333333', nome: 'Cliente Três', plano: 'Black', status: 'ativo' }
+    {
+      cpf: '11111111111',
+      nome: 'Cliente Um',
+      plano: 'Essencial',
+      status: 'ativo',
+      metodo_pagamento: 'pix'
+    },
+    {
+      cpf: '22222222222',
+      nome: 'Cliente Dois',
+      plano: 'Platinum',
+      status: 'ativo',
+      metodo_pagamento: 'pix'
+    },
+    {
+      cpf: '33333333333',
+      nome: 'Cliente Três',
+      plano: 'Black',
+      status: 'ativo',
+      metodo_pagamento: 'pix'
+    }
   ];
 
   const cpfs = registros.map(r => r.cpf);

--- a/controllers/clientesController.js
+++ b/controllers/clientesController.js
@@ -8,6 +8,7 @@ function sanitizeCpf(s = '') {
 
 const PLANOS = new Set(['Essencial', 'Platinum', 'Black']);
 const STATUS = new Set(['ativo', 'inativo']);
+const METODOS_PAGAMENTO = new Set(['pix', 'cartao_debito', 'cartao_credito', 'dinheiro']);
 
 function parseCliente(raw = {}) {
   const errors = [];
@@ -15,6 +16,7 @@ function parseCliente(raw = {}) {
   const nome = (raw.nome || '').toString().trim();
   const plano = raw.plano;
   const status = raw.status;
+  const metodo_pagamento = (raw.metodo_pagamento || '').toString().trim();
   let pagamento_em_dia = raw.pagamento_em_dia;
   let vencimento = raw.vencimento;
 
@@ -22,6 +24,7 @@ function parseCliente(raw = {}) {
   if (!nome) errors.push('nome obrigatório');
   if (!PLANOS.has(plano)) errors.push('plano inválido');
   if (!STATUS.has(status)) errors.push('status inválido');
+  if (!METODOS_PAGAMENTO.has(metodo_pagamento)) errors.push('metodo_pagamento inválido');
 
   if (pagamento_em_dia !== undefined) {
     pagamento_em_dia = pagamento_em_dia === true || pagamento_em_dia === 'true' || pagamento_em_dia === 1 || pagamento_em_dia === '1';
@@ -39,7 +42,7 @@ function parseCliente(raw = {}) {
 
   return {
     ok: errors.length === 0,
-    data: { cpf, nome, plano, status, pagamento_em_dia, vencimento },
+    data: { cpf, nome, plano, status, metodo_pagamento, pagamento_em_dia, vencimento },
     errors
   };
 }

--- a/db/migrations/20241020000000_add-metodo_pagamento-clientes.sql
+++ b/db/migrations/20241020000000_add-metodo_pagamento-clientes.sql
@@ -1,0 +1,8 @@
+-- migrate:up
+alter table public.clientes
+  add column if not exists metodo_pagamento text not null default 'pix'
+    check (metodo_pagamento in ('pix','cartao_debito','cartao_credito','dinheiro'));
+
+-- migrate:down
+alter table public.clientes
+  drop column if exists metodo_pagamento;

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -4,6 +4,7 @@ create table if not exists public.clientes (
   cpf text not null unique,
   plano text not null,
   data_adesao timestamp not null default now(),
+  metodo_pagamento text not null check (metodo_pagamento in ('pix','cartao_debito','cartao_credito','dinheiro')),
   status text not null
 );
 create table if not exists public.transacoes (

--- a/tests/clientes.test.js
+++ b/tests/clientes.test.js
@@ -61,7 +61,7 @@ describe('Clientes Controller', () => {
     supabase.from.mockReturnValue({
       upsert: jest.fn().mockReturnValue({
         select: jest.fn().mockResolvedValue({
-          data: [{ cpf: '12345678901', nome: 'Fulano' }],
+          data: [{ cpf: '12345678901', nome: 'Fulano', metodo_pagamento: 'pix' }],
           error: null,
         }),
       }),
@@ -74,6 +74,7 @@ describe('Clientes Controller', () => {
         nome: 'Fulano',
         plano: 'Essencial',
         status: 'ativo',
+        metodo_pagamento: 'pix',
       });
 
     expect(res.status).toBe(200);
@@ -83,7 +84,13 @@ describe('Clientes Controller', () => {
   test('upsertOne validação falha retorna 400', async () => {
     const res = await request(app)
       .post('/clientes')
-      .send({ cpf: '123', nome: '', plano: 'Essencial', status: 'ativo' });
+      .send({
+        cpf: '123',
+        nome: '',
+        plano: 'Essencial',
+        status: 'ativo',
+        metodo_pagamento: 'pix',
+      });
 
     expect(res.status).toBe(400);
     expect(supabase.from).not.toHaveBeenCalled();
@@ -105,6 +112,7 @@ describe('Clientes Controller', () => {
         nome: 'Fulano',
         plano: 'Essencial',
         status: 'ativo',
+        metodo_pagamento: 'pix',
       });
 
     expect(res.status).toBe(500);
@@ -133,6 +141,7 @@ describe('Clientes Controller', () => {
             nome: 'Fulano',
             plano: 'Essencial',
             status: 'ativo',
+            metodo_pagamento: 'pix',
           },
         ],
       });
@@ -172,6 +181,7 @@ describe('Clientes Controller', () => {
             nome: 'Fulano',
             plano: 'Essencial',
             status: 'ativo',
+            metodo_pagamento: 'pix',
           },
         ],
       });


### PR DESCRIPTION
## Summary
- add metodo_pagamento enum column to clientes
- validate metodo_pagamento in cliente parser
- update sample data and tests to include payment method

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c2c45ed84832ba4b5540d5072269c