### PR TITLE
Atualiza planos de assinatura e descontos

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ API em Node.js para gerenciamento de assinaturas, transações e administração
 | `RAILWAY_URL` | URL do deploy no Railway (referenciada em `scripts/patch-vercel.js`) |
 | `DATABASE_URL` | String de conexão PostgreSQL usada pelo `dbmate` |
 
+## Planos e descontos
+| Plano | Desconto |
+|-------|----------|
+| Mensal | 10% |
+| Semestral | 15% |
+| Anual | 30% |
+
 ## Rotas Principais
 - `GET /health` – Health check da API.
 - `GET /assinaturas?cpf=<cpf>` – Consulta assinatura pelo CPF.

--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -12,21 +12,21 @@ exports.seed = async (req, res, next) => {
     {
       cpf: '11111111111',
       nome: 'Cliente Um',
-      plano: 'Essencial',
+      plano: 'Mensal',
       status: 'ativo',
       metodo_pagamento: 'pix'
     },
     {
       cpf: '22222222222',
       nome: 'Cliente Dois',
-      plano: 'Platinum',
+      plano: 'Semestral',
       status: 'ativo',
       metodo_pagamento: 'pix'
     },
     {
       cpf: '33333333333',
       nome: 'Cliente Três',
-      plano: 'Black',
+      plano: 'Anual',
       status: 'ativo',
       metodo_pagamento: 'pix'
     }

--- a/controllers/clientesController.js
+++ b/controllers/clientesController.js
@@ -6,7 +6,7 @@ function sanitizeCpf(s = '') {
   return (s.match(/\d/g) || []).join('');
 }
 
-const PLANOS = new Set(['Essencial', 'Platinum', 'Black']);
+const PLANOS = new Set(['Mensal', 'Semestral', 'Anual']);
 const STATUS = new Set(['ativo', 'inativo']);
 const METODOS_PAGAMENTO = new Set(['pix', 'cartao_debito', 'cartao_credito', 'dinheiro']);
 

--- a/controllers/leadController.js
+++ b/controllers/leadController.js
@@ -1,6 +1,6 @@
 const supabase = require('../supabaseClient');
 const { assertSupabase } = require('../supabaseClient');
-const PLANOS = new Set(['Essencial', 'Platinum', 'Black']);
+const PLANOS = new Set(['Mensal', 'Semestral', 'Anual']);
 const onlyDigits = s => (String(s||'').match(/\d/g) || []).join('');
 function isEmail(s){ return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(s||'')); }
 

--- a/controllers/transacaoController.js
+++ b/controllers/transacaoController.js
@@ -28,10 +28,10 @@ async function getClienteByCpf(cpf) {
 }
 
 function calcularDesconto(plano, valor) {
-  // regra simples: Essencial 5%, Platinum 10%, Black 15% (ajuste se quiser)
-  const mapa = { Essencial: 5, Platinum: 10, Black: 15 };
+  // regra simples: Mensal 10%, Semestral 15%, Anual 30% (ajuste se quiser)
+  const mapa = { Mensal: 10, Semestral: 15, Anual: 30 };
   const pct = mapa[plano] || 0;
-  const valorFinal = Number((valor * (1 - pct/100)).toFixed(2));
+  const valorFinal = Number((valor * (1 - pct / 100)).toFixed(2));
   return { pct, valorFinal };
 }
 

--- a/public/leads-admin.html
+++ b/public/leads-admin.html
@@ -29,9 +29,9 @@
             <label class="label" for="plano">Plano</label>
             <select id="plano" class="input">
               <option value="">Todos</option>
-              <option>Essencial</option>
-              <option>Platinum</option>
-              <option>Black</option>
+              <option>Mensal</option>
+              <option>Semestral</option>
+              <option>Anual</option>
             </select>
           </div>
           <div class="field" style="grid-column: span 2;">

--- a/public/relatorios.html
+++ b/public/relatorios.html
@@ -32,9 +32,9 @@
             <label class="label" for="plano">Plano</label>
             <select id="plano" class="input">
               <option value="">Todos</option>
-              <option>Essencial</option>
-              <option>Platinum</option>
-              <option>Black</option>
+              <option>Mensal</option>
+              <option>Semestral</option>
+              <option>Anual</option>
             </select>
           </div>
         </div>

--- a/public/sample-clientes.csv
+++ b/public/sample-clientes.csv
@@ -1,5 +1,5 @@
 nome,cpf,email,telefone,plano,status_pagamento,vencimento
-Fulano da Silva,11111111111,fulano@example.com,11999999999,Essencial,em dia,2024-12-31
-Beltrano Souza,22222222222,beltrano@example.com,11888888888,Platinum,pendente,31/01/2025
-Maria Oliveira,33333333333,maria@example.com,11777777777,Black,inadimplente,2025-02-15
+Fulano da Silva,11111111111,fulano@example.com,11999999999,Mensal,em dia,2024-12-31
+Beltrano Souza,22222222222,beltrano@example.com,11888888888,Semestral,pendente,31/01/2025
+Maria Oliveira,33333333333,maria@example.com,11777777777,Anual,inadimplente,2025-02-15
 

--- a/test-mp.js
+++ b/test-mp.js
@@ -18,7 +18,7 @@ if (!API_URL) {
         cpf: '12345678900',
         plano: 'platinum',
         valor_original: 100,
-        descricao: 'Assinatura Platinum'
+        descricao: 'Assinatura Semestral'
       })
     });
 

--- a/tests/assinaturas.test.js
+++ b/tests/assinaturas.test.js
@@ -22,7 +22,7 @@ describe('Rotas de assinaturas', () => {
       select: jest.fn().mockReturnThis(),
       eq: jest.fn().mockReturnThis(),
       maybeSingle: jest.fn().mockResolvedValue({
-        data: { nome: 'João', plano: 'Essencial', status: 'ativo' },
+        data: { nome: 'João', plano: 'Mensal', status: 'ativo' },
         error: null,
       }),
     });

--- a/tests/clientes.test.js
+++ b/tests/clientes.test.js
@@ -72,7 +72,7 @@ describe('Clientes Controller', () => {
       .send({
         cpf: '12345678901',
         nome: 'Fulano',
-        plano: 'Essencial',
+        plano: 'Mensal',
         status: 'ativo',
         metodo_pagamento: 'pix',
       });
@@ -87,7 +87,7 @@ describe('Clientes Controller', () => {
       .send({
         cpf: '123',
         nome: '',
-        plano: 'Essencial',
+        plano: 'Mensal',
         status: 'ativo',
         metodo_pagamento: 'pix',
       });
@@ -110,7 +110,7 @@ describe('Clientes Controller', () => {
       .send({
         cpf: '12345678901',
         nome: 'Fulano',
-        plano: 'Essencial',
+        plano: 'Mensal',
         status: 'ativo',
         metodo_pagamento: 'pix',
       });
@@ -139,7 +139,7 @@ describe('Clientes Controller', () => {
           {
             cpf: '12345678901',
             nome: 'Fulano',
-            plano: 'Essencial',
+            plano: 'Mensal',
             status: 'ativo',
             metodo_pagamento: 'pix',
           },
@@ -179,7 +179,7 @@ describe('Clientes Controller', () => {
           {
             cpf: '12345678901',
             nome: 'Fulano',
-            plano: 'Essencial',
+            plano: 'Mensal',
             status: 'ativo',
             metodo_pagamento: 'pix',
           },

--- a/tests/leads.test.js
+++ b/tests/leads.test.js
@@ -30,7 +30,7 @@ describe('Rotas de leads', () => {
 
     const res = await request(app)
       .post('/public/lead')
-      .send({ nome: 'João', cpf: '12345678901', plano: 'Essencial' });
+      .send({ nome: 'João', cpf: '12345678901', plano: 'Mensal' });
 
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('id', 1);
@@ -39,7 +39,7 @@ describe('Rotas de leads', () => {
   test('validação falha retorna 400', async () => {
     const res = await request(app)
       .post('/public/lead')
-      .send({ cpf: '123', plano: 'Essencial' });
+      .send({ cpf: '123', plano: 'Mensal' });
     expect(res.status).toBe(400);
   });
 

--- a/tests/report.test.js
+++ b/tests/report.test.js
@@ -67,7 +67,7 @@ describe('Report Controller', () => {
       created_at: '2024-01-01',
       cpf: '123',
       cliente_nome: 'Fulano',
-      plano: 'Essencial',
+      plano: 'Mensal',
       valor_bruto: 10,
       desconto_aplicado: 0,
       valor_final: 10,

--- a/tests/transacoes.test.js
+++ b/tests/transacoes.test.js
@@ -26,7 +26,7 @@ describe('Rotas de transações', () => {
         select: jest.fn().mockReturnThis(),
         eq: jest.fn().mockReturnThis(),
         maybeSingle: jest.fn().mockResolvedValue({
-          data: { nome: 'João', plano: 'Essencial' },
+          data: { nome: 'João', plano: 'Mensal' },
           error: null,
         }),
       });
@@ -36,8 +36,8 @@ describe('Rotas de transações', () => {
         .query({ cpf: '12345678901', valor: '100,00' });
 
       expect(res.status).toBe(200);
-      expect(res.body).toHaveProperty('descontoPercent', 5);
-      expect(res.body).toHaveProperty('valorFinal', 95);
+      expect(res.body).toHaveProperty('descontoPercent', 10);
+      expect(res.body).toHaveProperty('valorFinal', 90);
     });
 
     test('dados inválidos retornam 400', async () => {
@@ -71,7 +71,7 @@ describe('Rotas de transações', () => {
             select: jest.fn().mockReturnThis(),
             eq: jest.fn().mockReturnThis(),
             maybeSingle: jest.fn().mockResolvedValue({
-              data: { nome: 'João', plano: 'Black' },
+              data: { nome: 'João', plano: 'Anual' },
               error: null,
             }),
           };
@@ -95,7 +95,7 @@ describe('Rotas de transações', () => {
 
       expect(res.status).toBe(200);
       expect(res.body).toHaveProperty('id', 1);
-      expect(res.body).toHaveProperty('valor_final', 85);
+      expect(res.body).toHaveProperty('valor_final', 70);
     });
 
     test('dados inválidos retornam 400', async () => {
@@ -127,7 +127,7 @@ describe('Rotas de transações', () => {
             select: jest.fn().mockReturnThis(),
             eq: jest.fn().mockReturnThis(),
             maybeSingle: jest.fn().mockResolvedValue({
-              data: { nome: 'João', plano: 'Essencial' },
+              data: { nome: 'João', plano: 'Mensal' },
               error: null,
             }),
           };


### PR DESCRIPTION
## Summary
- substitui planos Essencial/Platinum/Black por Mensal, Semestral e Anual
- ajusta cálculo de desconto para 10%, 15% e 30%
- atualiza páginas públicas, CSV de exemplo, testes e documentação

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c2ddafeec832bafe83fb36d193b04