### PR TITLE
Corrige campo valor e importação manual de clientes

### DIFF
--- a/public/clientes-admin.js
+++ b/public/clientes-admin.js
@@ -142,7 +142,8 @@ async function onImport() {
     const r = await UI.adminFetch('/admin/clientes/bulk', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ rows: validRows })
+      // O endpoint espera o campo `clientes`, não `rows`.
+      body: JSON.stringify({ clientes: validRows })
     });
     if (!r.ok) {
       toast('Erro ao importar', 'error');

--- a/public/main.js
+++ b/public/main.js
@@ -478,7 +478,10 @@ function getCpf(){
 }
 
 function getValorBRL(){
-  return money?.get ? money.get() : 0; // em centavos
+  // Retorna o valor em reais (com centavos) como Number
+  // Antes retornava em centavos, o que causava discrepâncias ao enviar
+  // para a API quando o usuário digitava valores com vírgula.
+  return getValorNumero();
 }
 
 // Dica: se precisar zerar o campo após registrar e a preferência estiver marcada:


### PR DESCRIPTION
## Summary
- corrige função de coleta do valor para não enviar mais centavos à API
- ajusta importação manual de clientes usando propriedade `clientes`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c38c82360832baa7d592870ef0881