### PR TITLE
feat: add admin signup routes and form

### DIFF
--- a/public/admin/novo-cadastro.html
+++ b/public/admin/novo-cadastro.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8" />
+<title>Novo Cadastro</title>
+</head>
+<body>
+<form onsubmit="cadastrar(event)">
+  <input name="nome" placeholder="Nome" required />
+  <input name="documento" placeholder="Documento" required />
+  <input name="telefone" placeholder="Telefone" required />
+  <input name="email" placeholder="Email" />
+  <select name="plano" required>
+    <option value="ESSENCIAL">ESSENCIAL</option>
+    <option value="PLATINUM">PLATINUM</option>
+    <option value="BLACK">BLACK</option>
+  </select>
+  <select name="forma_pagamento" required>
+    <option value="PIX">PIX</option>
+    <option value="CREDITO">CREDITO</option>
+    <option value="DEBITO">DEBITO</option>
+    <option value="DINHEIRO">DINHEIRO</option>
+    <option value="BOLETO">BOLETO</option>
+  </select>
+  <input name="valor" placeholder="Valor" required />
+  <input name="vencimento" placeholder="Vencimento" />
+  <input name="pin" placeholder="PIN" required />
+  <button type="submit">Cadastrar</button>
+</form>
+<script>
+const api = '';
+async function cadastrar(e){
+  e.preventDefault();
+  const f = e.target;
+  const pin = f.pin.value;
+  // 1) cliente
+    const clienteRes = await fetch(`${api}/admin/clientes`, {
+      method:'POST',
+      headers:{'Content-Type':'application/json','x-admin-pin':pin},
+      body: JSON.stringify({
+        nome: f.nome.value,
+        documento: f.documento.value,
+        telefone: f.telefone.value,
+        email: f.email.value
+      })
+    });
+  const cliente = await clienteRes.json(); if(!cliente.id) return alert('Erro cliente: '+JSON.stringify(cliente));
+  // 2) assinatura
+  const assRes = await fetch(`${api}/admin/assinatura`, {
+    method:'POST',
+    headers:{'Content-Type':'application/json','x-admin-pin':pin},
+    body: JSON.stringify({
+      cliente_id: cliente.id,
+      plano: f.plano.value,
+      forma_pagamento: f.forma_pagamento.value,
+      valor: f.valor.value,
+      vencimento: f.vencimento.value
+    })
+  });
+  const ass = await assRes.json(); if(!ass.id) return alert('Erro assinatura: '+JSON.stringify(ass));
+  alert('Cadastro OK! Cliente '+cliente.nome+' com transação #'+ass.id);
+  f.reset();
+}
+</script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -14,6 +14,7 @@ const lead = require('./controllers/leadController');
 const clientes = require('./controllers/clientesController');
 const { requireAdmin } = require('./middlewares/requireAdmin');
 const errorHandler = require('./middlewares/errorHandler');
+const adminRoutes = require('./src/routes/admin');
 const hasMpEnv = process.env.MP_ACCESS_TOKEN && process.env.MP_COLLECTOR_ID && process.env.MP_WEBHOOK_SECRET;
 let mpController = null;
 if (hasMpEnv) {
@@ -73,6 +74,7 @@ app.get('/admin/status/ping-supabase', requireAdmin, status.pingSupabase);
 app.get('/assinaturas', assinaturaController.consultarPorIdentificador);
 app.get('/assinaturas/listar', assinaturaController.listarTodas);
 app.use('/transacao', transacaoController);
+app.use('/admin', adminRoutes);
 app.post('/admin/seed', requireAdmin, adminController.seed);
 app.get('/admin/clientes', requireAdmin, clientes.list);
 app.post('/admin/clientes/upsert', requireAdmin, clientes.upsertOne);

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,0 +1,3 @@
+const supabase = require('../../supabaseClient');
+
+module.exports = supabase;

--- a/src/middlewares/adminPin.js
+++ b/src/middlewares/adminPin.js
@@ -1,0 +1,9 @@
+function requireAdminPin(req, res, next) {
+  const pin = req.get('x-admin-pin') || req.query.pin;
+  if (!pin || pin !== process.env.ADMIN_PIN) {
+    return res.status(401).json({ error: 'PIN inválido' });
+  }
+  next();
+}
+
+module.exports = { requireAdminPin };

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -1,0 +1,62 @@
+const express = require('express');
+const supabase = require('../lib/supabase');
+const { requireAdminPin } = require('../middlewares/adminPin');
+const { ClienteCreate, AssinaturaCreate } = require('../schemas/admin');
+const { toCents } = require('../utils/currency');
+
+const router = express.Router();
+
+router.post('/clientes', requireAdminPin, async (req, res) => {
+  try {
+    const data = ClienteCreate.parse(req.body);
+    const { data: cli, error } = await supabase
+      .from('clientes')
+      .insert(data)
+      .select()
+      .single();
+    if (error) throw error;
+    res.json(cli);
+  } catch (e) {
+    res.status(400).json({ error: e.message });
+  }
+});
+
+router.post('/assinatura', requireAdminPin, async (req, res) => {
+  try {
+    const payload = AssinaturaCreate.parse(req.body);
+    let cliente_id = payload.cliente_id;
+    if (!cliente_id && payload.documento) {
+      const { data: cli, error } = await supabase
+        .from('clientes')
+        .select('id')
+        .eq('documento', payload.documento)
+        .maybeSingle();
+      if (error) throw error;
+      if (!cli) throw new Error('Cliente não encontrado pelo documento');
+      cliente_id = cli.id;
+    }
+    if (!cliente_id) throw new Error('Informe cliente_id ou documento');
+    const valor_original = toCents(payload.valor);
+    const insert = {
+      cliente_id,
+      plano: payload.plano,
+      forma_pagamento: payload.forma_pagamento,
+      valor_original,
+      desconto_aplicado: 0,
+      valor_final: valor_original,
+      status_pagamento: 'pendente',
+      vencimento: payload.vencimento ?? null,
+    };
+    const { data: trx, error } = await supabase
+      .from('transacoes')
+      .insert(insert)
+      .select()
+      .single();
+    if (error) throw error;
+    res.json(trx);
+  } catch (e) {
+    res.status(400).json({ error: e.message });
+  }
+});
+
+module.exports = router;

--- a/src/schemas/admin.js
+++ b/src/schemas/admin.js
@@ -1,0 +1,19 @@
+const { z } = require('zod');
+
+const ClienteCreate = z.object({
+  nome: z.string().min(2),
+  documento: z.string().min(8),
+  telefone: z.string().min(8),
+  email: z.string().email().optional().or(z.literal('')),
+});
+
+const AssinaturaCreate = z.object({
+  cliente_id: z.string().uuid().optional(),
+  documento: z.string().min(8).optional(),
+  plano: z.enum(['ESSENCIAL', 'PLATINUM', 'BLACK']),
+  forma_pagamento: z.enum(['PIX', 'CREDITO', 'DEBITO', 'DINHEIRO', 'BOLETO']),
+  valor: z.union([z.string(), z.number()]),
+  vencimento: z.string().optional(),
+});
+
+module.exports = { ClienteCreate, AssinaturaCreate };

--- a/src/utils/currency.js
+++ b/src/utils/currency.js
@@ -1,0 +1,11 @@
+function parseBRL(input) {
+  const s = String(input ?? '').trim();
+  if (!s) return 0;
+  const n = Number(s.replace(/\./g, '').replace(',', '.'));
+  if (Number.isNaN(n)) throw new Error('Valor inválido');
+  return n;
+}
+
+const toCents = (v) => Math.round(parseBRL(v) * 100);
+
+module.exports = { parseBRL, toCents };


### PR DESCRIPTION
## Summary
- add currency parsing util for BRL values
- protect new admin endpoints with PIN middleware
- create client and subscription routes plus static signup form

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c4b1d3f44832b88034d2fa3dd102c