### PR TITLE
Add static Netlify frontend and adjust CORS handling

### DIFF
--- a/frontend/_redirects
+++ b/frontend/_redirects
@@ -1,0 +1,2 @@
+/api/*  https://SEU-APP-RAILWAY.up.railway.app/:splat  200
+

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Cadastro - Clube de Vantagens</title>
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body>
+  <main class="card">
+    <h1>Novo Cadastro</h1>
+    <form id="f" onsubmit="cadastrar(event)">
+      <section>
+        <label>PIN (admin)</label>
+        <input name="pin" type="password" required />
+      </section>
+
+      <h2>Dados do cliente</h2>
+      <section class="grid">
+        <label>Nome <input name="nome" required /></label>
+        <label>Documento <input name="documento" required /></label>
+        <label>Telefone <input name="telefone" required /></label>
+        <label>E-mail <input name="email" type="email" /></label>
+      </section>
+
+      <h2>Assinatura</h2>
+      <section class="grid">
+        <label>Plano
+          <select name="plano" required>
+            <option value="ESSENCIAL">Essencial</option>
+            <option value="PLATINUM">Platinum</option>
+            <option value="BLACK">Black</option>
+          </select>
+        </label>
+        <label>Forma de pagamento
+          <select name="forma_pagamento" required>
+            <option>PIX</option><option>CREDITO</option>
+            <option>DEBITO</option><option>DINHEIRO</option>
+            <option>BOLETO</option>
+          </select>
+        </label>
+        <label>Valor (ex: 49,90) <input name="valor" required /></label>
+        <label>Vencimento <input name="vencimento" type="date" /></label>
+      </section>
+
+      <button type="submit">Cadastrar</button>
+      <p id="msg"></p>
+    </form>
+  </main>
+
+  <script>
+  const API = '/api'; // proxy via Netlify _redirects
+
+  async function cadastrar(e){
+    e.preventDefault();
+    const f = e.target;
+    const msg = document.getElementById('msg');
+    msg.textContent = 'Enviando...';
+
+    const pin = f.pin.value;
+
+    // 1) cliente
+    const cRes = await fetch(`${API}/admin/clientes`, {
+      method:'POST',
+      headers:{'Content-Type':'application/json','x-admin-pin': pin},
+      body: JSON.stringify({
+        nome: f.nome.value, documento: f.documento.value,
+        telefone: f.telefone.value, email: f.email.value
+      })
+    });
+    const cliente = await cRes.json();
+    if(!cRes.ok){ msg.textContent = 'Erro cliente: '+(cliente?.error||cRes.status); return; }
+
+    // 2) assinatura
+    const aRes = await fetch(`${API}/admin/assinatura`, {
+      method:'POST',
+      headers:{'Content-Type':'application/json','x-admin-pin': pin},
+      body: JSON.stringify({
+        cliente_id: cliente.id,
+        plano: f.plano.value,
+        forma_pagamento: f.forma_pagamento.value,
+        valor: f.valor.value,
+        vencimento: f.vencimento.value
+      })
+    });
+    const ass = await aRes.json();
+    if(!aRes.ok){ msg.textContent = 'Erro assinatura: '+(ass?.error||aRes.status); return; }
+
+    msg.textContent = `Cadastro OK! Cliente ${cliente.nome} — transação #${ass.id}`;
+    f.reset();
+  }
+  </script>
+</body>
+</html>
+

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,12 @@
+:root{font-family:system-ui,Segoe UI,Roboto,Inter,Arial,sans-serif}
+body{margin:0;display:grid;place-items:center;min-height:100svh;background:#0b1220;color:#eef2ff}
+.card{background:#121a2b;padding:24px;max-width:860px;width:100%;border-radius:18px;box-shadow:0 10px 30px #0008}
+h1,h2{margin:8px 0 12px}
+form section{margin:10px 0}
+.grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}
+label{display:flex;flex-direction:column;font-size:14px;gap:6px}
+input,select,button{padding:10px;border-radius:10px;border:1px solid #28324a;background:#0e1626;color:#e6eaff}
+button{cursor:pointer;margin-top:8px}
+#msg{margin-top:10px;font-size:14px}
+@media (max-width:720px){.grid{grid-template-columns:1fr}}
+

--- a/server.js
+++ b/server.js
@@ -37,14 +37,21 @@ const PORT = process.env.PORT || 3000;
 app.use(helmet({ crossOriginResourcePolicy: false }));
 
 // --- CORS dinâmico ---
-const allowed = process.env.ALLOWED_ORIGIN; // ex: "https://seu-site.netlify.app,http://localhost:8888"
-app.use(cors({
-  origin: (origin, cb) => {
-    if (!origin) return cb(null, true);
-    if (allowed && allowed.split(',').some(o => origin.startsWith(o.trim()))) return cb(null, true);
-    return cb(new Error('CORS blocked'), false);
-  }
-}));
+// ex: process.env.ALLOWED_ORIGIN = "https://seu-site.netlify.app,http://localhost:8888"
+const whitelist = (process.env.ALLOWED_ORIGIN || '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+app.use(
+  cors({
+    origin(origin, cb) {
+      if (!origin || whitelist.includes(origin)) return cb(null, true);
+      return cb(new Error('Not allowed by CORS'));
+    },
+    credentials: true,
+  }),
+);
 
 // garante resposta ao preflight
 app.options('*', cors());


### PR DESCRIPTION
## Summary
- add static signup page with Netlify proxy and styles
- tighten CORS whitelist based on `ALLOWED_ORIGIN`

## Testing
- `npm test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689c4e6b6f24832b9cad608a3ab14788