### PR TITLE
feat: add admin endpoints and BRL utils

### DIFF
--- a/docs/sql/create_tables.sql
+++ b/docs/sql/create_tables.sql
@@ -1,0 +1,22 @@
+-- Tabelas básicas (apenas se não existirem)
+create table if not exists public.clientes (
+  id uuid primary key default gen_random_uuid(),
+  nome text not null,
+  documento text unique not null,
+  telefone text not null,
+  email text,
+  created_at timestamp with time zone default now()
+);
+
+create table if not exists public.transacoes (
+  id uuid primary key default gen_random_uuid(),
+  cliente_id uuid references public.clientes(id) on delete cascade,
+  plano text not null,
+  forma_pagamento text not null,
+  valor_original integer not null,      -- centavos
+  desconto_aplicado integer not null,   -- centavos
+  valor_final integer not null,         -- centavos
+  status_pagamento text not null,       -- pendente|pago|cancelado
+  vencimento date,
+  created_at timestamp with time zone default now()
+);

--- a/server.js
+++ b/server.js
@@ -37,14 +37,19 @@ const PORT = process.env.PORT || 3000;
 app.use(helmet({ crossOriginResourcePolicy: false }));
 
 // --- CORS dinâmico ---
-const allowed = process.env.ALLOWED_ORIGIN; // ex: "https://seu-site.netlify.app,http://localhost:8888"
-app.use(cors({
-  origin: (origin, cb) => {
-    if (!origin) return cb(null, true);
-    if (allowed && allowed.split(',').some(o => origin.startsWith(o.trim()))) return cb(null, true);
-    return cb(new Error('CORS blocked'), false);
-  }
-}));
+const whitelist = (process.env.ALLOWED_ORIGIN || '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+app.use(
+  cors({
+    origin(origin, cb) {
+      if (!origin || whitelist.includes(origin)) return cb(null, true);
+      return cb(new Error('Not allowed by CORS'));
+    },
+    credentials: true,
+  })
+);
 
 // garante resposta ao preflight
 app.options('*', cors());

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -2,20 +2,28 @@ const express = require('express');
 const supabase = require('../lib/supabase');
 const { requireAdminPin } = require('../middlewares/adminPin');
 const { ClienteCreate, AssinaturaCreate } = require('../schemas/admin');
-const { toCents } = require('../utils/currency');
+const { toCents, fromCents } = require('../utils/currency');
 
 const router = express.Router();
 
 router.post('/clientes', requireAdminPin, async (req, res) => {
   try {
-    const data = ClienteCreate.parse(req.body);
-    const { data: cli, error } = await supabase
+    const payload = ClienteCreate.parse(req.body);
+    const { data: exists, error: exErr } = await supabase
       .from('clientes')
-      .insert(data)
+      .select('id')
+      .eq('documento', payload.documento)
+      .maybeSingle();
+    if (exErr) throw exErr;
+    if (exists) return res.status(409).json({ error: 'Cliente já existe' });
+
+    const { data, error } = await supabase
+      .from('clientes')
+      .insert(payload)
       .select()
       .single();
     if (error) throw error;
-    res.json(cli);
+    res.json(data);
   } catch (e) {
     res.status(400).json({ error: e.message });
   }
@@ -23,37 +31,46 @@ router.post('/clientes', requireAdminPin, async (req, res) => {
 
 router.post('/assinatura', requireAdminPin, async (req, res) => {
   try {
-    const payload = AssinaturaCreate.parse(req.body);
-    let cliente_id = payload.cliente_id;
-    if (!cliente_id && payload.documento) {
+    const p = AssinaturaCreate.parse(req.body);
+
+    let cliente_id = p.cliente_id;
+    if (!cliente_id && p.documento) {
       const { data: cli, error } = await supabase
         .from('clientes')
         .select('id')
-        .eq('documento', payload.documento)
+        .eq('documento', p.documento)
         .maybeSingle();
       if (error) throw error;
-      if (!cli) throw new Error('Cliente não encontrado pelo documento');
+      if (!cli) return res.status(404).json({ error: 'Cliente não encontrado' });
       cliente_id = cli.id;
     }
-    if (!cliente_id) throw new Error('Informe cliente_id ou documento');
-    const valor_original = toCents(payload.valor);
+    if (!cliente_id)
+      return res.status(400).json({ error: 'Informe cliente_id ou documento' });
+
+    const valor_original = toCents(p.valor);
     const insert = {
       cliente_id,
-      plano: payload.plano,
-      forma_pagamento: payload.forma_pagamento,
+      plano: p.plano,
+      forma_pagamento: p.forma_pagamento,
       valor_original,
       desconto_aplicado: 0,
       valor_final: valor_original,
       status_pagamento: 'pendente',
-      vencimento: payload.vencimento ?? null,
+      vencimento: p.vencimento ?? null,
     };
-    const { data: trx, error } = await supabase
+
+    const { data: trx, error: insErr } = await supabase
       .from('transacoes')
       .insert(insert)
       .select()
       .single();
-    if (error) throw error;
-    res.json(trx);
+    if (insErr) throw insErr;
+
+    res.json({
+      ...trx,
+      valor_original_reais: fromCents(trx.valor_original),
+      valor_final_reais: fromCents(trx.valor_final),
+    });
   } catch (e) {
     res.status(400).json({ error: e.message });
   }

--- a/src/utils/currency.js
+++ b/src/utils/currency.js
@@ -8,4 +8,6 @@ function parseBRL(input) {
 
 const toCents = (v) => Math.round(parseBRL(v) * 100);
 
-module.exports = { parseBRL, toCents };
+const fromCents = (c) => Number(c || 0) / 100;
+
+module.exports = { parseBRL, toCents, fromCents };


### PR DESCRIPTION
## Summary
- handle dynamic CORS using environment whitelist
- add BRL currency helpers and expose fromCents
- support admin client and subscription routes with validation and cent values
- document SQL schema for clients and transactions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c5b88bdb8832bb9a2cb9e578e467d