### PR TITLE
refactor: convert currency utils to esm

### DIFF
--- a/src/utils/currency.js
+++ b/src/utils/currency.js
@@ -7,5 +7,6 @@ function parseBRL(input) {
 }
 
 const toCents = (v) => Math.round(parseBRL(v) * 100);
+const fromCents = (c) => Number(c || 0) / 100;
 
-module.exports = { parseBRL, toCents };
+export { parseBRL, toCents, fromCents };


### PR DESCRIPTION
## Summary
- refactor currency helpers to use ESM exports
- add fromCents utility for converting cents to BRL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c622a5f50832bbaf1b81a3a407bd3