### PR TITLE
refactor: use esm for admin pin middleware

### DIFF
--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,3 +1,3 @@
-const supabase = require('../../supabaseClient');
+import supabase from '../../supabaseClient.js';
 
-module.exports = supabase;
+export default supabase;

--- a/src/middlewares/adminPin.js
+++ b/src/middlewares/adminPin.js
@@ -1,9 +1,7 @@
-function requireAdminPin(req, res, next) {
+export function requireAdminPin(req, res, next) {
   const pin = req.get('x-admin-pin') || req.query.pin;
   if (!pin || pin !== process.env.ADMIN_PIN) {
     return res.status(401).json({ error: 'PIN inválido' });
   }
   next();
 }
-
-module.exports = { requireAdminPin };

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -1,8 +1,8 @@
-const express = require('express');
-const supabase = require('../lib/supabase');
-const { requireAdminPin } = require('../middlewares/adminPin');
-const { ClienteCreate, AssinaturaCreate } = require('../schemas/admin');
-const { toCents } = require('../utils/currency');
+import express from 'express';
+import supabase from '../lib/supabase.js';
+import { requireAdminPin } from '../middlewares/adminPin.js';
+import { ClienteCreate, AssinaturaCreate } from '../schemas/admin.js';
+import { toCents } from '../utils/currency.js';
 
 const router = express.Router();
 
@@ -59,4 +59,4 @@ router.post('/assinatura', requireAdminPin, async (req, res) => {
   }
 });
 
-module.exports = router;
+export default router;

--- a/src/schemas/admin.js
+++ b/src/schemas/admin.js
@@ -1,13 +1,13 @@
-const { z } = require('zod');
+import { z } from 'zod';
 
-const ClienteCreate = z.object({
+export const ClienteCreate = z.object({
   nome: z.string().min(2),
   documento: z.string().min(8),
   telefone: z.string().min(8),
   email: z.string().email().optional().or(z.literal('')),
 });
 
-const AssinaturaCreate = z.object({
+export const AssinaturaCreate = z.object({
   cliente_id: z.string().uuid().optional(),
   documento: z.string().min(8).optional(),
   plano: z.enum(['ESSENCIAL', 'PLATINUM', 'BLACK']),
@@ -15,5 +15,3 @@ const AssinaturaCreate = z.object({
   valor: z.union([z.string(), z.number()]),
   vencimento: z.string().optional(),
 });
-
-module.exports = { ClienteCreate, AssinaturaCreate };


### PR DESCRIPTION
## Summary
- convert admin PIN middleware to ESM export
- update admin routes and related modules to ESM imports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c6318cc54832b804df0954f9461dc