### PR TITLE
Refactor Supabase imports and improve ping script

### DIFF
--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -1,5 +1,5 @@
 const supabase = require('../supabaseClient');
-const { assertSupabase } = require('../supabaseClient');
+const { assertSupabase } = supabase;
 const generateClientIds = require('../utils/generateClientIds');
 
 function sanitizeCpf(s = '') {

--- a/controllers/assinaturaController.js
+++ b/controllers/assinaturaController.js
@@ -1,5 +1,5 @@
 const supabase = require('../supabaseClient');
-const { assertSupabase } = require('../supabaseClient');
+const { assertSupabase } = supabase;
 
 exports.consultarPorIdentificador = async (req, res, next) => {
   if (!assertSupabase(res)) return;

--- a/controllers/clientesController.js
+++ b/controllers/clientesController.js
@@ -1,5 +1,5 @@
 const supabase = require('../supabaseClient');
-const { assertSupabase } = require('../supabaseClient');
+const { assertSupabase } = supabase;
 const generateClientIds = require('../utils/generateClientIds');
 
 function sanitizeCpf(s = '') {

--- a/controllers/leadController.js
+++ b/controllers/leadController.js
@@ -1,5 +1,5 @@
 const supabase = require('../supabaseClient');
-const { assertSupabase } = require('../supabaseClient');
+const { assertSupabase } = supabase;
 const PLANOS = new Set(['Mensal', 'Semestral', 'Anual']);
 const onlyDigits = s => (String(s||'').match(/\d/g) || []).join('');
 function isEmail(s){ return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(s||'')); }

--- a/controllers/metricsController.js
+++ b/controllers/metricsController.js
@@ -1,5 +1,5 @@
 const supabase = require('../supabaseClient');
-const { assertSupabase } = require('../supabaseClient');
+const { assertSupabase } = supabase;
 const { periodFromQuery, iso, aggregate } = require('../services/transacoesMetrics');
 
 exports.resume = async (req, res, next) => {

--- a/controllers/reportController.js
+++ b/controllers/reportController.js
@@ -1,5 +1,5 @@
 const supabase = require('../supabaseClient');
-const { assertSupabase } = require('../supabaseClient');
+const { assertSupabase } = supabase;
 const { periodFromQuery, iso, aggregate } = require('../services/transacoesMetrics');
 
 exports.resumo = async (req, res, next) => {

--- a/controllers/statusController.js
+++ b/controllers/statusController.js
@@ -1,5 +1,5 @@
 const supabase = require('../supabaseClient');
-const { assertSupabase } = require('../supabaseClient');
+const { assertSupabase } = supabase;
 
 exports.info = async (req, res) => {
   res.json({

--- a/tests/ping.js
+++ b/tests/ping.js
@@ -1,5 +1,10 @@
 const supabase = require('../supabaseClient');
+
 (async () => {
+  if (typeof supabase.from !== 'function') {
+    console.error('Supabase não configurado');
+    process.exit(1);
+  }
   const { data, error } = await supabase.from('clientes').select('id').limit(1);
   if (error) {
     console.error('Erro Supabase:', error.message);


### PR DESCRIPTION
## Summary
- reuse the supabase client once per controller and destructure assertSupabase
- handle missing Supabase configuration in ping script

## Testing
- `npm test`
- `npm run test:api` *(fails: Supabase não configurado)*

------
https://chatgpt.com/codex/tasks/task_e_689c6cb2b5b8832b9fc46235a24dfb8e