### PR TITLE
feat: add static frontend for netlify

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,17 +1,5 @@
-body {
-  font-family: Arial, sans-serif;
-  margin: 2rem;
-  line-height: 1.5;
-}
-
-nav a {
-  color: #0077cc;
-  text-decoration: none;
-}
-
-form {
-  display: flex;
-  flex-direction: column;
-  max-width: 400px;
-  gap: 0.5rem;
-}
+body { font-family: system-ui, Arial, sans-serif; max-width: 720px; margin: 24px auto; padding: 0 16px; }
+h1 { margin-bottom: 16px; }
+form { display: grid; gap: 8px; max-width: 420px; }
+input, button { padding: 10px; font-size: 16px; }
+pre { background: #f6f6f6; padding: 12px; overflow: auto; }

--- a/frontend/testar-cadastro.html
+++ b/frontend/testar-cadastro.html
@@ -28,9 +28,7 @@
     async function toJSONSafe(res) {
       const text = await res.text();
       try { return JSON.parse(text); }
-      catch {
-        return { ok:false, error:'Resposta não JSON (provável HTML de erro/proxy)', raw: text.slice(0, 300) };
-      }
+      catch { return { ok:false, error:'Resposta não JSON (provável HTML de erro/proxy)', raw: text.slice(0, 300) }; }
     }
 
     $('#form').addEventListener('submit', async (e) => {
@@ -45,24 +43,16 @@
       const pin = $('#pin').value.trim();
 
       try {
-        // cria cliente
         const r1 = await fetch(`${API_BASE}/admin/clientes`, {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'x-admin-pin': pin
-          },
+          headers: { 'Content-Type': 'application/json', 'x-admin-pin': pin },
           body: JSON.stringify(body)
         });
         const j1 = await toJSONSafe(r1);
         out.textContent = 'Resultado /admin/clientes:\n' + JSON.stringify(j1, null, 2);
 
-        // (opcional) criar assinatura se sua API já estiver pronta:
-        // const r2 = await fetch(`${API_BASE}/admin/assinatura`, {
-        //   method: 'POST',
-        //   headers: { 'Content-Type': 'application/json', 'x-admin-pin': pin },
-        //   body: JSON.stringify({ email: body.email, plano: 'basico' })
-        // });
+        // opcional: assinatura
+        // const r2 = await fetch(`${API_BASE}/admin/assinatura`, { method:'POST', headers:{ 'Content-Type':'application/json', 'x-admin-pin': pin }, body: JSON.stringify({ email: body.email, plano: 'basico' }) });
         // const j2 = await toJSONSafe(r2);
         // out.textContent += '\n\nResultado /admin/assinatura:\n' + JSON.stringify(j2, null, 2);
 
@@ -73,4 +63,3 @@
   </script>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
- add simple static styles
- add registration test page pointing to API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c9df11168832b987485762160bc4d