### PR TITLE
feat: add responsive cadastro tester and CORS whitelist

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,10 +7,14 @@
   <link rel="stylesheet" href="/styles.css" />
 </head>
 <body>
-  <h1>Clube de Vantagens</h1>
-  <p>Bem-vindo ao protótipo do frontend.</p>
-  <nav>
-    <a href="/testar-cadastro.html">Testar cadastro</a>
-  </nav>
+  <div class="container">
+    <div class="card">
+      <h1>Clube de Vantagens</h1>
+      <p class="sub">Protótipo do frontend.</p>
+      <div class="actions">
+        <a href="/testar-cadastro.html"><button class="secondary">Testar cadastro</button></a>
+      </div>
+    </div>
+  </div>
 </body>
 </html>

--- a/frontend/settings.js
+++ b/frontend/settings.js
@@ -1,1 +1,2 @@
-export const API_BASE = "/api";
+// Usa o proxy do Netlify: /api → Railway
+export const API_BASE = '/api';

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,5 +1,57 @@
-body { font-family: system-ui, Arial, sans-serif; max-width: 720px; margin: 24px auto; padding: 0 16px; }
-h1 { margin-bottom: 16px; }
-form { display: grid; gap: 8px; max-width: 420px; }
-input, button { padding: 10px; font-size: 16px; }
-pre { background: #f6f6f6; padding: 12px; overflow: auto; }
+:root{
+  --bg:#0b0c10; --panel:#121317; --text:#e5e7eb; --muted:#a5adb8;
+  --primary:#4f46e5; --primary-2:#4338ca; --success:#10b981; --danger:#ef4444;
+  --border:#1f2430;
+}
+*{box-sizing:border-box}
+html,body{height:100%}
+body{
+  margin:0; font-family:Inter,system-ui,Arial,sans-serif; color:var(--text);
+  background:linear-gradient(180deg, #0b0c10 0%, #0f1115 100%);
+}
+.container{
+  max-width:880px; margin:48px auto; padding:0 20px;
+}
+.card{
+  background:var(--panel); border:1px solid var(--border); border-radius:16px;
+  padding:24px; box-shadow:0 10px 30px rgb(0 0 0 / .35);
+}
+h1{font-size:clamp(24px,3.5vw,34px); margin:0 0 12px}
+p.sub{color:var(--muted); margin:0 0 24px}
+form{display:grid; gap:12px; grid-template-columns:1fr 1fr}
+form .full{grid-column:1 / -1}
+label{display:block; font-size:14px; color:var(--muted); margin:2px 0 6px}
+input{
+  width:100%; padding:12px 14px; border-radius:12px; border:1px solid var(--border);
+  background:#0e1014; color:var(--text); outline:none; transition:border .15s;
+}
+input:focus{border-color:#2c3342}
+.actions{display:flex; gap:12px; align-items:center}
+button{
+  padding:12px 16px; border:0; border-radius:12px; color:#fff; cursor:pointer;
+  background:var(--primary); transition:transform .06s, background .2s;
+}
+button:hover{background:var(--primary-2)}
+button:active{transform:translateY(1px)}
+button.secondary{background:#2a2f3a}
+.badge{
+  font-size:12px; padding:4px 8px; border-radius:999px; border:1px solid var(--border);
+  color:var(--muted); background:#0e1014;
+}
+pre{
+  margin:16px 0 0; padding:16px; border-radius:12px; background:#0b0f16;
+  border:1px solid var(--border); overflow:auto; max-height:40vh;
+  font-size:13px; line-height:1.45;
+}
+.toast{
+  display:none; position:fixed; inset:auto 16px 16px auto; padding:12px 14px;
+  border-radius:12px; border:1px solid var(--border); background:#0e1014;
+  box-shadow:0 10px 30px rgb(0 0 0 / .35); color:var(--text);
+}
+.toast.show{display:block; animation:fade .2s ease-out}
+.toast.ok{border-color:#134e4a; color:#34d399}
+.toast.err{border-color:#4c1d1d; color:#fca5a5}
+@keyframes fade{from{opacity:.0; transform:translateY(6px)} to{opacity:1; transform:none}}
+@media (max-width:720px){
+  form{grid-template-columns:1fr}
+}

--- a/frontend/testar-cadastro.html
+++ b/frontend/testar-cadastro.html
@@ -2,39 +2,75 @@
 <html lang="pt-BR">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Testar Cadastro</title>
-  <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="/styles.css"/>
 </head>
 <body>
-  <h1>Testar Cadastro</h1>
+  <div class="container">
+    <div class="card">
+      <h1>Testar Cadastro</h1>
+      <p class="sub">Crie um cliente via API. Use o <span class="badge">x-admin-pin</span> para autenticar.</p>
 
-  <form id="form">
-    <input id="nome" placeholder="Nome" required />
-    <input id="email" type="email" placeholder="Email" required />
-    <input id="telefone" placeholder="Telefone" required />
-    <input id="pin" placeholder="Admin PIN" required />
-    <button type="submit">Enviar</button>
-  </form>
+      <form id="form">
+        <div class="full">
+          <label for="nome">Nome</label>
+          <input id="nome" placeholder="Ex: Ana Silva" required />
+        </div>
+        <div>
+          <label for="email">Email</label>
+          <input id="email" type="email" placeholder="ana@exemplo.com" required />
+        </div>
+        <div>
+          <label for="telefone">Telefone</label>
+          <input id="telefone" placeholder="DDD + número" required />
+        </div>
+        <div class="full">
+          <label for="pin">Admin PIN</label>
+          <input id="pin" placeholder="PIN de administrador" required />
+        </div>
+        <div class="actions full">
+          <button id="btn" type="submit">Enviar</button>
+          <span id="hint" class="badge">Aguardando</span>
+        </div>
+      </form>
 
-  <pre id="resultado"></pre>
+      <pre id="saida">Sem resultados ainda…</pre>
+    </div>
+  </div>
+
+  <div id="toast" class="toast"></div>
 
   <script type="module">
     import { API_BASE } from './settings.js';
 
     const $ = (s) => document.querySelector(s);
-    const out = $('#resultado');
+    const btn = $('#btn');
+    const hint = $('#hint');
+    const saida = $('#saida');
+    const toast = $('#toast');
 
-    async function toJSONSafe(res) {
-      const text = await res.text();
-      try { return JSON.parse(text); }
-      catch { return { ok:false, error:'Resposta não JSON (provável HTML de erro/proxy)', raw: text.slice(0, 300) }; }
+    function showToast(msg, ok=true){
+      toast.textContent = msg;
+      toast.className = 'toast show ' + (ok ? 'ok' : 'err');
+      setTimeout(()=> toast.className='toast', 2500);
     }
 
-    $('#form').addEventListener('submit', async (e) => {
-      e.preventDefault();
-      out.textContent = 'Enviando...';
+    async function toJSONSafe(res){
+      const text = await res.text();
+      try { return { data: JSON.parse(text), status: res.status }; }
+      catch { return { data: { ok:false, error:'Resposta não JSON', raw:text.slice(0,300) }, status: res.status }; }
+    }
 
+    function lockUI(lock=true){
+      btn.disabled = lock;
+      btn.textContent = lock ? 'Enviando…' : 'Enviar';
+      hint.textContent = lock ? 'Processando' : 'Aguardando';
+    }
+
+    $('#form').addEventListener('submit', async (e)=>{
+      e.preventDefault();
+      lockUI(true); saida.textContent = '…';
       const body = {
         nome: $('#nome').value.trim(),
         email: $('#email').value.trim(),
@@ -42,23 +78,28 @@
       };
       const pin = $('#pin').value.trim();
 
-      try {
-        const r1 = await fetch(`${API_BASE}/admin/clientes`, {
+      // validação simples
+      if(!body.nome || !body.email || !body.telefone || !pin){
+        showToast('Preencha todos os campos', false);
+        lockUI(false); return;
+      }
+
+      try{
+        const r = await fetch(`${API_BASE}/admin/clientes`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'x-admin-pin': pin },
+          headers: { 'Content-Type':'application/json', 'x-admin-pin': pin },
           body: JSON.stringify(body)
         });
-        const j1 = await toJSONSafe(r1);
-        out.textContent = 'Resultado /admin/clientes:\n' + JSON.stringify(j1, null, 2);
+        const j = await toJSONSafe(r);
 
-        // opcional: assinatura
-        // const r2 = await fetch(`${API_BASE}/admin/assinatura`, { method:'POST', headers:{ 'Content-Type':'application/json', 'x-admin-pin': pin }, body: JSON.stringify({ email: body.email, plano: 'basico' }) });
-        // const j2 = await toJSONSafe(r2);
-        // out.textContent += '\n\nResultado /admin/assinatura:\n' + JSON.stringify(j2, null, 2);
+        saida.textContent = JSON.stringify(j.data, null, 2);
+        if(r.ok) showToast('Cliente criado com sucesso!'); else showToast('Falha ao criar cliente', false);
 
-      } catch (err) {
-        out.textContent = 'Erro de rede: ' + err.message;
+      }catch(err){
+        showToast('Erro de rede: '+ err.message, false);
+        saida.textContent = JSON.stringify({ ok:false, error: err.message }, null, 2);
       }
+      finally{ lockUI(false); }
     });
   </script>
 </body>

--- a/server.js
+++ b/server.js
@@ -37,18 +37,20 @@ async function start() {
   // --- Segurança ---
   app.use(helmet({ crossOriginResourcePolicy: false }));
 
-  // --- CORS dinâmico ---
-  const allowedOrigins = (process.env.ALLOWED_ORIGIN || '')
-    .split(',')
-    .map(o => o.trim())
-    .filter(Boolean); // ex: ["https://seu-site.netlify.app","http://localhost:8888"]
+  // --- CORS com whitelist ---
+  const whitelist = [
+    'http://localhost:8888',
+    'https://<SEU-SITE>.netlify.app'
+  ];
 
   app.use(cors({
     origin: (origin, cb) => {
-      if (!origin) return cb(null, true);
-      if (allowedOrigins.includes(origin)) return cb(null, true);
-      return cb(new Error('CORS blocked'), false);
-    }
+      if (!origin || whitelist.includes(origin)) return cb(null, true);
+      cb(new Error('CORS not allowed'));
+    },
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'x-admin-pin'],
+    credentials: false
   }));
 
   // garante resposta ao preflight


### PR DESCRIPTION
## Summary
- add responsive Testar Cadastro page using `/api` proxy and toast-based feedback
- streamline frontend layout and shared styles
- enforce CORS whitelist for localhost and Netlify domain

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ca3036fb8832b9364523c6ef8e63d