### PR TITLE
feat: add layered clientes feature with validation and duplicate check

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "jest tests",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js tests",
     "test:api": "node ./tests/ping.js",
     "vercel:prepare": "node scripts/patch-vercel.js",
     "build:meta": "echo \"ok\"",

--- a/server.js
+++ b/server.js
@@ -14,6 +14,7 @@ async function start() {
   const lead = require('./controllers/leadController');
   const clientes = require('./controllers/clientesController');
   const { requireAdminPin } = await import('./src/middlewares/adminPin.js');
+  const clienteRoutes = (await import('./src/features/clientes/cliente.routes.js')).default;
   const errorHandler = require('./middlewares/errorHandler');
   const adminRoutes = require('./src/routes/admin');
   const hasMpEnv = process.env.MP_ACCESS_TOKEN && process.env.MP_COLLECTOR_ID && process.env.MP_WEBHOOK_SECRET;
@@ -89,6 +90,7 @@ async function start() {
   app.post('/admin/clientes/bulk', requireAdminPin, adminController.bulkClientes);
   app.delete('/admin/clientes/:cpf', requireAdminPin, clientes.remove);
   app.post('/admin/clientes/generate-ids', requireAdminPin, clientes.generateIds);
+  app.use('/admin/clientes', requireAdminPin, clienteRoutes);
   app.get('/admin/relatorios/resumo', requireAdminPin, report.resumo);
   app.get('/admin/relatorios/transacoes.csv', requireAdminPin, report.csv);
   app.get('/admin/metrics', requireAdminPin, metrics.resume);

--- a/src/features/clientes/cliente.controller.js
+++ b/src/features/clientes/cliente.controller.js
@@ -1,0 +1,17 @@
+import * as service from './cliente.service.js';
+import supabase from '../../../supabaseClient.js';
+
+const META = { version: 'v0.1.0' };
+
+export async function create(req, res) {
+  if (supabase.assertSupabase && !supabase.assertSupabase(res)) return;
+  try {
+    const cliente = await service.createCliente(req.body);
+    res.status(201).json({ ok: true, data: cliente, meta: META });
+  } catch (err) {
+    const status = err.status || 500;
+    res.status(status).json({ ok: false, error: err.message, code: err.code });
+  }
+}
+
+export default { create };

--- a/src/features/clientes/cliente.repo.js
+++ b/src/features/clientes/cliente.repo.js
@@ -1,0 +1,23 @@
+import supabase from '../../../supabaseClient.js';
+
+export async function findByEmail(email) {
+  const { data, error } = await supabase
+    .from('clientes')
+    .select('id')
+    .eq('email', email)
+    .maybeSingle();
+  if (error) throw error;
+  return data;
+}
+
+export async function create(cliente) {
+  const { data, error } = await supabase
+    .from('clientes')
+    .insert(cliente)
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+export default { findByEmail, create };

--- a/src/features/clientes/cliente.routes.js
+++ b/src/features/clientes/cliente.routes.js
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { create } from './cliente.controller.js';
+
+const router = Router();
+
+router.post('/', create);
+
+export default router;

--- a/src/features/clientes/cliente.schema.js
+++ b/src/features/clientes/cliente.schema.js
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+// Schema for cliente creation
+export const clienteSchema = z.object({
+  nome: z.string().min(1, 'nome obrigatório'),
+  email: z.string().email('email inválido'),
+  telefone: z
+    .string()
+    .min(1, 'telefone obrigatório')
+    .transform((val) => val.replace(/\D/g, '')),
+});
+
+export default clienteSchema;

--- a/src/features/clientes/cliente.service.js
+++ b/src/features/clientes/cliente.service.js
@@ -1,0 +1,19 @@
+import { clienteSchema } from './cliente.schema.js';
+import * as repo from './cliente.repo.js';
+
+export async function createCliente(payload) {
+  const data = clienteSchema.parse(payload);
+
+  const existing = await repo.findByEmail(data.email);
+  if (existing) {
+    const err = new Error('Email já cadastrado');
+    err.code = 'DUPLICATE_EMAIL';
+    err.status = 409;
+    throw err;
+  }
+
+  const created = await repo.create(data);
+  return created;
+}
+
+export default { createCliente };

--- a/tests/cliente-test-server.js
+++ b/tests/cliente-test-server.js
@@ -1,0 +1,25 @@
+const express = require('express');
+
+(async () => {
+  const routes = (await import('../src/features/clientes/cliente.routes.js')).default;
+  const repo = await import('../src/features/clientes/cliente.repo.js');
+
+  const scenario = process.env.SCENARIO;
+  if (scenario === 'duplicate') {
+    repo.findByEmail = async () => ({ id: 1 });
+    repo.create = async () => { throw new Error('should not'); };
+  } else {
+    // default success behaviour
+    repo.findByEmail = async () => null;
+    repo.create = async (c) => ({ id: 1, ...c });
+  }
+
+  const { requireAdminPin } = await import('../src/middlewares/adminPin.js');
+
+  const app = express();
+  app.use(express.json());
+  app.use('/admin/clientes', requireAdminPin, routes);
+
+  const port = process.env.PORT || 3456;
+  app.listen(port, () => console.log('ready'));
+})();

--- a/tests/clientes.routes.test.js
+++ b/tests/clientes.routes.test.js
@@ -1,0 +1,82 @@
+const request = require('supertest');
+const { spawn } = require('child_process');
+
+function startServer(scenario, port) {
+  return new Promise((resolve) => {
+    const proc = spawn('node', ['tests/cliente-test-server.js'], {
+      env: {
+        ...process.env,
+        SCENARIO: scenario,
+        ADMIN_PIN: '1234',
+        PORT: port,
+        SUPABASE_URL: 'http://localhost',
+        SUPABASE_ANON: 'anon',
+      },
+    });
+    proc.stdout.on('data', (d) => {
+      if (d.toString().includes('ready')) resolve(proc);
+    });
+  });
+}
+
+function stopServer(proc) {
+  proc.kill();
+}
+
+function getPort() {
+  return 4000 + Math.floor(Math.random() * 500);
+}
+
+describe('POST /admin/clientes', () => {
+  test('cria cliente com sucesso', async () => {
+    const port = getPort();
+    const server = await startServer('success', port);
+    const agent = request(`http://localhost:${port}`);
+    const res = await agent
+      .post('/admin/clientes')
+      .set('x-admin-pin', '1234')
+      .send({ nome: 'Fulano', email: 'a@a.com', telefone: '(11)99999-8888' });
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({
+      ok: true,
+      data: {
+        id: 1,
+        nome: 'Fulano',
+        email: 'a@a.com',
+        telefone: '11999998888',
+      },
+      meta: { version: 'v0.1.0' },
+    });
+    stopServer(server);
+  });
+
+  test('retorna 400 para dados inválidos', async () => {
+    const port = getPort();
+    const server = await startServer('success', port);
+    const agent = request(`http://localhost:${port}`);
+    const res = await agent
+      .post('/admin/clientes')
+      .set('x-admin-pin', '1234')
+      .send({ nome: '', email: 'invalid', telefone: '' });
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    stopServer(server);
+  });
+
+  test('retorna 409 para email duplicado', async () => {
+    const port = getPort();
+    const server = await startServer('duplicate', port);
+    const agent = request(`http://localhost:${port}`);
+    const res = await agent
+      .post('/admin/clientes')
+      .set('x-admin-pin', '1234')
+      .send({ nome: 'Fulano', email: 'a@a.com', telefone: '11999998888' });
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({
+      ok: false,
+      error: 'Email já cadastrado',
+      code: 'DUPLICATE_EMAIL',
+    });
+    stopServer(server);
+  });
+});


### PR DESCRIPTION
## Summary
- add clientes feature with schema, repository, service, controller, and routes using ESM
- integrate clientes routes in server with admin PIN middleware
- add tests for POST /admin/clientes

## Testing
- `npm test` *(fails: POST /admin/clientes tests timeout or return 500)*

------
https://chatgpt.com/codex/tasks/task_e_689ca67c6848832ba0483bbd45a6a328