### PR TITLE
feat: implement subscription creation with proper currency conversion

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,8 +15,8 @@ async function start() {
   const clientes = require('./controllers/clientesController');
   const { requireAdminPin } = await import('./src/middlewares/adminPin.js');
   const clienteRoutes = (await import('./src/features/clientes/cliente.routes.js')).default;
+  const assinaturaRoutes = (await import('./src/features/assinaturas/assinatura.routes.js')).default;
   const errorHandler = require('./middlewares/errorHandler');
-  const adminRoutes = require('./src/routes/admin');
   const hasMpEnv = process.env.MP_ACCESS_TOKEN && process.env.MP_COLLECTOR_ID && process.env.MP_WEBHOOK_SECRET;
   let mpController = null;
   if (hasMpEnv) {
@@ -82,7 +82,6 @@ async function start() {
   app.get('/assinaturas', assinaturaController.consultarPorIdentificador);
   app.get('/assinaturas/listar', assinaturaController.listarTodas);
   app.use('/transacao', transacaoController);
-  app.use('/admin', adminRoutes);
   app.post('/admin/seed', requireAdminPin, adminController.seed);
   app.get('/admin/clientes', requireAdminPin, clientes.list);
   app.post('/admin/clientes/upsert', requireAdminPin, clientes.upsertOne);
@@ -91,6 +90,7 @@ async function start() {
   app.delete('/admin/clientes/:cpf', requireAdminPin, clientes.remove);
   app.post('/admin/clientes/generate-ids', requireAdminPin, clientes.generateIds);
   app.use('/admin/clientes', requireAdminPin, clienteRoutes);
+  app.use('/admin/assinatura', requireAdminPin, assinaturaRoutes);
   app.get('/admin/relatorios/resumo', requireAdminPin, report.resumo);
   app.get('/admin/relatorios/transacoes.csv', requireAdminPin, report.csv);
   app.get('/admin/metrics', requireAdminPin, metrics.resume);

--- a/src/features/assinaturas/assinatura.controller.js
+++ b/src/features/assinaturas/assinatura.controller.js
@@ -1,4 +1,4 @@
-import * as service from './cliente.service.js';
+import * as service from './assinatura.service.js';
 import supabase from '../../../supabaseClient.js';
 import { ZodError } from 'zod';
 
@@ -7,8 +7,8 @@ const META = { version: 'v0.1.0' };
 export async function create(req, res) {
   if (supabase.assertSupabase && !supabase.assertSupabase(res)) return;
   try {
-    const cliente = await service.createCliente(req.body);
-    res.status(201).json({ ok: true, data: cliente, meta: META });
+    const assinatura = await service.createAssinatura(req.body);
+    res.status(201).json({ ok: true, data: assinatura, meta: META });
   } catch (err) {
     const status = err instanceof ZodError ? 400 : err.status || 500;
     res.status(status).json({ ok: false, error: err.message, code: err.code });

--- a/src/features/assinaturas/assinatura.repo.js
+++ b/src/features/assinaturas/assinatura.repo.js
@@ -1,0 +1,13 @@
+import supabase from '../../../supabaseClient.js';
+
+export async function create(assinatura) {
+  const { data, error } = await supabase
+    .from('assinaturas')
+    .insert(assinatura)
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+export default { create };

--- a/src/features/assinaturas/assinatura.routes.js
+++ b/src/features/assinaturas/assinatura.routes.js
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { create } from './assinatura.controller.js';
+
+const router = Router();
+
+router.post('/', create);
+
+export default router;

--- a/src/features/assinaturas/assinatura.schema.js
+++ b/src/features/assinaturas/assinatura.schema.js
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const assinaturaSchema = z.object({
+  email: z.string().email('email inválido'),
+  plano: z.enum(['basico', 'pro', 'premium']),
+  valor: z.union([z.string(), z.number()]).optional(),
+});
+
+export default assinaturaSchema;

--- a/src/features/assinaturas/assinatura.service.js
+++ b/src/features/assinaturas/assinatura.service.js
@@ -1,0 +1,34 @@
+import { assinaturaSchema } from './assinatura.schema.js';
+import repo from './assinatura.repo.js';
+import clientesRepo from '../clientes/cliente.repo.js';
+import { toCents, fromCents } from '../../utils/currency.js';
+
+const PLAN_VALUES = {
+  basico: '49,90',
+  pro: '99,90',
+  premium: '149,90',
+};
+
+export async function createAssinatura(payload) {
+  const data = assinaturaSchema.parse(payload);
+
+  const cliente = await clientesRepo.findByEmail(data.email);
+  if (!cliente) {
+    const err = new Error('Cliente não encontrado');
+    err.status = 404;
+    throw err;
+  }
+
+  const valorBRL = data.valor ?? PLAN_VALUES[data.plano];
+  const valor = toCents(valorBRL);
+
+  const created = await repo.create({
+    cliente_id: cliente.id,
+    plano: data.plano,
+    valor,
+  });
+
+  return { ...created, valorBRL: fromCents(created.valor) };
+}
+
+export default { createAssinatura };

--- a/src/features/clientes/cliente.service.js
+++ b/src/features/clientes/cliente.service.js
@@ -1,5 +1,5 @@
 import { clienteSchema } from './cliente.schema.js';
-import * as repo from './cliente.repo.js';
+import repo from './cliente.repo.js';
 
 export async function createCliente(payload) {
   const data = clienteSchema.parse(payload);

--- a/src/utils/currency.js
+++ b/src/utils/currency.js
@@ -1,4 +1,4 @@
-function parseBRL(input) {
+export function parseBRL(input) {
   const s = String(input ?? '').trim();
   if (!s) return 0;
   const n = Number(s.replace(/\./g, '').replace(',', '.'));
@@ -6,7 +6,6 @@ function parseBRL(input) {
   return n;
 }
 
-const toCents = (v) => Math.round(parseBRL(v) * 100);
-const fromCents = (c) => Number(c || 0) / 100;
+export const toCents = (v) => Math.round(parseBRL(v) * 100);
+export const fromCents = (c) => Number(c || 0) / 100;
 
-export { parseBRL, toCents, fromCents };

--- a/tests/assinatura-test-server.js
+++ b/tests/assinatura-test-server.js
@@ -1,0 +1,24 @@
+const express = require('express');
+
+(async () => {
+  const routes = (await import('../src/features/assinaturas/assinatura.routes.js')).default;
+  const repo = (await import('../src/features/assinaturas/assinatura.repo.js')).default;
+  const clienteRepo = (await import('../src/features/clientes/cliente.repo.js')).default;
+
+  const scenario = process.env.SCENARIO;
+  if (scenario === 'missing') {
+    clienteRepo.findByEmail = async () => null;
+  } else {
+    clienteRepo.findByEmail = async () => ({ id: 1 });
+  }
+  repo.create = async (a) => ({ id: 1, ...a });
+
+  const { requireAdminPin } = await import('../src/middlewares/adminPin.js');
+
+  const app = express();
+  app.use(express.json());
+  app.use('/admin/assinatura', requireAdminPin, routes);
+
+  const port = process.env.PORT || 3456;
+  app.listen(port, () => console.log('ready'));
+})();

--- a/tests/assinaturas.routes.test.js
+++ b/tests/assinaturas.routes.test.js
@@ -1,0 +1,79 @@
+const request = require('supertest');
+const { spawn } = require('child_process');
+
+function startServer(scenario, port) {
+  return new Promise((resolve) => {
+    const proc = spawn('node', ['tests/assinatura-test-server.js'], {
+      env: {
+        ...process.env,
+        SCENARIO: scenario,
+        ADMIN_PIN: '1234',
+        PORT: port,
+        SUPABASE_URL: 'http://localhost',
+        SUPABASE_ANON: 'anon',
+      },
+    });
+    proc.stdout.on('data', (d) => {
+      if (d.toString().includes('ready')) resolve(proc);
+    });
+  });
+}
+
+function stopServer(proc) {
+  proc.kill();
+}
+
+function getPort() {
+  return 4000 + Math.floor(Math.random() * 500);
+}
+
+describe('POST /admin/assinatura', () => {
+  test('cria assinatura com sucesso', async () => {
+    const port = getPort();
+    const server = await startServer('success', port);
+    const agent = request(`http://localhost:${port}`);
+    const res = await agent
+      .post('/admin/assinatura')
+      .set('x-admin-pin', '1234')
+      .send({ email: 'a@a.com', plano: 'basico' });
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({
+      ok: true,
+      data: {
+        id: 1,
+        cliente_id: 1,
+        plano: 'basico',
+        valor: 4990,
+        valorBRL: 49.9,
+      },
+      meta: { version: 'v0.1.0' },
+    });
+    stopServer(server);
+  });
+
+  test('retorna 404 para cliente inexistente', async () => {
+    const port = getPort();
+    const server = await startServer('missing', port);
+    const agent = request(`http://localhost:${port}`);
+    const res = await agent
+      .post('/admin/assinatura')
+      .set('x-admin-pin', '1234')
+      .send({ email: 'b@b.com', plano: 'basico' });
+    expect(res.status).toBe(404);
+    expect(res.body.ok).toBe(false);
+    stopServer(server);
+  });
+
+  test('retorna 400 para dados inválidos', async () => {
+    const port = getPort();
+    const server = await startServer('success', port);
+    const agent = request(`http://localhost:${port}`);
+    const res = await agent
+      .post('/admin/assinatura')
+      .set('x-admin-pin', '1234')
+      .send({ email: 'invalid', plano: 'basico' });
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    stopServer(server);
+  });
+});

--- a/tests/cliente-test-server.js
+++ b/tests/cliente-test-server.js
@@ -2,7 +2,7 @@ const express = require('express');
 
 (async () => {
   const routes = (await import('../src/features/clientes/cliente.routes.js')).default;
-  const repo = await import('../src/features/clientes/cliente.repo.js');
+  const repo = (await import('../src/features/clientes/cliente.repo.js')).default;
 
   const scenario = process.env.SCENARIO;
   if (scenario === 'duplicate') {


### PR DESCRIPTION
## Summary
- convert currency utility to ESM and expose `fromCents`
- add assinatura feature with schema, repo, service, controller and routes
- register POST `/admin/assinatura` saving values in cents and returning BRL
- improve controllers and tests to validate input and handle errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ca99c036c832ba83a1ce3f6907141