### PR TITLE
Configure test env and Mercado Pago guard

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,9 @@
+NODE_ENV=test
+ADMIN_PIN=101881
+SUPABASE_URL=http://localhost
+SUPABASE_ANON=fake
+MP_ACCESS_TOKEN=fake
+MP_COLLECTOR_ID=fake
+MP_WEBHOOK_SECRET=fake
+DISABLE_MP=true
+ALLOWED_ORIGIN=http://localhost:3000,http://localhost:8888

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,0 +1,12 @@
+export default {
+  testEnvironment: 'node',
+  verbose: true,
+  setupFiles: ['dotenv/config'],
+  testMatch: ['**/tests/**/*.test.js'],
+  transform: {},
+  testTimeout: 15000,
+  // Map opcional: se existir mock de mpController, habilite-o descomentando a linha
+  // moduleNameMapper: {
+  //   '^./controllers/mpController$': '<rootDir>/tests/mocks/mpController.js'
+  // }
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js tests",
+
+    "test": "cross-env NODE_ENV=test DISABLE_MP=true dotenv_config_path=.env.test node --experimental-vm-modules ./node_modules/jest/bin/jest.js --runInBand",
+    "test:watch": "cross-env NODE_ENV=test DISABLE_MP=true dotenv_config_path=.env.test node --experimental-vm-modules ./node_modules/jest/bin/jest.js --watch",
+    "coverage": "cross-env NODE_ENV=test DISABLE_MP=true dotenv_config_path=.env.test node --experimental-vm-modules ./node_modules/jest/bin/jest.js --coverage",
+
     "test:api": "node ./tests/ping.js",
     "vercel:prepare": "node scripts/patch-vercel.js",
     "build:meta": "echo \"ok\"",
@@ -35,6 +39,7 @@
     "jest": "^29.7.0",
     "morgan": "^1.10.0",
     "nodemon": "^3.1.10",
-    "supertest": "^6.3.4"
+    "supertest": "^6.3.4",
+    "cross-env": "^7.0.3"
   }
 }

--- a/tests/health.test.js
+++ b/tests/health.test.js
@@ -1,0 +1,14 @@
+const request = require('supertest');
+const { createApp } = require('../server');
+
+let app;
+beforeAll(async () => {
+  process.env.NODE_ENV = 'test';
+  app = await createApp();
+});
+
+test('GET /health → 200', async () => {
+  const res = await request(app).get('/health');
+  expect(res.status).toBe(200);
+  expect(res.body).toHaveProperty('ok', true);
+});

--- a/tests/mocks/mpController.js
+++ b/tests/mocks/mpController.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const r = express.Router();
+
+r.post('/checkout', (req, res) => {
+  return res.status(200).json({ init_point: 'https://mp.local/fake' });
+});
+
+r.post('/webhook', (req, res) => res.sendStatus(204));
+
+module.exports = r;


### PR DESCRIPTION
## Summary
- add dedicated test scripts loading `.env.test` and disabling Mercado Pago
- provide Jest config with optional mpController mock
- export `createApp` with Mercado Pago guard and conditional listen
- include sample `.env.test` and smoke `health` test

## Testing
- `NODE_ENV=test DISABLE_MP=true dotenv_config_path=.env.test node --experimental-vm-modules ./node_modules/jest/bin/jest.js --runInBand` *(fails: Cannot find module '/workspace/clube-vantagens-api/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68a3882672c0832b944cfc87ecfc0bc1