### PR TITLE
chore(test): mock Mercado Pago controller for Jest

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -5,8 +5,7 @@ export default {
   testMatch: ['**/tests/**/*.test.js'],
   transform: {},
   testTimeout: 15000,
-  // Map opcional: se existir mock de mpController, habilite-o descomentando a linha
-  // moduleNameMapper: {
-  //   '^./controllers/mpController$': '<rootDir>/tests/mocks/mpController.js'
-  // }
+  moduleNameMapper: {
+    '^\\./controllers/mpController$': '<rootDir>/tests/mocks/mpController.js',
+  },
 };

--- a/tests/mocks/mpController.js
+++ b/tests/mocks/mpController.js
@@ -1,10 +1,18 @@
 const express = require('express');
 const r = express.Router();
 
+// Simula criação de checkout
 r.post('/checkout', (req, res) => {
-  return res.status(200).json({ init_point: 'https://mp.local/fake' });
+  return res.status(200).json({
+    init_point: 'https://mp.local/fake',
+    preference_id: 'pref_test_123',
+  });
 });
 
+// Simula webhook OK
 r.post('/webhook', (req, res) => res.sendStatus(204));
+
+// Endpoint de status opcional (se o real tiver)
+r.get('/status', (req, res) => res.json({ ok: true, mocked: true }));
 
 module.exports = r;


### PR DESCRIPTION
## Summary
- mock Mercado Pago controller with checkout, webhook and status routes
- map `./controllers/mpController` to the mock via Jest's `moduleNameMapper`

## Testing
- `NODE_ENV=test DISABLE_MP=true dotenv_config_path=.env.test node --experimental-vm-modules ./node_modules/jest/bin/jest.js --runInBand` *(fails: Cannot find module '/workspace/clube-vantagens-api/node_modules/jest/bin/jest.js')*


------
https://chatgpt.com/codex/tasks/task_e_68a38b2b179c832ba8e4ac9efb263cdb