### PR TITLE
test: avoid MP missing_env logs

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -4,3 +4,8 @@ ALLOWED_ORIGIN=http://localhost:8888,http://localhost:3000
 SUPABASE_URL=http://localhost
 SUPABASE_ANON=public-anon-key
 
+MP_ACCESS_TOKEN=fake
+MP_COLLECTOR_ID=fake
+MP_WEBHOOK_SECRET=fake
+DISABLE_MP=true
+

--- a/controllers/mpController.js
+++ b/controllers/mpController.js
@@ -36,7 +36,9 @@ async function status(_req, res, next) {
     const live = typeof info?.live_mode === 'boolean' ? info.live_mode : false;
     res.json({ ok: true, collector_id, live });
   } catch (err) {
-    console.error('MP_STATUS_ERR', err);
+    if (process.env.NODE_ENV !== 'test') {
+      console.error('MP_STATUS_ERR', err);
+    }
     err.status = err?.status || 502;
     err.message = 'mp_error';
     next(err);
@@ -102,7 +104,9 @@ async function createCheckout(req, res, next) {
 
     res.json({ ok: true, init_point: link, preference_id: preference.id });
   } catch (err) {
-    console.error('MP_CHECKOUT_ERR', err);
+    if (process.env.NODE_ENV !== 'test') {
+      console.error('MP_CHECKOUT_ERR', err);
+    }
     err.status = err?.status || 502;
     err.message = 'mp_error';
     next(err);
@@ -138,7 +142,9 @@ async function webhook(req, res) {
       }
     }
   } catch (err) {
-    console.error('MP_WEBHOOK_ERR', err);
+    if (process.env.NODE_ENV !== 'test') {
+      console.error('MP_WEBHOOK_ERR', err);
+    }
   }
   res.sendStatus(200);
 }


### PR DESCRIPTION
## Summary
- suppress Mercado Pago console errors when NODE_ENV is test
- add fake Mercado Pago env vars for test environment

## Testing
- `npm test tests/mp.test.js` *(fails: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3dcd33d5c832b8bd2dd098ab98d69