### PR TITLE
fix tests dotenv preload and plan pricing fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ API em Node.js para gerenciamento de assinaturas, transações e administração
 | `APP_BASE_URL` | URL pública do front utilizada nos redirecionamentos de pagamento |
 | `RAILWAY_URL` | URL do deploy no Railway (referenciada em `scripts/patch-vercel.js`) |
 | `DATABASE_URL` | String de conexão PostgreSQL usada pelo `dbmate` |
+| `PLAN_PRICE_BASICO` | Preço do plano Básico em centavos (padrão 4990) |
+| `PLAN_PRICE_PRO` | Preço do plano Pro em centavos (padrão 9990) |
+| `PLAN_PRICE_PREMIUM` | Preço do plano Premium em centavos (padrão 14990) |
 
 ## Planos e descontos
 | Plano | Desconto |

--- a/config/env.js
+++ b/config/env.js
@@ -1,5 +1,7 @@
 const { z } = require('zod');
-require('dotenv').config();
+require('dotenv').config({
+  path: process.env.DOTENV_CONFIG_PATH || process.env.dotenv_config_path || '.env',
+});
 
 const envSchema = z.object({
   SUPABASE_URL: z.string().url(),

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "cross-env NODE_ENV=test DISABLE_MP=true dotenv_config_path=.env.test jest --runInBand",
-    "test:watch": "cross-env NODE_ENV=test DISABLE_MP=true dotenv_config_path=.env.test jest --watch",
-    "coverage": "cross-env NODE_ENV=test DISABLE_MP=true dotenv_config_path=.env.test jest --coverage",
+    "test": "cross-env NODE_ENV=test DISABLE_MP=true DOTENV_CONFIG_PATH=.env.test node --experimental-vm-modules -r dotenv/config ./node_modules/jest/bin/jest.js --runInBand",
+    "test:watch": "cross-env NODE_ENV=test DISABLE_MP=true DOTENV_CONFIG_PATH=.env.test node --experimental-vm-modules -r dotenv/config ./node_modules/jest/bin/jest.js --watch",
+    "coverage": "cross-env NODE_ENV=test DISABLE_MP=true DOTENV_CONFIG_PATH=.env.test node --experimental-vm-modules -r dotenv/config ./node_modules/jest/bin/jest.js --coverage",
     "test:api": "node ./tests/ping.js",
     "vercel:prepare": "node scripts/patch-vercel.js",
     "build:meta": "echo \"ok\"",

--- a/scripts/patch-vercel.js
+++ b/scripts/patch-vercel.js
@@ -1,6 +1,8 @@
 const fs = require('fs');
 const path = require('path');
-require('dotenv').config();
+require('dotenv').config({
+  path: process.env.DOTENV_CONFIG_PATH || process.env.dotenv_config_path || '.env',
+});
 
 const vercelPath = path.join(__dirname, '..', 'public', 'vercel.json');
 const url = (process.env.RAILWAY_URL || '').replace(/\/+$/, '');

--- a/src/features/assinaturas/assinatura.service.js
+++ b/src/features/assinaturas/assinatura.service.js
@@ -1,25 +1,21 @@
 const { assinaturaSchema } = require('./assinatura.schema.js');
 const repo = require('./assinatura.repo.js');
 const clientesRepo = require('../clientes/cliente.repo.js');
-const { fromCents } = require('../../utils/currency.js');
 
 // Lê inteiro (centavos) do ENV com fallback seguro
 function envCents(name, fallback) {
   const raw = process.env[name];
-  const n = raw != null ? Number(raw) : NaN;
-  const cents = Number.isFinite(n) ? Math.max(0, Math.floor(n)) : fallback;
-  return cents;
+  const n = raw == null ? NaN : Number(raw);
+  const cents = Number.isFinite(n) ? Math.max(0, Math.floor(n)) : NaN;
+  return Number.isFinite(cents) ? cents : fallback;
 }
 
-// Retorna o preço em centavos para um plano, com fallback seguro
-function priceForPlan(plano = 'basico') {
-  const table = {
-    basico: envCents('PLAN_PRICE_BASICO', 4990),
-    pro: envCents('PLAN_PRICE_PRO', 9990),
-    premium: envCents('PLAN_PRICE_PREMIUM', 14990),
-  };
-  return table[plano] ?? table.basico;
-}
+// Tabela de preços dos planos em centavos
+const PLAN_PRICES = {
+  basico: envCents('PLAN_PRICE_BASICO', 4990),
+  pro: envCents('PLAN_PRICE_PRO', 9990),
+  premium: envCents('PLAN_PRICE_PREMIUM', 14990),
+};
 
 async function createAssinatura(payload) {
   const data = assinaturaSchema.parse(payload);
@@ -39,8 +35,8 @@ async function createAssinatura(payload) {
   }
 
   const planoKey = String(data.plano || '').toLowerCase();
-  const valor = priceForPlan(planoKey);
-  const valorBRL = fromCents(valor);
+  const valor = PLAN_PRICES[planoKey] ?? PLAN_PRICES.basico;
+  const valorBRL = valor / 100;
 
   const created = await repo.create({
     cliente_id: cliente.id,
@@ -57,5 +53,5 @@ async function createAssinatura(payload) {
   };
 }
 
-module.exports = { createAssinatura, envCents, priceForPlan };
+module.exports = { createAssinatura, envCents, PLAN_PRICES };
 

--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -1,7 +1,12 @@
 // supabaseClient.js
 const path = require('path');
 try {
-  require('dotenv').config({ path: path.resolve(process.cwd(), '.env') });
+  require('dotenv').config({
+    path:
+      process.env.DOTENV_CONFIG_PATH ||
+      process.env.dotenv_config_path ||
+      path.resolve(process.cwd(), '.env'),
+  });
 } catch (_) {
   // dotenv opcional
 }


### PR DESCRIPTION
## Summary
- preload dotenv with `DOTENV_CONFIG_PATH` and require hook for tests
- load environment variables consistently across runtime scripts
- handle plan pricing with env fallbacks and document new variables

## Testing
- `npm test -- --runInBand tests/assinaturas.routes.test.js` *(fails: cross-env: not found)*
- `npm test -- --runInBand` *(fails: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4627bf700832bb69c2aeaf2b09387