### PR TITLE
feat: add plan price fallback

### DIFF
--- a/src/features/assinaturas/assinatura.controller.js
+++ b/src/features/assinaturas/assinatura.controller.js
@@ -7,7 +7,7 @@ const META = { version: 'v0.1.0' };
 async function create(req, res) {
   if (supabase.assertSupabase && !supabase.assertSupabase(res)) return;
   try {
-    const assinatura = await service.createAssinatura(req.body);
+    const assinatura = await service.createAssinatura(req.body, { supabase });
     res.status(201).json({ ok: true, data: assinatura, meta: META });
   } catch (err) {
     const status = err instanceof ZodError ? 400 : err.status || 500;


### PR DESCRIPTION
## Summary
- implement reliable plan pricing with database, env, and default fallbacks
- return valor and valorBRL when creating assinaturas
- pass Supabase client to assinatura service

## Testing
- `NODE_ENV=test DISABLE_MP=true SUPABASE_URL=http://localhost SUPABASE_ANON=public-anon-key PLAN_PRICE_BASICO=4990 PLAN_PRICE_PRO=9990 PLAN_PRICE_PREMIUM=14990 node --experimental-vm-modules ./node_modules/jest/bin/jest.js tests/assinaturas.routes.test.js --runInBand` *(fails: Cannot find module 'dotenv/config')*

------
https://chatgpt.com/codex/tasks/task_e_68a477b9bc9c832b9e2d6b88fdaf08a8