### PR TITLE
fix(routes): monta /admin/assinatura sem prefixo + PIN middleware padronizado + schema válido

### DIFF
--- a/server.js
+++ b/server.js
@@ -26,6 +26,7 @@ async function createApp() {
   // Admin (CommonJS)
   const adminRoutes = require('./src/routes/admin');
   const { requireAdminPin } = require('./src/middlewares/adminPin');
+  const assinaturaFeatureRoutes = require('./src/features/assinaturas/assinatura.routes');
 
   // Error handler
   const errorHandler = require('./middlewares/errorHandler');
@@ -40,7 +41,8 @@ async function createApp() {
 
   // Rotas públicas
   app.get('/health', (_req, res) => res.status(200).json({ ok: true }));
-  app.use('/assinaturas', assinaturaController);
+  app.get('/assinaturas', assinaturaController.consultarPorIdentificador);
+  app.get('/assinaturas/listar', assinaturaController.listarTodas);
   app.use('/transacao', transacaoController);
   app.use('/public', lead);
   app.use('/status', status);
@@ -51,6 +53,7 @@ async function createApp() {
   app.use('/admin', requireAdminPin, adminController);
   app.use('/admin/clientes', requireAdminPin, clientes);
   app.use('/admin/report', requireAdminPin, report);
+  app.use(assinaturaFeatureRoutes);
 
   // Error handler SEMPRE por último
   app.use(errorHandler);

--- a/src/features/assinaturas/assinatura.controller.js
+++ b/src/features/assinaturas/assinatura.controller.js
@@ -1,21 +1,18 @@
 const service = require('./assinatura.service.js');
 const supabase = require('../../../supabaseClient.js');
 const { ZodError } = require('zod');
-
 const META = { version: 'v0.1.0' };
-
 async function create(req, res) {
-  if (supabase.assertSupabase && !supabase.assertSupabase(res)) return;
+  if (typeof supabase.assertSupabase === 'function') {
+    const ok = supabase.assertSupabase(res);
+    if (!ok) return;
+  }
   try {
     const assinatura = await service.createAssinatura(req.body, { supabase });
     return res.status(201).json({ ok: true, data: assinatura, meta: META });
   } catch (err) {
     const status = err instanceof ZodError ? 400 : err.status || 500;
-    return res
-      .status(status)
-      .json({ ok: false, error: err.message, code: err.code });
+    return res.status(status).json({ ok: false, error: err.message, code: err.code, meta: META });
   }
 }
-
 module.exports = { create };
-

--- a/src/features/assinaturas/assinatura.routes.js
+++ b/src/features/assinaturas/assinatura.routes.js
@@ -1,10 +1,6 @@
-const { Router } = require('express');
+const router = require('express').Router();
+const { requireAdminPin } = require('../../middlewares/adminPin');
 const controller = require('./assinatura.controller.js');
-const { requireAdminPin: adminPin } = require('../../middlewares/adminPin.js');
-
-const router = Router();
-
-router.post('/admin/assinatura', adminPin, controller.create);
-
+// este arquivo já define o caminho completo; não usar prefixo no server.js
+router.post('/admin/assinatura', requireAdminPin, controller.create);
 module.exports = router;
-

--- a/src/features/assinaturas/assinatura.schema.js
+++ b/src/features/assinaturas/assinatura.schema.js
@@ -1,9 +1,10 @@
 const { z } = require('zod');
-
 const assinaturaSchema = z.object({
-  email: z.string().email('email inválido'),
+  cliente_id: z.number().int().positive().optional(),
+  email: z.string().email().optional(),
+  documento: z.string().min(5).optional(),
   plano: z.enum(['basico', 'pro', 'premium']),
-  valor: z.union([z.string(), z.number()]).optional(),
+}).refine((d) => !!(d.cliente_id || d.email || d.documento), {
+  message: 'Informe cliente_id, email ou documento'
 });
-
 module.exports = { assinaturaSchema };

--- a/src/middlewares/adminPin.js
+++ b/src/middlewares/adminPin.js
@@ -1,15 +1,22 @@
-// src/middlewares/adminPin.js
+const META = { version: 'v0.1.0' };
+function readPin(req) {
+  const h = req.headers || {};
+  return (
+    (h['x-admin-pin'] ?? h['X-Admin-Pin'] ?? h['x-admin-key'] ?? h['admin-pin']) ||
+    (req.body && (req.body.pin || req.body.admin_pin)) ||
+    (req.query && (req.query.pin || req.query.admin_pin)) ||
+    ''
+  ).toString();
+}
 function requireAdminPin(req, res, next) {
-  const pinHeader = req.get('x-admin-pin');
-  const pinQuery = req.query.pin;
-  const pin = pinHeader || pinQuery;
-
-  if (!process.env.ADMIN_PIN || pin !== process.env.ADMIN_PIN) {
-    return res.status(401).json({ error: 'admin_pin_required' });
+  const expected = (process.env.ADMIN_PIN || '').toString();
+  const provided = readPin(req);
+  if (!expected) {
+    return res.status(503).json({ ok: false, error: 'ADMIN_PIN ausente no servidor', meta: META });
   }
-
+  if (provided !== expected) {
+    return res.status(401).json({ ok: false, error: 'PIN inválido', meta: META });
+  }
   return next();
 }
-
-module.exports = { requireAdminPin };
-
+module.exports = { requireAdminPin, default: requireAdminPin };

--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -28,12 +28,12 @@ if (url && url.startsWith('http') && anon) {
 }
 
 function assertSupabase(res) {
-  if (!supabase) {
-    res.status(503).json({ ok: false, message: 'Banco não configurado' });
+  const has = !!(process.env.SUPABASE_URL && process.env.SUPABASE_ANON);
+  if (!has) {
+    res.status(503).json({ ok: false, error: 'Supabase não configurado', meta: { version: 'v0.1.0' } });
     return false;
   }
   return true;
 }
 
 module.exports = supabase ? { ...supabase, assertSupabase } : { assertSupabase };
-


### PR DESCRIPTION
## Summary
- monta rotas de assinatura no server sem prefixo
- padroniza middleware de PIN admin com meta
- ajusta schema, controller e supabase client para validações corretas

## Testing
- `node --check server.js`
- `node --check src/middlewares/adminPin.js`
- `node --check src/features/assinaturas/assinatura.routes.js`
- `node --check src/features/assinaturas/assinatura.schema.js`
- `node --check src/features/assinaturas/assinatura.controller.js`
- `node --check supabaseClient.js`


------
https://chatgpt.com/codex/tasks/task_e_68a49a542ad0832b8f849241f50864b1