### PR TITLE
feat: add admin plan pricing endpoints

### DIFF
--- a/server.js
+++ b/server.js
@@ -27,6 +27,7 @@ async function createApp() {
   const adminRoutes = require('./src/routes/admin');
   const { requireAdminPin } = require('./src/middlewares/adminPin');
   const assinaturaFeatureRoutes = require('./src/features/assinaturas/assinatura.routes');
+  const planosFeatureRoutes = require('./src/features/planos/planos.routes');
 
   // Error handler
   const errorHandler = require('./middlewares/errorHandler');
@@ -45,6 +46,7 @@ async function createApp() {
   app.get('/assinaturas/listar', assinaturaController.listarTodas);
   // ⚠️ monte AQUI, SEM prefixo, e ANTES de adminRoutes
   app.use(assinaturaFeatureRoutes);
+  app.use(planosFeatureRoutes);
   // Transações
   app.use('/transacao', transacaoController);
   app.use('/public', lead);

--- a/src/features/planos/planos.controller.js
+++ b/src/features/planos/planos.controller.js
@@ -1,0 +1,31 @@
+const { ZodError } = require('zod');
+const { setPrecoSchema } = require('./planos.schema.js');
+const service = require('./planos.service.js');
+
+const META = { version: 'v0.1.0' };
+
+async function getAll(req, res) {
+  try {
+    const itens = await service.list();
+    return res.json({ ok: true, data: itens, meta: META });
+  } catch (err) {
+    return res.status(err.status || 500).json({ ok: false, error: err.message, meta: META });
+  }
+}
+
+async function setPreco(req, res) {
+  try {
+    const body = setPrecoSchema.parse(req.body);
+    const cents = body.preco_centavos != null
+      ? body.preco_centavos
+      : Math.round(Number(body.preco_brl) * 100);
+
+    const out = await service.setPreco({ nome: body.nome, preco_centavos: cents });
+    return res.status(200).json({ ok: true, data: out, meta: META });
+  } catch (err) {
+    const status = err instanceof ZodError ? 400 : err.status || 500;
+    return res.status(status).json({ ok: false, error: err.message, meta: META });
+  }
+}
+
+module.exports = { getAll, setPreco };

--- a/src/features/planos/planos.routes.js
+++ b/src/features/planos/planos.routes.js
@@ -1,0 +1,9 @@
+const router = require('express').Router();
+const { requireAdminPin } = require('../../middlewares/adminPin.js');
+const ctrl = require('./planos.controller.js');
+
+// Caminhos completos (sem prefixo no server.js)
+router.get('/admin/planos', requireAdminPin, ctrl.getAll);
+router.post('/admin/planos/preco', requireAdminPin, ctrl.setPreco);
+
+module.exports = router;

--- a/src/features/planos/planos.schema.js
+++ b/src/features/planos/planos.schema.js
@@ -1,0 +1,12 @@
+const { z } = require('zod');
+
+const setPrecoSchema = z.object({
+  nome: z.enum(['basico', 'pro', 'premium']),
+  // informe UM dos dois:
+  preco_centavos: z.number().int().min(0).optional(),
+  preco_brl: z.number().min(0).optional(),
+}).refine(d => d.preco_centavos != null || d.preco_brl != null, {
+  message: 'Informe preco_centavos ou preco_brl',
+});
+
+module.exports = { setPrecoSchema };

--- a/src/features/planos/planos.service.js
+++ b/src/features/planos/planos.service.js
@@ -1,0 +1,41 @@
+const supabase = require('../../../supabaseClient.js');
+
+async function list() {
+  const { data, error } = await supabase
+    .from('planos')
+    .select('nome, preco_centavos, ativo, updated_at')
+    .order('nome', { ascending: true });
+  if (error) throw error;
+  return (data || []).map(p => ({
+    nome: p.nome,
+    preco_centavos: p.preco_centavos,
+    precoBRL: Number((p.preco_centavos / 100).toFixed(2)),
+    ativo: p.ativo,
+    updated_at: p.updated_at,
+  }));
+}
+
+async function setPreco({ nome, preco_centavos }) {
+  const n = Number(preco_centavos);
+  if (!Number.isFinite(n) || n < 0) {
+    const err = new Error('preco_centavos inválido');
+    err.status = 400;
+    throw err;
+  }
+  const { data, error } = await supabase
+    .from('planos')
+    .upsert({ nome, preco_centavos: Math.floor(n), ativo: true, updated_at: new Date().toISOString() })
+    .select('nome, preco_centavos, ativo, updated_at')
+    .single();
+  if (error) throw error;
+
+  return {
+    nome: data.nome,
+    preco_centavos: data.preco_centavos,
+    precoBRL: Number((data.preco_centavos / 100).toFixed(2)),
+    ativo: data.ativo,
+    updated_at: data.updated_at,
+  };
+}
+
+module.exports = { list, setPreco };


### PR DESCRIPTION
## Summary
- add schema, service, controller and routes for plan price listing and updates
- expose GET /admin/planos and POST /admin/planos/preco with PIN protection
- mount plan routes before existing admin routes

## Testing
- `npm test` *(fails: cross-env not found)*
- `npm install` *(fails: 403 Forbidden for cross-env package)*

------
https://chatgpt.com/codex/tasks/task_e_68a5399e19d8832b89598ec3106428bd