### PR TITLE
feat(planos): cria GET/POST admin para listar/alterar preços com PIN; monta rotas antes do admin; adiciona migração

### DIFF
--- a/db/migrations/20250820_add_planos.sql
+++ b/db/migrations/20250820_add_planos.sql
@@ -1,0 +1,20 @@
+-- migrate:up
+create table if not exists public.planos (
+  id             bigserial primary key,
+  nome           text unique not null,
+  preco_centavos integer not null,
+  ativo          boolean not null default true,
+  updated_at     timestamptz not null default now()
+);
+
+insert into public.planos (nome, preco_centavos)
+values
+  ('basico', 4990),
+  ('pro', 9990),
+  ('premium', 14990)
+on conflict (nome) do update set
+  preco_centavos = excluded.preco_centavos,
+  updated_at = now();
+
+-- migrate:down
+drop table if exists public.planos;

--- a/src/features/planos/planos.service.js
+++ b/src/features/planos/planos.service.js
@@ -22,9 +22,15 @@ async function setPreco({ nome, preco_centavos }) {
     err.status = 400;
     throw err;
   }
+  const cents = Math.floor(n);
   const { data, error } = await supabase
     .from('planos')
-    .upsert({ nome, preco_centavos: Math.floor(n), ativo: true, updated_at: new Date().toISOString() })
+    .upsert({
+      nome,
+      preco_centavos: cents,
+      ativo: true,
+      updated_at: new Date().toISOString(),
+    })
     .select('nome, preco_centavos, ativo, updated_at')
     .single();
   if (error) throw error;


### PR DESCRIPTION
## Summary
- enable pricing endpoints with validation and pin security
- register pricing feature routes before legacy admin routes
- add migration to create and seed `planos` table

## Testing
- No tests were run


------
https://chatgpt.com/codex/tasks/task_e_68a53f2be1a8832b9f3372443788a8f4