### PR TITLE
fix(tests): correct supabase import path and jest mock mapping

### DIFF
--- a/__mocks__/config/supabase.js
+++ b/__mocks__/config/supabase.js
@@ -1,0 +1,11 @@
+module.exports = {
+  supabase: {
+    from: () => ({
+      select: () => ({ data: [], error: null }),
+      insert: () => ({ data: [{ id: 1 }], error: null }),
+      update: () => ({ data: [{ id: 1 }], error: null }),
+      delete: () => ({ data: [{ id: 1 }], error: null }),
+      eq: () => ({ data: [{ id: 1 }], error: null })
+    })
+  }
+};

--- a/__tests__/planos.service.test.js
+++ b/__tests__/planos.service.test.js
@@ -1,9 +1,11 @@
-jest.mock('../config/supabase', () => ({
-  from: jest.fn(),
+jest.mock('config/supabase', () => ({
+  supabase: {
+    from: jest.fn(),
+  },
 }));
 
-const supabase = require('../config/supabase');
-const service = require('../src/features/planos/planos.service');
+const { supabase } = require('config/supabase');
+const service = require('@src/features/planos/planos.service');
 
 describe('Planos Service', () => {
   beforeEach(() => {

--- a/config/supabase.js
+++ b/config/supabase.js
@@ -1,2 +1,2 @@
 const supabase = require('../supabaseClient.js');
-module.exports = supabase;
+module.exports = { supabase };

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,10 +2,14 @@ module.exports = {
   testEnvironment: 'node',
   verbose: true,
   setupFiles: ['dotenv/config'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testMatch: ['**/tests/**/*.test.js', '**/__tests__/**/*.test.js'],
   transform: {},
   testTimeout: 15000,
   moduleNameMapper: {
     '^\\./controllers/mpController$': '<rootDir>/tests/mocks/mpController.js',
+    '^config/(.*)$': '<rootDir>/config/$1',
+    '^@config/(.*)$': '<rootDir>/config/$1',
+    '^@src/(.*)$': '<rootDir>/src/$1',
   },
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+jest.mock('config/supabase');

--- a/package.json
+++ b/package.json
@@ -39,5 +39,12 @@
     "nodemon": "^3.1.10",
     "supertest": "^6.3.4",
     "cross-env": "^7.0.3"
+  },
+  "jest": {
+    "moduleNameMapper": {
+      "^config/(.*)$": "<rootDir>/config/$1",
+      "^@config/(.*)$": "<rootDir>/config/$1",
+      "^@src/(.*)$": "<rootDir>/src/$1"
+    }
   }
 }

--- a/src/features/planos/planos.service.js
+++ b/src/features/planos/planos.service.js
@@ -1,4 +1,4 @@
-const supabase = require('../../config/supabase.js');
+const { supabase } = require('config/supabase');
 
 async function getAllPlanos() {
   const { data, error } = await supabase.from('planos').select('*');


### PR DESCRIPTION
## Summary
- map config and src aliases for Jest
- mock supabase using global setup and manual __mocks__
- update planos service and tests to use alias imports

## Testing
- `NODE_ENV=test DISABLE_MP=true DOTENV_CONFIG_PATH=.env.test npx jest --runInBand` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68a631846f08832bb4d21932c272b58b