### PR TITLE
feat(planos): add planos.service with CRUD using Supabase alias

### DIFF
--- a/src/features/planos/planos.controller.js
+++ b/src/features/planos/planos.controller.js
@@ -1,8 +1,8 @@
-const planosService = require('./planos.service');
+const service = require('./planos.service');
 
 async function listarPlanos(req, res, next) {
   try {
-    const { data, error } = await planosService.getAllPlanos();
+    const { data, error } = await service.getAllPlanos();
     if (error) throw error;
     res.json(data);
   } catch (err) {
@@ -12,7 +12,7 @@ async function listarPlanos(req, res, next) {
 
 async function obterPlano(req, res, next) {
   try {
-    const { data, error } = await planosService.getPlanoById(req.params.id);
+    const { data, error } = await service.getPlanoById(req.params.id);
     if (error) throw error;
     if (!data) return res.status(404).json({ message: 'Plano não encontrado' });
     res.json(data);
@@ -23,7 +23,7 @@ async function obterPlano(req, res, next) {
 
 async function criarPlano(req, res, next) {
   try {
-    const { data, error } = await planosService.createPlano(req.body);
+    const { data, error } = await service.createPlano(req.body);
     if (error) throw error;
     res.status(201).json(data);
   } catch (err) {
@@ -33,7 +33,7 @@ async function criarPlano(req, res, next) {
 
 async function atualizarPlano(req, res, next) {
   try {
-    const { data, error } = await planosService.updatePlano(req.params.id, req.body);
+    const { data, error } = await service.updatePlano(req.params.id, req.body);
     if (error) throw error;
     res.json(data);
   } catch (err) {
@@ -43,7 +43,7 @@ async function atualizarPlano(req, res, next) {
 
 async function removerPlano(req, res, next) {
   try {
-    const { error } = await planosService.deletePlano(req.params.id);
+    const { error } = await service.deletePlano(req.params.id);
     if (error) throw error;
     res.status(204).end();
   } catch (err) {

--- a/src/features/planos/planos.service.js
+++ b/src/features/planos/planos.service.js
@@ -3,38 +3,31 @@ const { supabase } = require('config/supabase');
 async function getAllPlanos() {
   const { data, error } = await supabase.from('planos').select('*');
   if (error) throw error;
-  return { data, error };
+  return { data, error: null };
 }
 
 async function getPlanoById(id) {
   const { data, error } = await supabase
     .from('planos')
     .select('*')
-    .eq('id', id)
-    .single();
+    .eq('id', id);
   if (error) throw error;
-  return { data, error };
+  return { data: data ? data[0] : null, error: null };
 }
 
 async function createPlano(payload) {
-  const { data, error } = await supabase
-    .from('planos')
-    .insert([payload])
-    .select()
-    .single();
+  const { data, error } = await supabase.from('planos').insert(payload);
   if (error) throw error;
-  return { data, error };
+  return { data: data ? data[0] : null, error: null };
 }
 
 async function updatePlano(id, payload) {
   const { data, error } = await supabase
     .from('planos')
     .update(payload)
-    .eq('id', id)
-    .select()
-    .single();
+    .eq('id', id);
   if (error) throw error;
-  return { data, error };
+  return { data: data ? data[0] : null, error: null };
 }
 
 async function deletePlano(id) {
@@ -43,7 +36,7 @@ async function deletePlano(id) {
     .delete()
     .eq('id', id);
   if (error) throw error;
-  return { data, error };
+  return { data, error: null };
 }
 
 module.exports = {
@@ -53,3 +46,4 @@ module.exports = {
   updatePlano,
   deletePlano,
 };
+


### PR DESCRIPTION
## Summary
- add Supabase-based planos.service with basic CRUD helpers
- update controller to import new service alias

## Testing
- `npm test` *(fails: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a641565ff8832b87b19c95edc185b7