### PR TITLE
feat(planos): add service CRUD and satisfy controller require

### DIFF
--- a/src/features/planos/planos.service.js
+++ b/src/features/planos/planos.service.js
@@ -1,3 +1,4 @@
+// src/features/planos/planos.service.js
 const { supabase } = require('config/supabase');
 
 async function getAllPlanos() {
@@ -7,36 +8,31 @@ async function getAllPlanos() {
 }
 
 async function getPlanoById(id) {
-  const { data, error } = await supabase
-    .from('planos')
-    .select('*')
-    .eq('id', id);
+  const { data, error } = await supabase.from('planos').select('*').eq('id', id);
   if (error) throw error;
-  return { data: data ? data[0] : null, error: null };
+  const row = Array.isArray(data) ? data[0] : data;
+  return { data: row ?? null, error: null };
 }
 
 async function createPlano(payload) {
   const { data, error } = await supabase.from('planos').insert(payload);
   if (error) throw error;
-  return { data: data ? data[0] : null, error: null };
+  const row = Array.isArray(data) ? data[0] : data;
+  return { data: row ?? null, error: null };
 }
 
 async function updatePlano(id, payload) {
-  const { data, error } = await supabase
-    .from('planos')
-    .update(payload)
-    .eq('id', id);
+  const { data, error } = await supabase.from('planos').update(payload).eq('id', id);
   if (error) throw error;
-  return { data: data ? data[0] : null, error: null };
+  const row = Array.isArray(data) ? data[0] : data;
+  return { data: row ?? null, error: null };
 }
 
 async function deletePlano(id) {
-  const { data, error } = await supabase
-    .from('planos')
-    .delete()
-    .eq('id', id);
+  const { data, error } = await supabase.from('planos').delete().eq('id', id);
   if (error) throw error;
-  return { data, error: null };
+  const row = Array.isArray(data) ? data[0] : data;
+  return { data: row ?? null, error: null };
 }
 
 module.exports = {
@@ -46,4 +42,3 @@ module.exports = {
   updatePlano,
   deletePlano,
 };
-


### PR DESCRIPTION
## Summary
- add Supabase-backed CRUD service for Planos
- ensure controller loads Planos service via CommonJS require

## Testing
- `npm test` *(fails: cross-env: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cross-env)*

------
https://chatgpt.com/codex/tasks/task_e_68a6454031c0832bac41a463b28a5202