### PR TITLE
fix: resilient supabase import and test mocks

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,10 @@
-jest.mock('config/supabase');
+// Mock alias if present in Jest
+try { jest.mock('config/supabase'); } catch (_e) {}
+
+// Mock fallback (caminho absoluto do arquivo real)
+try {
+  const path = require('path');
+  const abs = path.join(process.cwd(), 'config', 'supabase.js');
+  jest.mock(abs, () => require('__mocks__/config/supabase.js'));
+} catch (_e) {}
+

--- a/src/features/planos/planos.service.js
+++ b/src/features/planos/planos.service.js
@@ -1,5 +1,11 @@
 // src/features/planos/planos.service.js
-const { supabase } = require('config/supabase');
+// Resilient import: alias first, fallback to relative path
+let supabase;
+try {
+  ({ supabase } = require('config/supabase'));
+} catch (_e) {
+  ({ supabase } = require('../../../config/supabase'));
+}
 
 async function getAllPlanos() {
   const { data, error } = await supabase.from('planos').select('*');


### PR DESCRIPTION
## Summary
- add resilient supabase import in planos service using alias with relative fallback
- ensure Jest mocks both alias and absolute supabase paths

## Testing
- `npm test` *(fails: cross-env not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a720fd6bf8832b8fb69a158aafe8a7