### PR TITLE
chore(test): use single jest.config.js and remove duplicate package.json config

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "cross-env NODE_ENV=test dotenv_config_path=.env.test node --experimental-vm-modules ./node_modules/jest/bin/jest.js --runInBand",
+    "test": "cross-env NODE_ENV=test dotenv_config_path=.env.test node ./node_modules/jest/bin/jest.js --runInBand --config jest.config.js",
     "test:watch": "npm run test -- --watch",
     "coverage": "cross-env NODE_ENV=test DISABLE_MP=true DOTENV_CONFIG_PATH=.env.test node --experimental-vm-modules -r dotenv/config ./node_modules/jest/bin/jest.js --coverage",
     "test:api": "node ./tests/ping.js",
@@ -40,12 +40,5 @@
     "nodemon": "^3.1.10",
     "supertest": "^6.3.4",
     "cross-env": "^7.0.3"
-  },
-  "jest": {
-    "moduleNameMapper": {
-      "^config/(.*)$": "<rootDir>/config/$1",
-      "^@config/(.*)$": "<rootDir>/config/$1",
-      "^@src/(.*)$": "<rootDir>/src/$1"
-    }
   }
 }


### PR DESCRIPTION
## Summary
- remove inline Jest config from package.json
- invoke Jest via script using explicit config file

## Testing
- `npm test` *(fails: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7299fe088832bac7311a248249d7e