### PR TITLE
Fix planos insert and add in-memory supabase mock

### DIFF
--- a/__mocks__/config/supabase.js
+++ b/__mocks__/config/supabase.js
@@ -1,11 +1,105 @@
-module.exports = {
-  supabase: {
-    from: () => ({
-      select: () => ({ data: [], error: null }),
-      insert: () => ({ data: [{ id: 1 }], error: null }),
-      update: () => ({ data: [{ id: 1 }], error: null }),
-      delete: () => ({ data: [{ id: 1 }], error: null }),
-      eq: () => ({ data: [{ id: 1 }], error: null })
-    })
-  }
+const seed = {
+  clientes: [{ id: 1, email: 'a@a.com' }],
+  planos: [
+    { id: 1, nome: 'basico' },
+    { id: 2, nome: 'premium' },
+  ],
+  assinaturas: [],
 };
+
+const __db = {
+  clientes: [],
+  planos: [],
+  assinaturas: [],
+};
+
+const clone = (obj) => JSON.parse(JSON.stringify(obj));
+
+const select = jest.fn();
+const insert = jest.fn();
+const update = jest.fn();
+const del = jest.fn();
+const eq = jest.fn();
+
+const from = jest.fn((table) => {
+  const filters = {};
+
+  const run = () => {
+    let rows = __db[table] ? clone(__db[table]) : [];
+    Object.entries(filters).forEach(([col, val]) => {
+      rows = rows.filter((r) => r[col] === val);
+    });
+    return { data: rows, error: null };
+  };
+
+  const query = {
+    select: select.mockImplementation(() => {
+      const result = run();
+      const p = Promise.resolve(result);
+      p.eq = eq.mockImplementation((col, value) => {
+        filters[col] = value;
+        return Promise.resolve(run());
+      });
+      return p;
+    }),
+    insert: insert.mockImplementation((arr) => {
+      const payload = Array.isArray(arr) ? arr[0] : arr;
+      const tableData = __db[table] || [];
+      const id = tableData.length ? Math.max(...tableData.map((r) => r.id || 0)) + 1 : 1;
+      const row = { id, ...payload };
+      tableData.push(row);
+      return Promise.resolve({ data: row, error: null });
+    }),
+    update: update.mockImplementation((payload) => ({
+      eq: eq.mockImplementation((col, value) => {
+        const tableData = __db[table] || [];
+        const item = tableData.find((r) => r[col] === value);
+        if (item) Object.assign(item, payload);
+        return Promise.resolve({ data: item ? clone(item) : null, error: null });
+      }),
+    })),
+    delete: del.mockImplementation(() => ({
+      eq: eq.mockImplementation((col, value) => {
+        const tableData = __db[table] || [];
+        const index = tableData.findIndex((r) => r[col] === value);
+        const removed = index >= 0 ? tableData.splice(index, 1)[0] : null;
+        return Promise.resolve({ data: removed ? { id: removed.id } : null, error: null });
+      }),
+    })),
+    eq: eq.mockImplementation((col, value) => {
+      filters[col] = value;
+      return query;
+    }),
+  };
+
+  return query;
+});
+
+function __reset() {
+  __db.clientes = clone(seed.clientes);
+  __db.planos = clone(seed.planos);
+  __db.assinaturas = clone(seed.assinaturas);
+  from.mockClear();
+  select.mockClear();
+  insert.mockClear();
+  update.mockClear();
+  del.mockClear();
+  eq.mockClear();
+}
+
+__reset();
+
+const supabase = { from };
+
+module.exports = {
+  __db,
+  __reset,
+  from,
+  insert,
+  update,
+  select,
+  del,
+  eq,
+  supabase,
+};
+

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -5,3 +5,6 @@ try {
   jest.mock(abs, () => require('__mocks__/config/supabase.js'));
 } catch (_e) {}
 
+const supabaseMock = require('__mocks__/config/supabase.js');
+beforeEach(() => supabaseMock.__reset && supabaseMock.__reset());
+

--- a/src/features/planos/planos.service.js
+++ b/src/features/planos/planos.service.js
@@ -20,7 +20,7 @@ async function getPlanoById(id) {
 }
 
 async function createPlano(payload) {
-  const { data, error } = await supabase.from('planos').insert(payload);
+  const { data, error } = await supabase.from('planos').insert([payload]);
   if (error) throw error;
   const row = Array.isArray(data) ? data[0] : data;
   return { data: row ?? null, error: null };


### PR DESCRIPTION
## Summary
- ensure plano creation sends array to Supabase insert
- add seeded in-memory Supabase mock with per-test reset

## Testing
- `npm test tests/assinaturas.routes.test.js __tests__/planos.service.test.js` *(fails: cross-env: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cross-env)*

------
https://chatgpt.com/codex/tasks/task_e_68a7325717a0832bb19afa24010be1a2