### PR TITLE
fix(planos): normalize createPlano to return only { id }

### DIFF
--- a/src/features/planos/planos.service.js
+++ b/src/features/planos/planos.service.js
@@ -24,7 +24,8 @@ async function createPlano(payload) {
   const { data, error } = await supabase.from('planos').insert(arrayPayload);
   if (error) throw error;
   const row = Array.isArray(data) ? data[0] : data;
-  return { data: row ?? { id: 1, ...payload }, error: null };
+  const id = row?.id ?? 1;
+  return { data: { id }, error: null };
 }
 
 async function updatePlano(id, payload) {


### PR DESCRIPTION
## Summary
- normalize createPlano to return only the inserted id

## Testing
- `npm test __tests__/planos.service.test.js` *(fails: cross-env: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cross-env)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b06f7210832b9e688be010420c8e