### PR TITLE
chore: add duplicate audit script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build:meta": "echo \"ok\"",
     "migrate": "dbmate up",
     "postinstall": "node scripts/maybe-migrate.cjs",
-    "test:ci": "cross-env NODE_ENV=test dotenv_config_path=.env.test node ./node_modules/jest/bin/jest.js --runInBand --reporters=default --ci"
+    "test:ci": "cross-env NODE_ENV=test dotenv_config_path=.env.test node ./node_modules/jest/bin/jest.js --runInBand --reporters=default --ci",
+    "audit:dup": "node scripts/audit-duplicates.cjs"
   },
   "keywords": [],
   "author": "",

--- a/scripts/audit-duplicates.cjs
+++ b/scripts/audit-duplicates.cjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+const { spawnSync } = require('node:child_process');
+const { readFileSync } = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+function git(args) {
+  return spawnSync('git', args, { encoding: 'utf8' });
+}
+
+const ls = git(['ls-files', 'src']);
+const files = ls.stdout.trim().split('\n').filter(Boolean);
+
+const byBase = new Map();
+const byHash = new Map();
+const byNames = [];
+
+for (const file of files) {
+  const content = readFileSync(file, 'utf8');
+  const hash = crypto.createHash('sha1').update(content).digest('hex');
+  const base = path.basename(file);
+  const names = new Set();
+  const regex = /function\s+(\w+)/g;
+  let m;
+  while ((m = regex.exec(content))) {
+    names.add(m[1]);
+  }
+  byNames.push({ file, names });
+  if (!byBase.has(base)) byBase.set(base, []);
+  byBase.get(base).push(file);
+  if (!byHash.has(hash)) byHash.set(hash, []);
+  byHash.get(hash).push(file);
+}
+
+let problems = false;
+
+console.log('== Duplicate basenames ==');
+for (const [base, list] of byBase) {
+  if (list.length > 1) {
+    problems = true;
+    console.log(`${base}: ${list.join(', ')}`);
+  }
+}
+
+console.log('== Identical files ==');
+for (const [hash, list] of byHash) {
+  if (list.length > 1) {
+    problems = true;
+    console.log(`${hash}: ${list.join(', ')}`);
+  }
+}
+
+console.log('== Similar exports (>=3 common functions) ==');
+for (let i = 0; i < byNames.length; i++) {
+  for (let j = i + 1; j < byNames.length; j++) {
+    const a = byNames[i];
+    const b = byNames[j];
+    const common = [...a.names].filter((n) => b.names.has(n));
+    if (common.length >= 3) {
+      problems = true;
+      console.log(`${a.file} ~ ${b.file}: ${common.join(', ')}`);
+    }
+  }
+}
+
+function runGrep(pattern) {
+  const res = git(['grep', '-n', pattern, '--', 'src']);
+  const out = res.stdout.trim();
+  if (out) {
+    console.log(`== git grep ${pattern} ==\n${out}`);
+  } else {
+    console.log(`== git grep ${pattern} ==\n(no results)`);
+  }
+}
+
+runGrep('createPlano');
+runGrep('updatePlano');
+runGrep('module\\.exports');
+
+process.exit(problems ? 1 : 0);


### PR DESCRIPTION
## Summary
- add duplicate/collision scanner script
- expose audit:dup npm script

## Testing
- `npm run audit:dup` (fails: duplicate basename admin.js)
- `npm test` (fails: cross-env not found; `npm install` returned 403 Forbidden)

------
https://chatgpt.com/codex/tasks/task_e_68a7b1aa5a18832b9aebb4ac92468738