### PR TITLE
Fix assinatura route and robust router imports

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,6 +8,10 @@
 const express = require('express');
 require('./config/env');
 
+function asRouter(mod) {
+  return (mod && (mod.router || mod.default?.router || mod.default)) || mod;
+}
+
 async function createApp() {
   const helmet = require('helmet');
   const rateLimit = require('express-rate-limit');
@@ -15,21 +19,23 @@ async function createApp() {
 
   // Controllers (CommonJS)
   const assinaturaController = require('./controllers/assinaturaController');
-  const transacaoController = require('./controllers/transacaoController');
   const adminController = require('./controllers/adminController');
   const report = require('./controllers/reportController');
-  const lead = require('./controllers/leadController');
   const clientes = require('./controllers/clientesController');
-  const metrics = require('./controllers/metricsController');
-  const status = require('./controllers/statusController');
+
+  // Routers (CommonJS)
+  const lead = asRouter(require('./src/routes/lead'));
+  const status = asRouter(require('./src/routes/status'));
+  const metrics = asRouter(require('./src/routes/metrics'));
+  const transacaoController = asRouter(require('./src/routes/transacao'));
 
   // Admin (CommonJS)
   const adminRoutes = require('./src/routes/admin');
   const { requireAdminPin } = require('./src/middlewares/adminPin');
 
   // Features (CommonJS)
-  const assinaturaFeatureRoutes = require('./src/features/assinaturas/assinatura.routes');
-  const planosFeatureRoutes = require('./src/features/planos/planos.routes'); // ✅
+  const assinaturaFeatureRoutes = asRouter(require('./src/features/assinaturas/assinatura.routes'));
+  const planosFeatureRoutes = asRouter(require('./src/features/planos/planos.routes')); // ✅
 
   // Error handler
   const errorHandler = require('./middlewares/errorHandler');

--- a/src/features/assinaturas/assinatura.routes.js
+++ b/src/features/assinaturas/assinatura.routes.js
@@ -3,6 +3,6 @@ const { requireAdminPin } = require('../../middlewares/adminPin');
 const controller = require('./assinatura.controller.js');
 
 // já publica o caminho completo
-router.post('/admin/assinatura', requireAdminPin, controller.create);
+router.post(['/admin/assinatura', '/admin/assinaturas'], requireAdminPin, controller.create);
 
 module.exports = router;

--- a/src/routes/lead.js
+++ b/src/routes/lead.js
@@ -1,0 +1,11 @@
+const router = require('express').Router();
+const controller = require('../../controllers/leadController');
+const { requireAdminPin } = require('../middlewares/adminPin');
+
+router.post('/lead', controller.publicCreate);
+router.get('/leads', requireAdminPin, controller.adminList);
+router.get('/leads.csv', requireAdminPin, controller.adminExportCsv);
+router.post('/leads/approve', requireAdminPin, controller.adminApprove);
+router.post('/leads/discard', requireAdminPin, controller.adminDiscard);
+
+module.exports = router;

--- a/src/routes/metrics.js
+++ b/src/routes/metrics.js
@@ -1,0 +1,7 @@
+const router = require('express').Router();
+const controller = require('../../controllers/metricsController');
+
+router.get('/', controller.resume);
+router.get('/csv', controller.csv);
+
+module.exports = router;

--- a/src/routes/status.js
+++ b/src/routes/status.js
@@ -1,0 +1,7 @@
+const router = require('express').Router();
+const controller = require('../../controllers/statusController');
+
+router.get('/', controller.info);
+router.get('/supabase', controller.pingSupabase);
+
+module.exports = router;

--- a/src/routes/transacao.js
+++ b/src/routes/transacao.js
@@ -1,0 +1,1 @@
+module.exports = require('../../controllers/transacaoController');


### PR DESCRIPTION
## Summary
- accept both singular and plural `/admin/assinatura(s)`
- add `asRouter` helper and resilient imports for lead, status, metrics, transacao
- add router files for those modules

## Testing
- `npm test` *(fails: cross-env not found)*
- `npm install` *(fails: 403 Forbidden - cannot fetch cross-env)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b38feb50832b9c113a9472b81bb8