### PR TITLE
fix: wrap route imports with asRouter helper

### DIFF
--- a/src/routes/admin-routes.js
+++ b/src/routes/admin-routes.js
@@ -1,0 +1,8 @@
+const router = require('express').Router();
+const controller = require('../../controllers/adminController');
+
+router.post('/seed', controller.seed);
+router.post('/clientes/bulk', controller.bulkClientes);
+router.post('/clientes/generate-ids', controller.generateIds);
+
+module.exports = router;

--- a/src/routes/clientes.js
+++ b/src/routes/clientes.js
@@ -1,0 +1,10 @@
+const router = require('express').Router();
+const controller = require('../../controllers/clientesController');
+
+router.get('/', controller.list);
+router.post('/', controller.upsertOne);
+router.post('/bulk', controller.bulkUpsert);
+router.delete('/:cpf', controller.remove);
+router.post('/generate-ids', controller.generateIds);
+
+module.exports = router;

--- a/src/routes/report.js
+++ b/src/routes/report.js
@@ -1,0 +1,7 @@
+const router = require('express').Router();
+const controller = require('../../controllers/reportController');
+
+router.get('/', controller.resumo);
+router.get('/csv', controller.csv);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- normalize route imports in `server.js` with `asRouter` helper
- add explicit Express routers for admin, clientes, and report modules

## Testing
- `npm test` *(fails: cross-env not found)*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bbceee94832baa605053dd4cc877