### PR TITLE
ci: add GitHub Actions workflow to run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+on:
+  push:
+    branches: [ main, feature/**, fix/** ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: node ./node_modules/jest/bin/jest.js --clearCache
+      - run: npm test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests on push and PR

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cross-env)*
- `npm test` *(fails: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c11af9a0832bb2950daf6748d5d2