### PR TITLE
ci: use npm install in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+      - run: npm install --no-audit --no-fund
+      - run: node ./node_modules/jest/bin/jest.js --clearCache
+      - run: npm test -- --config jest.config.js


### PR DESCRIPTION
## Summary
- run `npm install` instead of `npm ci` during tests
- clear Jest cache and run tests with explicit config on Node 22

## Testing
- `node ./node_modules/jest/bin/jest.js --clearCache` *(fails: Cannot find module '/workspace/clube-vantagens-api/node_modules/jest/bin/jest.js')*
- `npm test -- --config jest.config.js` *(fails: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c3ccc1ac832bb76ed6e70ce85e48