### PR TITLE
ci: fix jest config duplication in workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+      - name: Clear Jest cache
+        run: node ./node_modules/jest/bin/jest.js --clearCache
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
## Summary
- remove duplicate `--config` from test step
- add cache, jest cache clearing and `npm test` to workflow

## Testing
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cross-env)*
- `node ./node_modules/jest/bin/jest.js --clearCache` *(fails: Cannot find module '/workspace/clube-vantagens-api/node_modules/jest/bin/jest.js')*
- `npm test` *(fails: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c6306768832b8f0da32be74eb2b7