### PR TITLE
chore(dev): VS Code F5 debug (nodemon)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,8 @@ pids/
 *.pid
 *.pid.lock
 lib-cov/
+
+# Allow VS Code debug configs
+!.vscode/
+!.vscode/launch.json
+!.vscode/tasks.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "API (F5) – nodemon + .env",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/nodemon",
+      "program": "${workspaceFolder}/server.js",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "restart": true,
+      "autoAttachChildProcesses": true,
+      "envFile": "${workspaceFolder}/.env"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "API (F5) – node",
+      "program": "${workspaceFolder}/server.js",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "envFile": "${workspaceFolder}/.env"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "dev",
+      "label": "API: dev (nodemon)",
+      "isBackground": true,
+      "runOptions": { "runOn": "folderOpen" },
+      "problemMatcher": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- allow VS Code to commit launch and task configs
- add nodemon-based and node fallback launchers
- add npm task to start dev server on folder open

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cross-env)*
- `npm run dev` *(fails: nodemon not found)*
- `curl -i http://localhost:3000/health` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68a87e58610c832ba9011f5131df0382