### PR TITLE
chore(audit): repo inventory + safe cleanup (no public signup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 API em Node.js para gerenciamento de assinaturas, transações e administração de um clube de vantagens. Utiliza [Express](https://expressjs.com/) e [Supabase](https://supabase.com/) como backend.
 
+## Desenvolvimento
+- **Rodar local**: `npm run dev` (usa nodemon e `.env`).
+- **Rodar testes**: `npm test`.
+- **Debug VS Code**: pressione `F5` usando a configuração "API (F5) – nodemon".
+- **Variáveis esperadas**: defina `SUPABASE_URL`, `SUPABASE_ANON`, `ADMIN_PIN` e `ALLOWED_ORIGIN` em `.env`.
+- **Healthcheck**: `GET /health` deve responder `{ ok: true }`.
+
 ## Arquitetura
 - **Express** para rotas e middleware.
 - **Supabase** para persistência de dados (`supabaseClient.js`).

--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -1,4 +1,9 @@
-const supabase = require('../supabaseClient');
+let supabase;
+try {
+  ({ supabase } = require('config/supabase'));
+} catch (_e) {
+  ({ supabase } = require('../config/supabase'));
+}
 const { assertSupabase } = supabase;
 const generateClientIds = require('../utils/generateClientIds');
 

--- a/controllers/assinaturaController.js
+++ b/controllers/assinaturaController.js
@@ -1,4 +1,9 @@
-const supabase = require('../supabaseClient');
+let supabase;
+try {
+  ({ supabase } = require('config/supabase'));
+} catch (_e) {
+  ({ supabase } = require('../config/supabase'));
+}
 const { assertSupabase } = supabase;
 
 exports.consultarPorIdentificador = async (req, res, next) => {

--- a/controllers/clientesController.js
+++ b/controllers/clientesController.js
@@ -1,4 +1,9 @@
-const supabase = require('../supabaseClient');
+let supabase;
+try {
+  ({ supabase } = require('config/supabase'));
+} catch (_e) {
+  ({ supabase } = require('../config/supabase'));
+}
 const { assertSupabase } = supabase;
 const generateClientIds = require('../utils/generateClientIds');
 

--- a/controllers/leadController.js
+++ b/controllers/leadController.js
@@ -1,4 +1,9 @@
-const supabase = require('../supabaseClient');
+let supabase;
+try {
+  ({ supabase } = require('config/supabase'));
+} catch (_e) {
+  ({ supabase } = require('../config/supabase'));
+}
 const { assertSupabase } = supabase;
 const PLANOS = new Set(['Mensal', 'Semestral', 'Anual']);
 const onlyDigits = s => (String(s||'').match(/\d/g) || []).join('');

--- a/controllers/metricsController.js
+++ b/controllers/metricsController.js
@@ -1,4 +1,9 @@
-const supabase = require('../supabaseClient');
+let supabase;
+try {
+  ({ supabase } = require('config/supabase'));
+} catch (_e) {
+  ({ supabase } = require('../config/supabase'));
+}
 const { assertSupabase } = supabase;
 const { periodFromQuery, iso, aggregate } = require('../services/transacoesMetrics');
 

--- a/controllers/mpController.js
+++ b/controllers/mpController.js
@@ -1,6 +1,12 @@
 const express = require('express');
 const MP = require('mercadopago');
-const supabase = require('../supabaseClient');
+
+let supabase;
+try {
+  ({ supabase } = require('config/supabase'));
+} catch (_e) {
+  ({ supabase } = require('../config/supabase'));
+}
 const { assertSupabase } = supabase;
 
 const logError = (...args) => { if (process.env.NODE_ENV !== 'test') console.error(...args); };

--- a/controllers/reportController.js
+++ b/controllers/reportController.js
@@ -1,4 +1,9 @@
-const supabase = require('../supabaseClient');
+let supabase;
+try {
+  ({ supabase } = require('config/supabase'));
+} catch (_e) {
+  ({ supabase } = require('../config/supabase'));
+}
 const { assertSupabase } = supabase;
 const { periodFromQuery, iso, aggregate } = require('../services/transacoesMetrics');
 

--- a/controllers/statusController.js
+++ b/controllers/statusController.js
@@ -1,4 +1,9 @@
-const supabase = require('../supabaseClient');
+let supabase;
+try {
+  ({ supabase } = require('config/supabase'));
+} catch (_e) {
+  ({ supabase } = require('../config/supabase'));
+}
 const { assertSupabase } = supabase;
 
 exports.info = async (req, res) => {

--- a/controllers/transacaoController.js
+++ b/controllers/transacaoController.js
@@ -1,6 +1,12 @@
 const express = require('express');
 const router = express.Router();
-const supabase = require('../supabaseClient');
+
+let supabase;
+try {
+  ({ supabase } = require('config/supabase'));
+} catch (_e) {
+  ({ supabase } = require('../config/supabase'));
+}
 const { assertSupabase } = supabase;
 const { z } = require('zod');
 

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -1,0 +1,79 @@
+# Repository Audit
+
+## Rotas
+| Método | Caminho | x-admin-pin |
+|--------|---------|-------------|
+| GET | /health | - |
+| GET | /assinaturas | - |
+| GET | /assinaturas/listar | - |
+| POST | /admin/assinatura | sim |
+| POST | /admin/assinaturas | sim |
+| GET | /planos | - |
+| GET | /planos/:id | - |
+| POST | /planos | - |
+| PUT | /planos/:id | - |
+| DELETE | /planos/:id | - |
+| POST | /public/lead | - |
+| GET | /public/leads | sim |
+| GET | /public/leads.csv | sim |
+| POST | /public/leads/approve | sim |
+| POST | /public/leads/discard | sim |
+| GET | /status | - |
+| GET | /status/supabase | - |
+| GET | /metrics | - |
+| GET | /metrics/csv | - |
+| GET | /transacao/preview | - |
+| POST | /transacao | - |
+| POST | /admin/seed | sim |
+| POST | /admin/clientes/bulk | sim |
+| POST | /admin/clientes/generate-ids | sim |
+| POST | /admin/clientes | sim |
+| GET | /admin/clientes | sim |
+| POST | /admin/clientes/bulk | sim |
+| DELETE | /admin/clientes/:cpf | sim |
+| POST | /admin/clientes/generate-ids | sim |
+| GET | /admin/report | sim |
+| GET | /admin/report/csv | sim |
+| GET | /mp/status * | - |
+| POST | /mp/checkout * | - |
+| POST | /mp/webhook * | - |
+
+\* rotas de Mercado Pago existem em `controllers/mpController.js`, mas não estão montadas por padrão em `server.js`.
+
+## Serviços / Módulos
+- `src/features/assinaturas/assinatura.service.js` – cria assinaturas e calcula preço do plano.
+- `src/features/planos/planos.service.js` – CRUD de planos.
+- `src/features/clientes/cliente.service.js` – criação de clientes.
+- `services/transacoesMetrics.js` – agregação de métricas de transações.
+- `controllers/*` – controllers legados para métricas, leads, transações, etc.
+
+## Middlewares
+- `src/middlewares/adminPin.js` – valida header `x-admin-pin`.
+- `middlewares/errorHandler.js` – tratamento de erros.
+- `helmet`, `cors` e `express-rate-limit` configurados em `server.js`.
+
+## Variáveis de Ambiente
+- `SUPABASE_URL`, `SUPABASE_ANON`, `ADMIN_PIN`, `ALLOWED_ORIGIN`, `PORT`.
+- Integração opcional com Mercado Pago: `MP_ACCESS_TOKEN`, `MP_COLLECTOR_ID`, `MP_WEBHOOK_SECRET`, `APP_BASE_URL`.
+- Outros: `RECAPTCHA_SECRET`, `RAILWAY_URL`, `DATABASE_URL`, `PLAN_PRICE_BASICO`, `PLAN_PRICE_PRO`, `PLAN_PRICE_PREMIUM`.
+
+## Testes
+- Jest com config em `jest.config.js` e mocks em `jest.setup.js`.
+- Testes em `tests/` e `__tests__/`.
+- Executar com `npm test`.
+
+## Experiência de Desenvolvimento
+- `npm run dev` usa nodemon.
+- `npm start` executa `node server.js`.
+- VS Code: `.vscode/launch.json` permite depurar com F5.
+
+## CI
+- Workflow GitHub Actions `.github/workflows/test.yml` roda `npm test` em Node 22.
+
+## Pontos Frágeis / Dívidas
+- Rotas de planos estão públicas (não exigem PIN).
+- `mpController` existe mas não é montado no servidor.
+- `cliente.repo.js` não implementa `findById`/`findByDocumento`, usados em `assinatura.service.js`.
+- Arquivo duplicado `assinatura.routes.js` removido.
+- Página "Testar Cadastro" (Netlify) é externa; API não expõe cadastro público.
+

--- a/package.json
+++ b/package.json
@@ -6,15 +6,15 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "cross-env NODE_ENV=test dotenv_config_path=.env.test node ./node_modules/jest/bin/jest.js --runInBand --config jest.config.js",
+    "test": "NODE_ENV=test dotenv_config_path=.env.test node ./node_modules/jest/bin/jest.js --runInBand",
     "test:watch": "npm run test -- --watch",
-    "coverage": "cross-env NODE_ENV=test DISABLE_MP=true DOTENV_CONFIG_PATH=.env.test node --experimental-vm-modules -r dotenv/config ./node_modules/jest/bin/jest.js --coverage",
+    "coverage": "NODE_ENV=test DISABLE_MP=true DOTENV_CONFIG_PATH=.env.test node --experimental-vm-modules -r dotenv/config ./node_modules/jest/bin/jest.js --coverage",
     "test:api": "node ./tests/ping.js",
     "vercel:prepare": "node scripts/patch-vercel.js",
     "build:meta": "echo \"ok\"",
     "migrate": "dbmate up",
     "postinstall": "node scripts/maybe-migrate.cjs",
-    "test:ci": "cross-env NODE_ENV=test dotenv_config_path=.env.test node ./node_modules/jest/bin/jest.js --runInBand --reporters=default --ci",
+    "test:ci": "NODE_ENV=test dotenv_config_path=.env.test node ./node_modules/jest/bin/jest.js --runInBand --reporters=default --ci",
     "audit:dup": "node scripts/audit-duplicates.cjs"
   },
   "keywords": [],
@@ -35,7 +35,6 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "cross-env": "^7.0.3",
     "dbmate": "^2.0.0",
     "jest": "^29.7.0",
     "morgan": "^1.10.0",

--- a/server.js
+++ b/server.js
@@ -54,7 +54,17 @@ async function createApp() {
   app.set('trust proxy', 1);
 
   app.use(helmet());
-  app.use(cors({ origin: process.env.ALLOWED_ORIGIN?.split(',') || true }));
+  const defaultOrigins = ['http://localhost:5173', /\.netlify\.app$/];
+  const allowed = process.env.ALLOWED_ORIGIN?.split(',').filter(Boolean) || defaultOrigins;
+  app.use(
+    cors({
+      origin(origin, cb) {
+        if (!origin) return cb(null, true);
+        const ok = allowed.some((o) => (o instanceof RegExp ? o.test(origin) : o === origin));
+        return cb(ok ? null : new Error('Not allowed by CORS'), ok);
+      },
+    }),
+  );
   app.use(rateLimit({ windowMs: 60_000, max: 100 }));
   app.use(express.json());
 

--- a/src/features/assinaturas/assinatura.controller.js
+++ b/src/features/assinaturas/assinatura.controller.js
@@ -1,5 +1,10 @@
 const service = require('./assinatura.service.js');
-const supabase = require('../../../supabaseClient.js');
+let supabase;
+try {
+  ({ supabase } = require('config/supabase'));
+} catch (_e) {
+  ({ supabase } = require('../../../config/supabase'));
+}
 const { ZodError } = require('zod');
 
 const META = { version: 'v0.1.0' };

--- a/src/features/assinaturas/assinatura.repo.js
+++ b/src/features/assinaturas/assinatura.repo.js
@@ -1,4 +1,9 @@
-const supabase = require('../../../supabaseClient.js');
+let supabase;
+try {
+  ({ supabase } = require('config/supabase'));
+} catch (_e) {
+  ({ supabase } = require('../../../config/supabase'));
+}
 
 async function create(assinatura) {
   const { data, error } = await supabase

--- a/src/features/assinaturas/assinatura.routes.js
+++ b/src/features/assinaturas/assinatura.routes.js
@@ -1,1 +1,0 @@
-module.exports = require('./assinaturas.routes');

--- a/src/features/assinaturas/assinaturas.routes.js
+++ b/src/features/assinaturas/assinaturas.routes.js
@@ -1,8 +1,8 @@
 const express = require('express');
 const router = express.Router();
 const { create } = require('./assinatura.controller.js');
+const { requireAdminPin } = require('../../middlewares/adminPin.js');
 
-// permite chamadas com e sem prefixo /admin, em formas singular e plural
-router.post(['/', '/assinatura', '/assinaturas', '/admin/assinatura', '/admin/assinaturas'], create);
+router.post(['/admin/assinatura', '/admin/assinaturas'], requireAdminPin, create);
 
 module.exports = router;

--- a/src/features/clientes/cliente.controller.js
+++ b/src/features/clientes/cliente.controller.js
@@ -1,5 +1,10 @@
 const service = require('./cliente.service.js');
-const supabase = require('../../../supabaseClient.js');
+let supabase;
+try {
+  ({ supabase } = require('config/supabase'));
+} catch (_e) {
+  ({ supabase } = require('../../../config/supabase'));
+}
 const { ZodError } = require('zod');
 
 const META = { version: 'v0.1.0' };

--- a/src/features/clientes/cliente.repo.js
+++ b/src/features/clientes/cliente.repo.js
@@ -1,4 +1,9 @@
-const supabase = require('../../../supabaseClient.js');
+let supabase;
+try {
+  ({ supabase } = require('config/supabase'));
+} catch (_e) {
+  ({ supabase } = require('../../../config/supabase'));
+}
 
 async function findByEmail(email) {
   const { data, error } = await supabase

--- a/tests/assinatura-test-server.js
+++ b/tests/assinatura-test-server.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const routes = require('../src/features/assinaturas/assinatura.routes.js');
+const routes = require('../src/features/assinaturas/assinaturas.routes.js');
 const repo = require('../src/features/assinaturas/assinatura.repo.js');
 const clienteRepo = require('../src/features/clientes/cliente.repo.js');
 const { requireAdminPin } = require('../src/middlewares/adminPin.js');

--- a/utils/generateClientIds.js
+++ b/utils/generateClientIds.js
@@ -1,4 +1,9 @@
-const supabase = require('../supabaseClient');
+let supabase;
+try {
+  ({ supabase } = require('config/supabase'));
+} catch (_e) {
+  ({ supabase } = require('../config/supabase'));
+}
 const { gerarIdUnico } = require('./idGenerator');
 
 async function generateClientIds() {


### PR DESCRIPTION
## Summary
- add docs/AUDIT.md inventory of routes, services, env vars and CI
- tighten CORS defaults and lock signup routes behind admin PIN
- unify stable Supabase imports and trim duplicate files/scripts

## Testing
- `npm test` *(fails: Cannot find module '/workspace/clube-vantagens-api/node_modules/jest/bin/jest.js')*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68a90f83cc1c832ba6a1e31198a6f239