### PR TITLE
fix(ci): make Railway build deterministic (npm ci) and tighten env & CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ API em Node.js para gerenciamento de assinaturas, transações e administração
 | `SUPABASE_ANON` | Chave pública do Supabase |
 | `ADMIN_PIN` | PIN exigido em rotas administrativas (`x-admin-pin`) |
 | `PORT` | Porta do servidor (padrão 3000) |
-| `ALLOWED_ORIGIN` | Lista de origens CORS permitidas separadas por vírgula |
+| `ALLOWED_ORIGIN` | Lista de origens CORS permitidas separadas por vírgula (ex.: `https://site1.com,https://site2.com`). Use `*` para liberar todos os domínios; se omitida, CORS é desativado |
 | `RECAPTCHA_SECRET` | Chave do reCAPTCHA usada na captura de leads |
 | `MP_ACCESS_TOKEN` | Token de acesso do Mercado Pago |
 | `MP_COLLECTOR_ID` | ID do coletor Mercado Pago |
@@ -124,10 +124,37 @@ Este projeto utiliza [dbmate](https://github.com/amacneil/dbmate) para versionar
 - Durante o deploy, `npm install` aciona `npm run migrate` automaticamente.
 
 ## Deploy
-Resumo rápido; detalhes adicionais em [`README_DEPLOY.md`](README_DEPLOY.md).
-1. **Railway**: criar projeto a partir deste repositório e configurar as variáveis de ambiente.
-2. **Vercel**: importar o repositório, usar build `npm run vercel:prepare` e definir `RAILWAY_URL` e origens opcionais.
-3. **Mercado Pago**: definir `MP_ACCESS_TOKEN`, `MP_COLLECTOR_ID`, `MP_WEBHOOK_SECRET` e `APP_BASE_URL`; integrar rotas `/mp/*`.
+
+### Railway
+
+1. Crie um projeto no [Railway](https://railway.app/) a partir deste repositório.
+2. O build utiliza `npm ci` (ver `railway.json`), portanto o `package-lock.json` precisa estar versionado.
+3. Configure as variáveis de ambiente obrigatórias (`SUPABASE_URL`, `SUPABASE_ANON`, `ADMIN_PIN`, `DATABASE_URL` etc.) e defina `ALLOWED_ORIGIN` com as origens permitidas.
+4. Após o deploy, verifique `https://SEU-APP.up.railway.app/health` – a resposta deve ser `{ "ok": true }`.
+
+### Netlify
+
+Para consumir a API a partir do frontend hospedado na Netlify, adicione redirects no `netlify.toml`:
+
+```toml
+[[redirects]]
+from = "/api/*"
+to = "https://SEU-APP.up.railway.app/:splat"
+status = 200
+force = true
+
+[[redirects]]
+from = "/admin/*"
+to = "https://SEU-APP.up.railway.app/admin/:splat"
+status = 200
+force = true
+
+[[redirects]]
+from = "/planos/*"
+to = "https://SEU-APP.up.railway.app/planos/:splat"
+status = 200
+force = true
+```
 
 ```bash
 npm install

--- a/config/env.js
+++ b/config/env.js
@@ -11,7 +11,10 @@ const envSchema = z.object({
   MP_COLLECTOR_ID: z.string().optional(),
   MP_WEBHOOK_SECRET: z.string().optional(),
   APP_BASE_URL: z.string().url().optional(),
-  ALLOWED_ORIGIN: z.string().optional(),
+  ALLOWED_ORIGIN: z
+    .string()
+    .optional()
+    .transform(val => (val ? val.split(',').map(v => v.trim()).filter(Boolean) : undefined)),
   RECAPTCHA_SECRET: z.string().optional(),
   PORT: z.string().optional(),
   NODE_ENV: z.string().optional(),

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,18 @@ status = 200
 force = true
 
 [[redirects]]
+from = "/admin/*"
+to = "https://clube-vantagens-api-production.up.railway.app/admin/:splat"
+status = 200
+force = true
+
+[[redirects]]
+from = "/planos/*"
+to = "https://clube-vantagens-api-production.up.railway.app/planos/:splat"
+status = 200
+force = true
+
+[[redirects]]
 from = "/testar-cadastro"
 to = "/admin/cadastro"
 status = 301

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "node-fetch": "^2.7.0"
       },
       "devDependencies": {
-        "morgan": "^1.10.0",
         "nodemon": "^3.1.10"
       },
       "engines": {
@@ -902,36 +901,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/morgan": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
-      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "basic-auth": "~2.0.1",
-        "debug": "2.6.9",
-        "depd": "~2.0.0",
-        "on-finished": "~2.3.0",
-        "on-headers": "~1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/morgan/node_modules/on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "cross-env": "^7.0.3",
     "dbmate": "^2.0.0",
     "jest": "^29.7.0",
-    "morgan": "^1.10.0",
     "nodemon": "^3.1.10",
     "supertest": "^6.3.4"
   }

--- a/railway.json
+++ b/railway.json
@@ -1,6 +1,7 @@
 {
   "build": {
-    "builder": "NIXPACKS"
+    "builder": "NIXPACKS",
+    "installCommand": "npm ci"
   },
   "deploy": {
     "startCommand": "node server.js"

--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@
 // ================================
 
 const express = require('express');
-require('./config/env');
+const env = require('./config/env');
 
 function asRouter(mod) {
   const candidate = (mod && (mod.router || mod.default?.router || mod.default)) || mod;
@@ -51,10 +51,16 @@ async function createApp() {
   const errorHandler = require('./middlewares/errorHandler');
 
   const app = express();
-  app.set('trust proxy', 1);
-
-  app.use(helmet());
-  app.use(cors({ origin: process.env.ALLOWED_ORIGIN?.split(',') || true }));
+    app.set('trust proxy', 1);
+    app.use(helmet());
+    const allowedOrigins = env.ALLOWED_ORIGIN || [];
+    if (allowedOrigins.includes('*')) {
+      app.use(cors());
+    } else if (allowedOrigins.length > 0) {
+      app.use(cors({ origin: allowedOrigins }));
+    } else {
+      app.use(cors({ origin: false }));
+    }
   app.use(rateLimit({ windowMs: 60_000, max: 100 }));
   app.use(express.json());
 


### PR DESCRIPTION
## Summary
- ensure Railway uses `npm ci` for deterministic builds and remove unused `morgan`
- validate `ALLOWED_ORIGIN` as a comma-separated list and apply stricter CORS defaults
- document Railway deploy steps and add Netlify proxy examples for `/api`, `/admin`, and `/planos`

## Testing
- `npm install` *(fails: 403 Forbidden fetching cross-env)*
- `npm test` *(fails: sh: 1: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7f2c0e58832b837ea26c19714c0d