### PR TITLE
ci(fix): cache do npm + retentativas para evitar E429 no Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,16 @@ jobs:
         with:
           node-version: '22.x'
           cache: 'npm'
-      - name: Install dependencies
-        run: npm install --no-audit --no-fund
+          cache-dependency-path: package-lock.json
+      - name: Install deps (cached + retries)
+        env:
+          NPM_CONFIG_FETCH_RETRIES: 5
+          NPM_CONFIG_FETCH_RETRY_FACTOR: 2
+          NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: 20000
+          NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: 120000
+        run: |
+          npm install --no-audit --no-fund || \
+          npm install --no-audit --no-fund
       - name: Clear Jest cache
         run: node ./node_modules/jest/bin/jest.js --clearCache
       - name: Run tests


### PR DESCRIPTION
## Summary
- enable npm caching in setup-node with explicit dependency path
- add install step with retries to mitigate E429 errors

## Testing
- `npm install --no-audit --no-fund` (fails: 403 Forbidden - GET https://registry.npmjs.org/cross-env)
- `npm test` (fails: sh: 1: cross-env: not found)


------
https://chatgpt.com/codex/tasks/task_e_68ad8abb4758832ba1d504028ff6508f