### PR TITLE
chore(netlify): proxy /api /admin /planos -> Railway

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ Este projeto utiliza [dbmate](https://github.com/amacneil/dbmate) para versionar
 - Para aplicar migrações pendentes, execute `npm run migrate` (requer `DATABASE_URL`).
 - Durante o deploy, `npm install` aciona `npm run migrate` automaticamente.
 
+## Deploy/Infra
+
+- A API roda no Railway em: https://clube-vantagens-api-production.up.railway.app
+- O site no Netlify consome a API via os proxies de [`netlify.toml`](netlify.toml) usando caminhos relativos (`/api`, `/admin`, `/planos`).
+- Em desenvolvimento local, execute `npm run dev` (nodemon) e o front acessa `http://localhost:3000` diretamente.
+
 ## Deploy
 Resumo rápido; detalhes adicionais em [`README_DEPLOY.md`](README_DEPLOY.md).
 1. **Railway**: criar projeto a partir deste repositório e configurar as variáveis de ambiente.

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,11 +2,26 @@
   publish = "frontend"
   command = ""
 
+# --- Proxies para a API no Railway ---
+# API pública: https://clube-vantagens-api-production.up.railway.app
+
 [[redirects]]
 from = "/api/*"
-to = "https://clube-vantagens-api-production.up.railway.app/:splat"
+to   = "https://clube-vantagens-api-production.up.railway.app/:splat"
 status = 200
-force = true
+force  = true
+
+[[redirects]]
+from = "/admin/*"
+to   = "https://clube-vantagens-api-production.up.railway.app/:splat"
+status = 200
+force  = true
+
+[[redirects]]
+from = "/planos/*"
+to   = "https://clube-vantagens-api-production.up.railway.app/:splat"
+status = 200
+force  = true
 
 [[redirects]]
 from = "/testar-cadastro"


### PR DESCRIPTION
## Summary
- Add Netlify proxies for API, admin and plans endpoints to Railway
- Document Netlify proxy usage and development flow

## Testing
- ⚠️ `npm install` (403 Forbidden)
- ⚠️ `npm test` (cross-env: not found)


------
https://chatgpt.com/codex/tasks/task_e_68ada34abc64832b8bf165e1f9451bdf