### PR TITLE
feat(api): exigir PIN nas rotas de escrita de planos (GET público)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ API em Node.js para gerenciamento de assinaturas, transações e administração
 - `GET /health` – Health check da API.
 - `GET /assinaturas?cpf=<cpf>` – Consulta assinatura pelo CPF.
 - `GET /assinaturas/listar` – Lista todas as assinaturas.
+- `GET /planos` – Lista os planos disponíveis.
+- `POST /planos` – Cria plano (requer `x-admin-pin`).
+- `PUT /planos/:id` – Atualiza plano (requer `x-admin-pin`).
+- `DELETE /planos/:id` – Remove plano (requer `x-admin-pin`).
 - `POST /public/lead` – Captura leads do site público.
 - `GET /admin/clientes` – Lista clientes (requer `x-admin-pin`).
 - `GET /admin/metrics` – Resumo de métricas (requer `x-admin-pin`).

--- a/__tests__/planos.routes.test.js
+++ b/__tests__/planos.routes.test.js
@@ -19,6 +19,7 @@ app.use(planosRoutes);
 describe('Planos Routes', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env.ADMIN_PIN = '1234';
   });
 
   test('GET /planos - lista todos os planos', async () => {
@@ -31,7 +32,10 @@ describe('Planos Routes', () => {
   test('POST /planos - cria plano', async () => {
     const payload = { nome: 'A', descricao: 'desc', preco: 10 };
     planosService.createPlano.mockResolvedValue({ data: { id: 1, ...payload }, error: null });
-    const res = await request(app).post('/planos').send(payload);
+    const res = await request(app)
+      .post('/planos')
+      .set('x-admin-pin', '1234')
+      .send(payload);
     expect(res.status).toBe(201);
     expect(res.body).toEqual({ id: 1, ...payload });
     expect(planosService.createPlano).toHaveBeenCalledWith(payload);
@@ -40,7 +44,10 @@ describe('Planos Routes', () => {
   test('PUT /planos/:id - atualiza plano', async () => {
     const payload = { nome: 'B' };
     planosService.updatePlano.mockResolvedValue({ data: { id: '1', ...payload }, error: null });
-    const res = await request(app).put('/planos/1').send(payload);
+    const res = await request(app)
+      .put('/planos/1')
+      .set('x-admin-pin', '1234')
+      .send(payload);
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ id: '1', ...payload });
     expect(planosService.updatePlano).toHaveBeenCalledWith('1', payload);
@@ -48,7 +55,9 @@ describe('Planos Routes', () => {
 
   test('DELETE /planos/:id - remove plano', async () => {
     planosService.deletePlano.mockResolvedValue({ data: null, error: null });
-    const res = await request(app).delete('/planos/1');
+    const res = await request(app)
+      .delete('/planos/1')
+      .set('x-admin-pin', '1234');
     expect(res.status).toBe(204);
     expect(planosService.deletePlano).toHaveBeenCalledWith('1');
   });

--- a/src/features/planos/planos.routes.js
+++ b/src/features/planos/planos.routes.js
@@ -1,10 +1,11 @@
 const router = require('express').Router();
 const ctrl = require('./planos.controller');
+const { requireAdminPin } = require('../../middlewares/adminPin');
 
 router.get('/planos', ctrl.listarPlanos);
 router.get('/planos/:id', ctrl.obterPlano);
-router.post('/planos', ctrl.criarPlano);
-router.put('/planos/:id', ctrl.atualizarPlano);
-router.delete('/planos/:id', ctrl.removerPlano);
+router.post('/planos', requireAdminPin, ctrl.criarPlano);
+router.put('/planos/:id', requireAdminPin, ctrl.atualizarPlano);
+router.delete('/planos/:id', requireAdminPin, ctrl.removerPlano);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- require admin PIN for POST/PUT/DELETE /planos
- cover plans router with tests using x-admin-pin
- document admin PIN requirement for write operations in README

## Testing
- `npm test` *(fails: cross-env not found)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cross-env)*

------
https://chatgpt.com/codex/tasks/task_e_68ada78ca9f0832b983d79128bc0e547