### PR TITLE
chore(netlify): garantir proxies p/ Railway e atualizar docs/links

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,27 @@ Este projeto utiliza [dbmate](https://github.com/amacneil/dbmate) para versionar
 - O site no Netlify consome a API via os proxies de [`netlify.toml`](netlify.toml) usando caminhos relativos (`/api`, `/admin`, `/planos`).
 - Em desenvolvimento local, execute `npm run dev` (nodemon) e o front acessa `http://localhost:3000` diretamente.
 
+## Como testar pelo Netlify (proxy p/ Railway)
+
+Use o site publicado no Netlify para alcançar a API do Railway por meio dos proxies definidos em `netlify.toml`.
+
+```bash
+# Health check
+curl https://clube-vantagens-gng.netlify.app/api/health
+
+# Listar planos
+curl https://clube-vantagens-gng.netlify.app/planos
+
+# Criar plano (requer cabeçalho x-admin-pin)
+curl -X POST https://clube-vantagens-gng.netlify.app/planos \
+  -H "Content-Type: application/json" \
+  -H "x-admin-pin: SEU_PIN" \
+  -d '{"nome":"netlify-demo","preco_centavos":1234}'
+
+# Confirmar criação
+curl https://clube-vantagens-gng.netlify.app/planos
+```
+
 ## Deploy
 Resumo rápido; detalhes adicionais em [`README_DEPLOY.md`](README_DEPLOY.md).
 1. **Railway**: criar projeto a partir deste repositório e configurar as variáveis de ambiente.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,6 +12,7 @@
       <h1>Clube de Vantagens</h1>
       <p class="sub">Protótipo do frontend.</p>
       <div class="actions">
+        <a href="/painel.html"><button>Abrir painel</button></a>
         <a href="/testar-cadastro.html"><button class="secondary">Testar cadastro</button></a>
       </div>
     </div>

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,13 +13,13 @@ force  = true
 
 [[redirects]]
 from = "/admin/*"
-to   = "https://clube-vantagens-api-production.up.railway.app/:splat"
+to   = "https://clube-vantagens-api-production.up.railway.app/admin/:splat"
 status = 200
 force  = true
 
 [[redirects]]
 from = "/planos/*"
-to   = "https://clube-vantagens-api-production.up.railway.app/:splat"
+to   = "https://clube-vantagens-api-production.up.railway.app/planos/:splat"
 status = 200
 force  = true
 


### PR DESCRIPTION
## Summary
- adjust Netlify proxies for /admin and /planos to hit Railway API
- document how to test API via Netlify proxy
- add navigation buttons for painel and cadastro on homepage

## Testing
- `npm run build` *(fails: Missing script: "build")*
- `npm test` *(fails: cross-env not found; npm install forbidden: 403)*
- `curl -i https://clube-vantagens-gng.netlify.app/api/health` *(403 Forbidden: CONNECT tunnel failed)*
- `curl -i https://clube-vantagens-gng.netlify.app/planos` *(403 Forbidden: CONNECT tunnel failed)*
- `curl -i -X POST https://clube-vantagens-gng.netlify.app/planos -H "Content-Type: application/json" -H "x-admin-pin: 1234" -d '{"nome":"netlify-demo-123","preco_centavos":1234}'` *(403 Forbidden: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68adbf45a748832bba3dfd90fb92b407