### PR TITLE
chore(netlify): enable /planos rewrite (no /api) + prioritize before catch-all

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,18 +138,12 @@ Este projeto utiliza [dbmate](https://github.com/amacneil/dbmate) para versionar
 ```bash
 BASE=https://clube-vantagens-gng.netlify.app
 PIN=2468
+curl -i "$BASE/planos"
+curl -i -X POST "$BASE/planos" -H "x-admin-pin: $PIN" -H "Content-Type: application/json" \
+  -d '{"nome":"SMOKE-BLOCK","descricao":"via netlify","preco":1111}'
 
 # Saúde (via proxy)
 curl -i "$BASE/api/health"
-
-# Planos – lista
-curl -i "$BASE/planos"
-
-# Planos – cria
-curl -i -X POST "$BASE/planos" \
-  -H "x-admin-pin: $PIN" \
-  -H "Content-Type: application/json" \
-  -d '{"nome":"SMOKE-BLOCK","descricao":"via netlify","preco":1111}'
 
 # Com o ID retornado no POST:
 curl -i -X PUT "$BASE/planos/<ID>" \

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,10 +2,7 @@
   publish = "frontend"
   command = ""
 
-# --- Proxies para a API no Railway ---
-# API pública: https://clube-vantagens-api-production.up.railway.app
-
-# atalhos sem /api
+# --- atalhos sem /api (precisam vir antes de qualquer wildcard /*) ---
 [[redirects]]
 from = "/planos"
 to   = "/api/planos"
@@ -24,7 +21,7 @@ to   = "/api/planos/:splat"
 status = 200
 force = true
 
-# proxy geral da API
+# proxy da API na Railway (manter)
 [[redirects]]
 from = "/api/*"
 to   = "https://clube-vantagens-api-production.up.railway.app/:splat"
@@ -41,3 +38,9 @@ force  = true
 from = "/testar-cadastro"
 to = "/admin/cadastro"
 status = 301
+
+# QUALQUER catch-all fica POR ÚLTIMO
+# [[redirects]]
+#   from = "/*"
+#   to   = "/index.html"
+#   status = 200


### PR DESCRIPTION
## Summary
- ensure Netlify redirects for `/planos`, `/planos/` and `/planos/*` come before any wildcard catch-all
- document curl examples for testing `/planos` via Netlify proxy

## Testing
- `npm test` *(fails: cross-env: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cross-env)*

------
https://chatgpt.com/codex/tasks/task_e_68aded7f602c832bbadd91f786b34857