### PR TITLE
netlify: route /planos and /planos/* to Railway (add 301 for trailing slash)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,42 +2,37 @@
   publish = "frontend"
   command = ""
 
-# --- atalhos sem /api (precisam vir antes de qualquer wildcard /*) ---
+# proxy da API na Railway
 [[redirects]]
-from = "/planos"
-to   = "/api/planos"
-status = 200
-force = true
+  from = "/api/*"
+  to = "https://clube-vantagens-api-production.up.railway.app/:splat"
+  status = 200
+  force = true
 
 [[redirects]]
-from = "/planos/"
-to   = "/api/planos"
-status = 200
-force = true
+  from = "/admin/*"
+  to = "https://clube-vantagens-api-production.up.railway.app/admin/:splat"
+  status = 200
+  force = true
+
+# cobre a URL sem barra final
+[[redirects]]
+  from = "/planos"
+  to = "/planos/"
+  status = 301
+  force = true
+
+# encaminha para a API no Railway
+[[redirects]]
+  from = "/planos/*"
+  to = "https://clube-vantagens-api-production.up.railway.app/planos/:splat"
+  status = 200
+  force = true
 
 [[redirects]]
-from = "/planos/*"
-to   = "/api/planos/:splat"
-status = 200
-force = true
-
-# proxy da API na Railway (manter)
-[[redirects]]
-from = "/api/*"
-to   = "https://clube-vantagens-api-production.up.railway.app/:splat"
-status = 200
-force  = true
-
-[[redirects]]
-from = "/admin/*"
-to   = "https://clube-vantagens-api-production.up.railway.app/admin/:splat"
-status = 200
-force  = true
-
-[[redirects]]
-from = "/testar-cadastro"
-to = "/admin/cadastro"
-status = 301
+  from = "/testar-cadastro"
+  to = "/admin/cadastro"
+  status = 301
 
 # QUALQUER catch-all fica POR ÚLTIMO
 # [[redirects]]


### PR DESCRIPTION
## Summary
- proxy `/api/*` and `/admin/*` to Railway
- redirect `/planos` to `/planos/` then forward `/planos/*` to Railway

## Testing
- `npm test` *(fails: cross-env: not found)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cross-env)*

------
https://chatgpt.com/codex/tasks/task_e_68adfa4db880832bb9654ebddc761f98