### PR TITLE
feat: add Netlify redirects for planos page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -15,12 +15,16 @@
   status = 200
   force = true
 
-# cobre a URL sem barra final
+# rewrites para a página de planos
 [[redirects]]
   from = "/planos"
-  to = "/planos/"
-  status = 301
-  force = true
+  to = "/admin/planos.html"
+  status = 200
+
+[[redirects]]
+  from = "/planos/"
+  to = "/admin/planos.html"
+  status = 200
 
 # encaminha para a API no Railway
 [[redirects]]


### PR DESCRIPTION
## Summary
- rewrite /planos and /planos/ to /admin/planos.html in Netlify config

## Testing
- `npm test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1c0eeff8832b90b499dbfdb9cb80