### PR TITLE
chore(netlify): serve planos page via rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,17 @@ Este projeto utiliza [dbmate](https://github.com/amacneil/dbmate) para versionar
 
 ## Testes via Netlify (proxy)
 
+Para conferir que as reescritas funcionam e que os proxies seguem ativos:
+
+```bash
+curl -I https://clube-vantagens-gng.netlify.app/planos
+curl -I https://clube-vantagens-gng.netlify.app/planos/
+curl -i https://clube-vantagens-gng.netlify.app/api/health
+```
+
+As duas primeiras chamadas devem retornar **200** com conteúdo HTML. O health
+check `/api/health` também deve responder **200** via proxy.
+
 ```bash
 BASE=https://clube-vantagens-gng.netlify.app
 PIN=2468

--- a/frontend/admin/planos.html
+++ b/frontend/admin/planos.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <title>Planos (Admin)</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+<header>
+  <nav>
+    <a href="/">Dashboard</a>
+    <a href="/admin/cadastro.html">Clientes &gt; Novo</a>
+    <a href="/admin/assinatura.html">Assinaturas</a>
+    <a href="/deploy-check.html">Status/Health</a>
+  </nav>
+  <div><label>PIN <input type="password" class="pin-input" /></label></div>
+</header>
+<main class="container">
+  <div class="card">
+    <h1>Planos (Admin)</h1>
+    <p>placeholder</p>
+  </div>
+</main>
+</body>
+</html>

--- a/frontend/netlify.toml
+++ b/frontend/netlify.toml
@@ -1,0 +1,43 @@
+# proxy da API na Railway
+[[redirects]]
+  from = "/api/*"
+  to = "https://clube-vantagens-api-production.up.railway.app/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/admin/*"
+  to = "https://clube-vantagens-api-production.up.railway.app/admin/:splat"
+  status = 200
+  force = true
+
+# rewrites para a página de planos
+[[redirects]]
+  from = "/planos"
+  to = "/admin/planos.html"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/planos/"
+  to = "/admin/planos.html"
+  status = 200
+  force = true
+
+# encaminha para a API no Railway
+[[redirects]]
+  from = "/planos/*"
+  to = "https://clube-vantagens-api-production.up.railway.app/planos/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/testar-cadastro"
+  to = "/admin/cadastro"
+  status = 301
+
+# QUALQUER catch-all fica POR ÚLTIMO
+# [[redirects]]
+#   from = "/*"
+#   to   = "/index.html"
+#   status = 200


### PR DESCRIPTION
## Summary
- add Netlify redirects so `/planos` and `/planos/` serve `admin/planos.html`
- keep existing `/api/*` and `/admin/*` proxies
- add placeholder `frontend/admin/planos.html`
- document curl checks in README

## Testing
- `npm test` *(fails: cross-env: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cross-env)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1dae0270832bb8846cb620891d93