### PR TITLE
fix(api): mount /planos routes; public GET and PIN-protected writes

### DIFF
--- a/__tests__/planos.routes.test.js
+++ b/__tests__/planos.routes.test.js
@@ -40,6 +40,23 @@ describe('Planos Routes', () => {
       expect(planosService.create).toHaveBeenCalledWith(payload);
     });
 
+  test('POST /planos sem PIN retorna 401', async () => {
+      const payload = { nome: 'A' };
+      const res = await request(app).post('/planos').send(payload);
+      expect(res.status).toBe(401);
+      expect(planosService.create).not.toHaveBeenCalled();
+    });
+
+  test('POST /planos com PIN inválido retorna 403', async () => {
+      const payload = { nome: 'A' };
+      const res = await request(app)
+        .post('/planos')
+        .set('x-admin-pin', '0000')
+        .send(payload);
+      expect(res.status).toBe(403);
+      expect(planosService.create).not.toHaveBeenCalled();
+    });
+
   test('PUT /planos/:id - atualiza plano', async () => {
       const payload = { nome: 'B' };
       planosService.update.mockResolvedValue({ data: { id: '1', ...payload }, error: null });

--- a/server.js
+++ b/server.js
@@ -44,8 +44,8 @@ async function createApp() {
   const { requireAdminPin } = require('./src/middlewares/adminPin');
 
   // Features (CommonJS)
-  const assinaturaFeatureRoutes = asRouter(require('./src/features/assinaturas/assinaturas.routes'));
-  const planosRouter = require('./src/features/planos/planos.routes');
+  const assinaturaFeatureRoutes = asRouter(require('./src/features/assinaturas/assinaturas.routes.js'));
+  const planosRouter = require('./src/features/planos/planos.routes.js');
 
   // Error handler
   const errorHandler = require('./middlewares/errorHandler');

--- a/src/features/planos/planos.routes.js
+++ b/src/features/planos/planos.routes.js
@@ -3,7 +3,10 @@ const router = express.Router();
 const { requireAdminPin } = require('../../middlewares/requireAdminPin.js');
 const ctrl = require('./planos.controller.js');
 
+// público
 router.get('/', ctrl.getAll);
+
+// protegidas
 router.post('/', requireAdminPin, ctrl.create);
 router.put('/:id', requireAdminPin, ctrl.update);
 router.delete('/:id', requireAdminPin, ctrl.remove);

--- a/src/middlewares/adminPin.js
+++ b/src/middlewares/adminPin.js
@@ -16,8 +16,11 @@ function requireAdminPin(req, res, next) {
   if (!expected) {
     return res.status(503).json({ ok: false, error: 'ADMIN_PIN ausente no servidor', meta: META });
   }
+  if (!provided) {
+    return res.status(401).json({ ok: false, error: 'PIN ausente', meta: META });
+  }
   if (provided !== expected) {
-    return res.status(401).json({ ok: false, error: 'PIN inválido', meta: META });
+    return res.status(403).json({ ok: false, error: 'PIN inválido', meta: META });
   }
   return next();
 }


### PR DESCRIPTION
## Summary
- ensure plan routes expose public GET and PIN-protected writes
- harden admin PIN middleware with 401/403 responses
- test plan routes for missing or invalid PIN

## Testing
- `npm test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae343be324832b8f606c2a57b8fe15