### PR TITLE
fix(api): mount /planos across envs and add /__routes debug endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -84,23 +84,21 @@ async function createApp() {
 
   app.get('/__routes', (req, res) => {
     const list = [];
-    app._router.stack.forEach((layer) => {
+    const stack = (app._router && app._router.stack) || [];
+    for (const layer of stack) {
       if (layer.route && layer.route.path) {
-        const methods = Object.keys(layer.route.methods).filter(Boolean);
-        list.push({ path: layer.route.path, methods });
-      } else if (layer.name === 'router' && layer.handle.stack) {
-        layer.handle.stack.forEach((s) => {
+        const methods = Object.keys(layer.route.methods || {});
+        list.push({ base: '', path: layer.route.path, methods });
+      } else if (layer.name === 'router' && layer.handle && layer.handle.stack) {
+        const base = layer.regexp && layer.regexp.fast_star ? '*' : '';
+        for (const s of layer.handle.stack) {
           if (s.route && s.route.path) {
-            const methods = Object.keys(s.route.methods).filter(Boolean);
-            // base path
-            const base = layer.regexp && layer.regexp.fast_star
-              ? '*'
-              : (layer.regexp && layer.regexp.toString()) || '';
+            const methods = Object.keys(s.route.methods || {});
             list.push({ base, path: s.route.path, methods });
           }
-        });
+        }
       }
-    });
+    }
     res.json({ ok: true, routes: list });
   });
 


### PR DESCRIPTION
## Summary
- mount `/planos` router with JSON parsing enabled before other routes
- add `/__routes` endpoint to list all registered routes for debugging

## Testing
- `npm test` *(fails: cross-env not found)*
- `npm install` *(fails: 403 Forbidden fetching cross-env)*

------
https://chatgpt.com/codex/tasks/task_e_68ae39b5db18832bb1dbca17c7746738