### PR TITLE
feat(api): add route diagnostics and robust planos wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ curl http://localhost:3000/admin/clientes \
   -H "x-admin-pin: SEU_PIN"
 ```
 
+## Debug de rotas
+- `GET /__routes` – lista de rotas.
+
+Verificação rápida com curl:
+
+```bash
+curl -i $API/planos
+curl -i $API/api/planos
+```
+
 ## Páginas Administrativas (`public/`)
 A API expõe páginas estáticas acessíveis diretamente pelo navegador:
 

--- a/src/features/planos/planos.routes.js
+++ b/src/features/planos/planos.routes.js
@@ -1,10 +1,14 @@
 const express = require('express');
+// Router exportado via CommonJS
 const { requireAdminPin } = require('../../middlewares/requireAdminPin.js');
 const ctrl = require('./planos.controller.js');
 
 const router = express.Router();
 
-// GET público
+// rota pública mínima apenas para teste de wiring
+router.get('/__debug', (_req, res) => res.json({ ok: true, itens: [] }));
+
+// GET público real
 router.get('/', ctrl.getAll);
 
 // admin com PIN
@@ -12,4 +16,5 @@ router.post('/', requireAdminPin, ctrl.create);
 router.put('/:id', requireAdminPin, ctrl.update);
 router.delete('/:id', requireAdminPin, ctrl.remove);
 
+// exporta o router de forma inequívoca
 module.exports = router;


### PR DESCRIPTION
## Summary
- import `planos` router with CommonJS and error logging
- mount `/planos` and `/api/planos` before static assets
- expose `/__routes` debug endpoint and document route debugging

## Testing
- `npm test` *(fails: sh: 1: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeda25a148832bb5a2ffef865bff68