### PR TITLE
feat: add admin client creation with PIN guard

### DIFF
--- a/controllers/clientesController.js
+++ b/controllers/clientesController.js
@@ -2,6 +2,31 @@ const supabase = require('../supabaseClient');
 const { assertSupabase } = supabase;
 const generateClientIds = require('../utils/generateClientIds');
 
+async function createCliente(req, res) {
+  try {
+    const { nome, email, telefone } = req.body || {};
+    if (!nome || !email) {
+      return res.status(400).json({ ok: false, error: 'missing_fields' });
+    }
+
+    const { data, error } = await supabase
+      .from('clientes')
+      .insert([{ nome, email, telefone }])
+      .select()
+      .single();
+
+    if (error) {
+      return res.status(500).json({ ok: false, error: error.message });
+    }
+
+    return res.status(201).json({ ok: true, cliente: data });
+  } catch (e) {
+    return res.status(500).json({ ok: false, error: e.message });
+  }
+}
+
+exports.createCliente = createCliente;
+
 function sanitizeCpf(s = '') {
   return (s.match(/\d/g) || []).join('');
 }

--- a/middlewares/requireAdminPin.js
+++ b/middlewares/requireAdminPin.js
@@ -1,0 +1,11 @@
+function requireAdminPin(req, res, next) {
+  const pinQuery = (req.query.pin || '').toString();
+  const pinHeader = (req.headers['x-admin-pin'] || '').toString();
+  const pin = pinQuery || pinHeader;
+
+  if (!process.env.ADMIN_PIN || pin !== process.env.ADMIN_PIN) {
+    return res.status(401).json({ ok: false, error: 'invalid_pin' });
+  }
+  return next();
+}
+module.exports = { requireAdminPin };

--- a/public/admin/content.js
+++ b/public/admin/content.js
@@ -1,25 +1,30 @@
-document.addEventListener('DOMContentLoaded', () => {
+(function () {
   const form = document.getElementById('cadastro-form');
+  const pinInput = document.getElementById('pin');
+
+  if (!form) return;
+
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
-    const pin = document.getElementById('pin').value.trim();
+    const pin = (pinInput?.value || '2468').trim();
     const nome = document.getElementById('nome').value.trim();
     const email = document.getElementById('email').value.trim();
     const telefone = document.getElementById('telefone').value.trim();
+
     try {
-      const res = await fetch('/admin/clientes?pin=' + encodeURIComponent(pin), {
+      const resp = await fetch(`/admin/clientes?pin=${encodeURIComponent(pin)}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ nome, email, telefone })
       });
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        throw new Error(err.error || 'Erro ao cadastrar');
-      }
+
+      const json = await resp.json().catch(() => ({}));
+      if (!resp.ok || !json.ok) throw new Error(json.error || `HTTP ${resp.status}`);
+
       alert('Cliente cadastrado com sucesso!');
       form.reset();
     } catch (err) {
-      alert('Erro: ' + err.message);
+      alert(`Erro ao cadastrar: ${err.message}`);
     }
   });
-});
+})();

--- a/routes/admin.routes.js
+++ b/routes/admin.routes.js
@@ -1,0 +1,7 @@
+const router = require('express').Router();
+const { createCliente } = require('../controllers/clientesController');
+
+// POST /admin/clientes → cria cliente
+router.post('/clientes', createCliente);
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -1,8 +1,8 @@
 // server.js
 const express = require('express');
 const path = require('path');
-const { requireAdminPin } = require('./src/middlewares/requireAdminPin');
-const adminRoutes = require('./src/routes/admin');
+const { requireAdminPin } = require('./middlewares/requireAdminPin');
+const adminRoutes = require('./routes/admin.routes');
 
 const app = express();
 app.use(express.json());
@@ -30,7 +30,7 @@ const planosRouter = require('./src/features/planos/planos.routes.js');
 app.use('/planos', planosRouter);
 app.use('/api/planos', planosRouter);
 
-// ===== Rotas administrativas =====
+// ===== Rotas ADMIN (com PIN) =====
 app.use('/admin', requireAdminPin, adminRoutes);
 
 // ===== (/__routes) debug opcional e protegido =====


### PR DESCRIPTION
## Summary
- add requireAdminPin middleware accepting query or header
- create clientesController with Supabase insert
- expose POST /admin/clientes and mount before static assets
- wire admin cadastro form to submit via fetch with default PIN

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b24bd11000832b8b52a4b44486eec0