### PR TITLE
Fix Supabase client and secure admin client creation

### DIFF
--- a/__tests__/smoke.test.js
+++ b/__tests__/smoke.test.js
@@ -1,0 +1,46 @@
+process.env.NODE_ENV = 'test';
+process.env.ADMIN_PIN = '2468';
+
+jest.mock('../supabaseClient', () => {
+  const single = jest.fn().mockResolvedValue({ data: { id: 1, nome: 'John', email: 'john@example.com' }, error: null });
+  const select = jest.fn(() => ({ single }));
+  const insert = jest.fn(() => ({ select }));
+  const from = jest.fn(() => ({ insert }));
+  return { supabase: { from }, assertSupabase: () => true };
+});
+
+const request = require('supertest');
+const app = require('../server');
+
+describe('basic API smoke', () => {
+  test('/health', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  test('/planos', async () => {
+    const res = await request(app).get('/planos');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  describe('/admin/clientes', () => {
+    test('rejects without PIN', async () => {
+      const res = await request(app)
+        .post('/admin/clientes')
+        .send({ nome: 'John', email: 'john@example.com' });
+      expect(res.status).toBe(401);
+    });
+
+    test('creates with PIN', async () => {
+      const res = await request(app)
+        .post('/admin/clientes')
+        .set('x-admin-pin', '2468')
+        .send({ nome: 'John', email: 'john@example.com' });
+      expect(res.status).toBe(201);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.cliente).toBeTruthy();
+    });
+  });
+});

--- a/config/supabase.js
+++ b/config/supabase.js
@@ -1,2 +1,2 @@
-const supabase = require('../supabaseClient.js');
-module.exports = { supabase };
+const { supabase, assertSupabase } = require('../supabaseClient.js');
+module.exports = { supabase, assertSupabase };

--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -1,5 +1,4 @@
-const supabase = require('../supabaseClient');
-const { assertSupabase } = supabase;
+const { supabase, assertSupabase } = require('../supabaseClient');
 const generateClientIds = require('../utils/generateClientIds');
 
 function sanitizeCpf(s = '') {

--- a/controllers/assinaturaController.js
+++ b/controllers/assinaturaController.js
@@ -1,5 +1,4 @@
-const supabase = require('../supabaseClient');
-const { assertSupabase } = supabase;
+const { supabase, assertSupabase } = require('../supabaseClient');
 
 exports.consultarPorIdentificador = async (req, res, next) => {
   if (!assertSupabase(res)) return;

--- a/controllers/clientesController.js
+++ b/controllers/clientesController.js
@@ -1,41 +1,26 @@
 // controllers/clientesController.js
 
-// Importa corretamente a instância do cliente Supabase.
-// Antes: const supabase = require('../supabaseClient'); (incorreto)
-// Agora: desestrutura a instância e (opcional) o helper assertSupabase.
-const { supabase, assertSupabase: _assertSupabase } = require('../supabaseClient');
-
-// Fallback: se o módulo não exportar assertSupabase, usamos um no-op que sempre "passa".
-const assertSupabase = typeof _assertSupabase === 'function'
-  ? _assertSupabase
-  : () => true;
+const { supabase, assertSupabase } = require('../supabaseClient');
 
 const generateClientIds = require('../utils/generateClientIds');
 
 // ====== Create (cadastro simples via admin) ======
-async function createCliente(req, res) {
+exports.createCliente = async (req, res) => {
   try {
     const { nome, email, telefone } = req.body || {};
-    if (!nome || !email) {
-      return res.status(400).json({ ok: false, error: 'missing_fields' });
-    }
-
+    if (!nome || !email) return res.status(400).json({ ok: false, error: 'missing_fields' });
+    if (!assertSupabase(res)) return;
     const { data, error } = await supabase
       .from('clientes')
       .insert([{ nome, email, telefone }])
       .select()
       .single();
-
-    if (error) {
-      return res.status(500).json({ ok: false, error: error.message });
-    }
-
+    if (error) return res.status(500).json({ ok: false, error: error.message });
     return res.status(201).json({ ok: true, cliente: data });
   } catch (e) {
     return res.status(500).json({ ok: false, error: e.message });
   }
-}
-exports.createCliente = createCliente;
+};
 
 // == Utils ==
 function sanitizeCpf(s = '') {

--- a/controllers/leadController.js
+++ b/controllers/leadController.js
@@ -1,5 +1,4 @@
-const supabase = require('../supabaseClient');
-const { assertSupabase } = supabase;
+const { supabase, assertSupabase } = require('../supabaseClient');
 const PLANOS = new Set(['Mensal', 'Semestral', 'Anual']);
 const onlyDigits = s => (String(s||'').match(/\d/g) || []).join('');
 function isEmail(s){ return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(s||'')); }

--- a/controllers/metricsController.js
+++ b/controllers/metricsController.js
@@ -1,5 +1,4 @@
-const supabase = require('../supabaseClient');
-const { assertSupabase } = supabase;
+const { supabase, assertSupabase } = require('../supabaseClient');
 const { periodFromQuery, iso, aggregate } = require('../services/transacoesMetrics');
 
 exports.resume = async (req, res, next) => {

--- a/controllers/mpController.js
+++ b/controllers/mpController.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const MP = require('mercadopago');
-const supabase = require('../supabaseClient');
-const { assertSupabase } = supabase;
+const { supabase, assertSupabase } = require('../supabaseClient');
 
 const logError = (...args) => { if (process.env.NODE_ENV !== 'test') console.error(...args); };
 

--- a/controllers/reportController.js
+++ b/controllers/reportController.js
@@ -1,5 +1,4 @@
-const supabase = require('../supabaseClient');
-const { assertSupabase } = supabase;
+const { supabase, assertSupabase } = require('../supabaseClient');
 const { periodFromQuery, iso, aggregate } = require('../services/transacoesMetrics');
 
 exports.resumo = async (req, res, next) => {

--- a/controllers/statusController.js
+++ b/controllers/statusController.js
@@ -1,5 +1,4 @@
-const supabase = require('../supabaseClient');
-const { assertSupabase } = supabase;
+const { supabase, assertSupabase } = require('../supabaseClient');
 
 exports.info = async (req, res) => {
   res.json({

--- a/controllers/transacaoController.js
+++ b/controllers/transacaoController.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const router = express.Router();
-const supabase = require('../supabaseClient');
-const { assertSupabase } = supabase;
+const { supabase, assertSupabase } = require('../supabaseClient');
 const { z } = require('zod');
 
 function parseValor(str) {

--- a/middlewares/requireAdminPin.js
+++ b/middlewares/requireAdminPin.js
@@ -1,11 +1,8 @@
 function requireAdminPin(req, res, next) {
-  const pinQuery = (req.query.pin || '').toString();
-  const pinHeader = (req.headers['x-admin-pin'] || '').toString();
-  const pin = pinQuery || pinHeader;
-
+  const pin = ((req.query.pin || '') || (req.headers['x-admin-pin'] || '')).toString();
   if (!process.env.ADMIN_PIN || pin !== process.env.ADMIN_PIN) {
     return res.status(401).json({ ok: false, error: 'invalid_pin' });
   }
-  return next();
+  next();
 }
 module.exports = { requireAdminPin };

--- a/server.js
+++ b/server.js
@@ -3,9 +3,18 @@ const express = require('express');
 const path = require('path');
 const { requireAdminPin } = require('./middlewares/requireAdminPin');
 const adminRoutes = require('./routes/admin.routes');
+const cors = require('cors');
 
 const app = express();
 app.use(express.json());
+const allowed = process.env.ALLOWED_ORIGIN || '*';
+app.use(
+  cors({
+    origin: allowed,
+    credentials: true,
+    allowedHeaders: ['Content-Type', 'x-admin-pin'],
+  })
+);
 
 // ===== Boot marker (diagnóstico de boot) =====
 const COMMIT_SHA =

--- a/src/controllers/clientesController.js
+++ b/src/controllers/clientesController.js
@@ -1,10 +1,11 @@
-const supabase = require('../../supabaseClient');
+const { supabase, assertSupabase } = require('../../supabaseClient');
 
 async function createCliente(req, res) {
   const { nome, email, telefone } = req.body || {};
   if (!nome || !email) {
     return res.status(400).json({ ok: false, error: 'nome e email são obrigatórios' });
   }
+  if (!assertSupabase(res)) return;
   try {
     const { data, error } = await supabase
       .from('clientes')

--- a/src/features/assinaturas/assinatura.controller.js
+++ b/src/features/assinaturas/assinatura.controller.js
@@ -1,14 +1,11 @@
 const service = require('./assinatura.service.js');
-const supabase = require('../../../supabaseClient.js');
+const { supabase, assertSupabase } = require('../../../supabaseClient.js');
 const { ZodError } = require('zod');
 
 const META = { version: 'v0.1.0' };
 
 async function create(req, res) {
-  if (typeof supabase.assertSupabase === 'function') {
-    const ok = supabase.assertSupabase(res);
-    if (!ok) return;
-  }
+  if (!assertSupabase(res)) return;
   try {
     const assinatura = await service.createAssinatura(req.body, { supabase });
     return res.status(201).json({ ok: true, data: assinatura, meta: META });

--- a/src/features/assinaturas/assinatura.repo.js
+++ b/src/features/assinaturas/assinatura.repo.js
@@ -1,4 +1,4 @@
-const supabase = require('../../../supabaseClient.js');
+const { supabase } = require('../../../supabaseClient.js');
 
 async function create(assinatura) {
   const { data, error } = await supabase

--- a/src/features/clientes/cliente.controller.js
+++ b/src/features/clientes/cliente.controller.js
@@ -1,11 +1,11 @@
 const service = require('./cliente.service.js');
-const supabase = require('../../../supabaseClient.js');
+const { supabase, assertSupabase } = require('../../../supabaseClient.js');
 const { ZodError } = require('zod');
 
 const META = { version: 'v0.1.0' };
 
 async function create(req, res) {
-  if (supabase.assertSupabase && !supabase.assertSupabase(res)) return;
+  if (!assertSupabase(res)) return;
   try {
     const cliente = await service.createCliente(req.body);
     res.status(201).json({ ok: true, data: cliente, meta: META });

--- a/src/features/clientes/cliente.repo.js
+++ b/src/features/clientes/cliente.repo.js
@@ -1,4 +1,4 @@
-const supabase = require('../../../supabaseClient.js');
+const { supabase } = require('../../../supabaseClient.js');
 
 async function findByEmail(email) {
   const { data, error } = await supabase

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,2 +1,2 @@
-const supabase = require("../../supabaseClient.js");
-module.exports = supabase;
+const { supabase, assertSupabase } = require("../../supabaseClient.js");
+module.exports = { supabase, assertSupabase };

--- a/tests/assinaturas.test.js
+++ b/tests/assinaturas.test.js
@@ -2,11 +2,11 @@ const request = require('supertest');
 const express = require('express');
 
 jest.mock('../supabaseClient', () => ({
-  from: jest.fn(),
+  supabase: { from: jest.fn() },
   assertSupabase: () => true,
 }));
 
-const supabase = require('../supabaseClient');
+const { supabase } = require('../supabaseClient');
 const assinaturaController = require('../controllers/assinaturaController');
 
 const app = express();

--- a/tests/clientes.test.js
+++ b/tests/clientes.test.js
@@ -2,13 +2,13 @@ const request = require('supertest');
 const express = require('express');
 
 jest.mock('../supabaseClient', () => ({
-  from: jest.fn(),
+  supabase: { from: jest.fn() },
   assertSupabase: () => true,
 }));
 
 jest.mock('../utils/generateClientIds', () => jest.fn());
 
-const supabase = require('../supabaseClient');
+const { supabase } = require('../supabaseClient');
 const generateClientIds = require('../utils/generateClientIds');
 const clientesController = require('../controllers/clientesController');
 

--- a/tests/leads.test.js
+++ b/tests/leads.test.js
@@ -2,11 +2,11 @@ const request = require('supertest');
 const express = require('express');
 
 jest.mock('../supabaseClient', () => ({
-  from: jest.fn(),
+  supabase: { from: jest.fn() },
   assertSupabase: () => true,
 }));
 
-const supabase = require('../supabaseClient');
+const { supabase } = require('../supabaseClient');
 const leadController = require('../controllers/leadController');
 
 const requireAdmin = (req, res, next) => {

--- a/tests/metrics.test.js
+++ b/tests/metrics.test.js
@@ -2,11 +2,11 @@ const request = require('supertest');
 const express = require('express');
 
 jest.mock('../supabaseClient', () => ({
-  from: jest.fn(),
+  supabase: { from: jest.fn() },
   assertSupabase: () => true,
 }));
 
-const supabase = require('../supabaseClient');
+const { supabase } = require('../supabaseClient');
 const metricsController = require('../controllers/metricsController');
 
 const requireAdmin = (req, res, next) => {

--- a/tests/ping.js
+++ b/tests/ping.js
@@ -1,4 +1,4 @@
-const supabase = require('../supabaseClient');
+const { supabase } = require('../supabaseClient');
 
 (async () => {
   if (typeof supabase.from !== 'function') {

--- a/tests/report.test.js
+++ b/tests/report.test.js
@@ -2,7 +2,7 @@ const request = require('supertest');
 const express = require('express');
 
 jest.mock('../supabaseClient', () => ({
-  from: jest.fn(),
+  supabase: { from: jest.fn() },
   assertSupabase: () => true,
 }));
 
@@ -22,7 +22,7 @@ jest.mock('../services/transacoesMetrics', () => ({
   })),
 }));
 
-const supabase = require('../supabaseClient');
+const { supabase } = require('../supabaseClient');
 const reportController = require('../controllers/reportController');
 
 const app = express();

--- a/tests/transacoes.test.js
+++ b/tests/transacoes.test.js
@@ -2,11 +2,11 @@ const request = require('supertest');
 const express = require('express');
 
 jest.mock('../supabaseClient', () => ({
-  from: jest.fn(),
+  supabase: { from: jest.fn() },
   assertSupabase: () => true,
 }));
 
-const supabase = require('../supabaseClient');
+const { supabase } = require('../supabaseClient');
 const transacaoController = require('../controllers/transacaoController');
 const errorHandler = require('../src/middlewares/errorHandler.js');
 

--- a/utils/generateClientIds.js
+++ b/utils/generateClientIds.js
@@ -1,4 +1,4 @@
-const supabase = require('../supabaseClient');
+const { supabase } = require('../supabaseClient');
 const { gerarIdUnico } = require('./idGenerator');
 
 async function generateClientIds() {


### PR DESCRIPTION
## Summary
- export supabase client and assertion helper explicitly
- enable CORS and ensure admin routes use PIN protection
- standardize Supabase imports and implement admin client creation
- add smoke tests for health, planos and admin clients
- clean up admin PIN middleware

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b257ff6eec832b99c27bca0d94cf11