### PR TITLE
feat(server): add root handler and harden /__routes

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,13 +3,19 @@ const cors = require('cors');
 
 const app = express();
 
-// /health imune e primeiro
+// body parser primeiro
+app.use(express.json());
+
+// /health simples e sempre JSON
 app.get('/health', (req, res) => {
   const sha = process.env.RAILWAY_GIT_COMMIT_SHA || process.env.COMMIT_SHA || 'dev';
   res.json({ ok: true, version: 'v0.1.0', sha });
 });
 
-app.use(express.json());
+// raiz não deve gerar 500
+app.get('/', (req, res) => res.type('text/plain').send('ok'));
+app.head('/', (req, res) => res.status(200).end());
+
 const allowed = process.env.ALLOWED_ORIGIN || '*';
 app.use(
   cors({
@@ -30,38 +36,43 @@ const adminRoutes = require('./routes/admin.routes');
 app.use('/admin', requireAdminPin, adminRoutes);
 
 // /__routes opcional e protegido por PIN
-function listRoutes(app) {
-  const out = [];
-  app._router?.stack?.forEach?.((l) => {
-    if (l.route?.path) {
-      const methods = Object.keys(l.route.methods || {}).map((m) => m.toUpperCase());
-      out.push({ path: l.route.path, methods });
-    } else if (l.name === 'router' && l.handle?.stack) {
-      l.handle.stack.forEach((s) => {
-        if (s.route?.path) {
-          const methods = Object.keys(s.route.methods || {}).map((m) => m.toUpperCase());
-          out.push({ path: s.route.path, methods });
-        }
-      });
+function listRoutes(app){
+  const items=[];
+  const stack = app && app._router && Array.isArray(app._router.stack) ? app._router.stack : [];
+  for(const layer of stack){
+    if(layer && layer.route && layer.route.path){
+      const methods = Object.keys(layer.route.methods||{}).map(m=>m.toUpperCase());
+      items.push({ path: layer.route.path, methods });
     }
-  });
-  return out;
-}
-if (process.env.DIAG_ROUTES === '1') {
-  app.get('/__routes', (req, res) => {
-    try {
-      if ((req.query.pin || '') !== (process.env.ADMIN_PIN || '')) {
-        return res.status(401).json({ ok: false, error: 'invalid_pin' });
+    if(layer && layer.name==='router' && layer.handle && Array.isArray(layer.handle.stack)){
+      for(const s of layer.handle.stack){
+        if(s && s.route && s.route.path){
+          const methods = Object.keys(s.route.methods||{}).map(m=>m.toUpperCase());
+          items.push({ path: s.route.path, methods });
+        }
       }
-      return res.json({ ok: true, count: listRoutes(app).length, routes: listRoutes(app) });
-    } catch (e) {
-      return res.status(500).json({ ok: false, error: e.message });
+    }
+  }
+  return items;
+}
+if(process.env.DIAG_ROUTES==='1'){
+  app.get('/__routes',(req,res)=>{
+    try{
+      const adminPin = process.env.ADMIN_PIN || '';
+      const pin = (req.query.pin || '').toString();
+      if(!adminPin || pin!==adminPin){
+        return res.status(401).json({ ok:false, error:'invalid_pin' });
+      }
+      const routes = listRoutes(app);
+      return res.json({ ok:true, count: routes.length, routes });
+    }catch(e){
+      return res.status(500).json({ ok:false, error: e.message });
     }
   });
 }
 
 // static
-app.use(require('express').static(require('path').join(__dirname, 'public')));
+app.use(express.static(require('path').join(__dirname, 'public')));
 
 // 404
 app.use((req, res) => res.status(404).send(`Cannot ${req.method} ${req.path}`));


### PR DESCRIPTION
## Summary
- add root GET/HEAD handlers and PIN-gated /__routes listing
- ensure JSON body parser and diagnostic routes mount before other middleware

## Testing
- `npm test`

## Verification
```bash
API="https://clube-vantagens-api-production.up.railway.app"

# /health deve ser 200 JSON
curl -i "$API/health"

# / deve ser 200 (ok) ou 204
curl -i "$API/"

# se DIAG_ROUTES=1: /__routes deve ser 200 JSON com rotas
curl -i "$API/__routes?pin=2468"

# /admin/clientes sem PIN -> 401
curl -i -X POST "$API/admin/clientes" \
  -H "Content-Type: application/json" \
  -d '{"nome":"n","email":"e@e.com"}'

# /admin/clientes com PIN -> 201 { ok:true }
curl -i -X POST "$API/admin/clientes?pin=2468" \
  -H "Content-Type: application/json" \
  -d '{"nome":"Teste","email":"t@t.com","telefone":"64999999999"}'
```

------
https://chatgpt.com/codex/tasks/task_e_68b2fe9de5ac832b8f7cdb7ea10c496d