### PR TITLE
Add admin clientes routes and PIN protection

### DIFF
--- a/__tests__/smoke.test.js
+++ b/__tests__/smoke.test.js
@@ -2,10 +2,9 @@ process.env.NODE_ENV = 'test';
 process.env.ADMIN_PIN = '2468';
 
 jest.mock('../supabaseClient', () => {
-  const single = jest.fn().mockResolvedValue({ data: { id: 1 }, error: null });
-  const select = jest.fn(() => ({ single }));
-  const insert = jest.fn(() => ({ select }));
-  const from = jest.fn(() => ({ insert }));
+  const select = jest.fn().mockResolvedValue({ data: [{ id: 1 }], error: null });
+  const upsert = jest.fn(() => ({ select }));
+  const from = jest.fn(() => ({ upsert }));
   return { supabase: { from }, assertSupabase: () => true };
 });
 
@@ -31,10 +30,16 @@ describe('basic API smoke', () => {
       const res = await request(app)
         .post('/admin/clientes')
         .set('x-admin-pin', '2468')
-        .send({ nome: 'John', email: 'john@example.com' });
-      expect(res.status).toBe(201);
+        .send({
+          cpf: '12345678901',
+          nome: 'John',
+          plano: 'Mensal',
+          status: 'ativo',
+          metodo_pagamento: 'pix'
+        });
+      expect(res.status).toBe(200);
       expect(res.body.ok).toBe(true);
-      expect(res.body.cliente).toBeTruthy();
+      expect(res.body.data).toBeTruthy();
     });
   });
 });

--- a/routes/admin.routes.js
+++ b/routes/admin.routes.js
@@ -1,6 +1,9 @@
 const router = require('express').Router();
-const { createCliente } = require('../controllers/clientesController');
-
-router.post('/clientes', createCliente);
-
+const c = require('../controllers/clientesController');
+router.get('/clientes', c.list);
+router.post('/clientes', c.upsertOne);      // mantém create via upsert
+router.put('/clientes/:cpf', c.upsertOne);
+router.delete('/clientes/:cpf', c.remove);
+router.post('/clientes:bulk', c.bulkUpsert);
+router.post('/clientes:generate-ids', c.generateIds);
 module.exports = router;


### PR DESCRIPTION
## Summary
- expose admin clientes routes for list, upsert, bulk operations and id generation
- secure admin endpoints with x-admin-pin middleware
- adjust smoke tests for updated upsert behaviour

## Testing
- `npm test`

## Manual testing
```
API="https://clube-vantagens-api-production.up.railway.app"
PIN=2468
curl -i -H "x-admin-pin: $PIN" "$API/admin/clientes?q=tes"
curl -i -X PUT -H "x-admin-pin: $PIN" -H "Content-Type: application/json" \
  -d '{"cpf":"12345678901","nome":"Fulano","plano":"Mensal","status":"ativo","metodo_pagamento":"pix"}' \
  "$API/admin/clientes/12345678901"
curl -i -X DELETE -H "x-admin-pin: $PIN" "$API/admin/clientes/12345678901"
```


------
https://chatgpt.com/codex/tasks/task_e_68b30e074170832ba944bffc453df321