### PR TITLE
feat: send admin pin header

### DIFF
--- a/public/admin/content.js
+++ b/public/admin/content.js
@@ -2,29 +2,37 @@
   const form = document.getElementById('cadastro-form');
   const pinInput = document.getElementById('pin');
 
+  if (pinInput) {
+    const storedPin = localStorage.getItem('ADMIN_PIN');
+    if (storedPin) pinInput.value = storedPin;
+  }
+
   if (!form) return;
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
-    const pin = (pinInput?.value || '2468').trim();
+    const pin = (pinInput?.value || localStorage.getItem('ADMIN_PIN') || '2468').trim();
+    localStorage.setItem('ADMIN_PIN', pin);
     const nome = document.getElementById('nome').value.trim();
     const email = document.getElementById('email').value.trim();
     const telefone = document.getElementById('telefone').value.trim();
 
     try {
-      const resp = await fetch(`/admin/clientes?pin=${encodeURIComponent(pin)}`, {
+      const resp = await fetch('/admin/clientes', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'x-admin-pin': pin },
         body: JSON.stringify({ nome, email, telefone })
       });
 
-      const json = await resp.json().catch(() => ({}));
-      if (!resp.ok || !json.ok) throw new Error(json.error || `HTTP ${resp.status}`);
-
-      alert('Cliente cadastrado com sucesso!');
-      form.reset();
+      if (resp.ok) {
+        form.reset();
+        alert('Cliente cadastrado!');
+      } else {
+        const { error } = await resp.json().catch(() => ({ error: `HTTP ${resp.status}` }));
+        alert(error);
+      }
     } catch (err) {
-      alert(`Erro ao cadastrar: ${err.message}`);
+      alert(err.message || 'Erro ao cadastrar');
     }
   });
 })();


### PR DESCRIPTION
## Summary
- send admin PIN as x-admin-pin header
- show success or server error when registering client

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b30fabfbe8832b88114a7de1607453