### PR TITLE
feat: admin clientes page and pin handling

### DIFF
--- a/public/admin/cadastro.html
+++ b/public/admin/cadastro.html
@@ -8,12 +8,14 @@
 <body>
 <header>
   <nav>
-    <a href="/">Dashboard</a>
-    <a href="/admin/cadastro.html">Clientes &gt; Novo</a>
-    <a href="/admin/assinatura.html">Assinaturas</a>
+    <a href="/admin/cadastro.html">Cadastro</a>
+    <a href="/admin/clientes.html">Clientes</a>
     <a href="/deploy-check.html">Status/Health</a>
   </nav>
-  <div><label>PIN <input type="password" id="pin" class="pin-input"></label></div>
+  <div>
+    <label>PIN <input type="password" id="pin" class="pin-input"></label>
+    <button id="save-pin">Salvar PIN</button>
+  </div>
 </header>
 <main>
     <form id="cadastro-form" class="card">

--- a/public/admin/clientes.html
+++ b/public/admin/clientes.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<title>Clientes</title>
+<link rel="stylesheet" href="/assets/app.css">
+</head>
+<body>
+<header>
+  <nav>
+    <a href="/admin/cadastro.html">Cadastro</a>
+    <a href="/admin/clientes.html">Clientes</a>
+    <a href="/deploy-check.html">Status/Health</a>
+  </nav>
+  <div>
+    <label>PIN <input type="password" id="pin" class="pin-input"></label>
+    <button id="save-pin">Salvar PIN</button>
+  </div>
+</header>
+<main>
+  <form id="filtros" class="card">
+    <input type="text" name="q" placeholder="Busca">
+    <select name="status">
+      <option value="">Todos os status</option>
+      <option value="ativo">Ativo</option>
+      <option value="inativo">Inativo</option>
+    </select>
+    <select name="plano">
+      <option value="">Todos os planos</option>
+      <option value="mensal">Mensal</option>
+      <option value="semestral">Semestral</option>
+      <option value="anual">Anual</option>
+    </select>
+    <button type="submit">Buscar</button>
+    <button type="button" id="limpar">Limpar</button>
+  </form>
+
+  <table id="lista" class="card">
+    <thead>
+      <tr>
+        <th>Nome</th>
+        <th>Email</th>
+        <th>Telefone</th>
+        <th>Status</th>
+        <th>Plano</th>
+        <th>Ações</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+  <div class="paginacao">
+    <button id="prev">Anterior</button>
+    <button id="next">Próxima</button>
+  </div>
+</main>
+<script src="clientes.js"></script>
+</body>
+</html>

--- a/public/admin/clientes.js
+++ b/public/admin/clientes.js
@@ -1,0 +1,111 @@
+(function(){
+  const limit = 20;
+  let offset = 0;
+  const form = document.getElementById('filtros');
+  const tbody = document.querySelector('#lista tbody');
+  const pinInput = document.getElementById('pin');
+  const savePinBtn = document.getElementById('save-pin');
+
+  const stored = localStorage.getItem('ADMIN_PIN');
+  if (stored) pinInput.value = stored;
+
+  savePinBtn.addEventListener('click', () => {
+    const val = pinInput.value.trim();
+    localStorage.setItem('ADMIN_PIN', val);
+    alert('PIN salvo!');
+  });
+
+  function getPin(){
+    let pin = localStorage.getItem('ADMIN_PIN');
+    if(!pin){
+      pin = prompt('Informe o PIN do admin');
+      if(pin) localStorage.setItem('ADMIN_PIN', pin);
+    }
+    return pin || '';
+  }
+
+  async function fetchClientes(params={}){
+    const pin = getPin();
+    const query = new URLSearchParams({ limit, offset, ...params });
+    try{
+      const resp = await fetch(`/admin/clientes?${query.toString()}`, {
+        headers: { 'x-admin-pin': pin }
+      });
+      if(resp.status === 401){
+        alert('PIN inválido');
+        return;
+      }
+      const data = await resp.json().catch(()=>[]);
+      if(!resp.ok){
+        alert(data.error || 'Erro ao buscar');
+        return;
+      }
+      tbody.innerHTML='';
+      data.forEach(c=>{
+        const tr=document.createElement('tr');
+        tr.innerHTML=`<td>${c.nome||''}</td><td>${c.email||''}</td><td>${c.telefone||''}</td><td>${c.status||''}</td><td>${c.plano||''}</td><td><button class="editar" data-cpf="${c.cpf}">Editar</button> <button class="remover" data-cpf="${c.cpf}">Remover</button></td>`;
+        tbody.appendChild(tr);
+      });
+    }catch(err){
+      alert(err.message||'Erro ao buscar');
+    }
+  }
+
+  form.addEventListener('submit',e=>{
+    e.preventDefault();
+    offset=0;
+    const params=Object.fromEntries(new FormData(form).entries());
+    fetchClientes(params);
+  });
+
+  document.getElementById('limpar').addEventListener('click',()=>{
+    form.reset();
+    offset=0;
+    fetchClientes();
+  });
+
+  document.getElementById('prev').addEventListener('click',()=>{
+    if(offset>=limit){
+      offset-=limit;
+      const params=Object.fromEntries(new FormData(form).entries());
+      fetchClientes(params);
+    }
+  });
+  document.getElementById('next').addEventListener('click',()=>{
+    offset+=limit;
+    const params=Object.fromEntries(new FormData(form).entries());
+    fetchClientes(params);
+  });
+
+  tbody.addEventListener('click',async e=>{
+    const btn=e.target;
+    if(btn.classList.contains('remover')){
+      const cpf=btn.dataset.cpf;
+      if(!confirm('Remover este cliente?')) return;
+      try{
+        const resp=await fetch(`/admin/clientes/${cpf}`,{method:'DELETE',headers:{'x-admin-pin':getPin()}});
+        if(resp.status===401){alert('PIN inválido');return;}
+        const data=await resp.json().catch(()=>({}));
+        if(!resp.ok){alert(data.error||'Erro ao remover');return;}
+        fetchClientes(Object.fromEntries(new FormData(form).entries()));
+      }catch(err){alert(err.message||'Erro ao remover');}
+    }
+    if(btn.classList.contains('editar')){
+      const cpf=btn.dataset.cpf;
+      const status=prompt('Status (ativo/inativo):');
+      const plano=prompt('Plano (mensal/semestral/anual):');
+      const body={};
+      if(status) body.status=status;
+      if(plano) body.plano=plano;
+      try{
+        const resp=await fetch(`/admin/clientes/${cpf}`,{method:'PUT',headers:{'Content-Type':'application/json','x-admin-pin':getPin()},body:JSON.stringify(body)});
+        if(resp.status===401){alert('PIN inválido');return;}
+        const data=await resp.json().catch(()=>({}));
+        if(!resp.ok){alert(data.error||'Erro ao editar');return;}
+        fetchClientes(Object.fromEntries(new FormData(form).entries()));
+      }catch(err){alert(err.message||'Erro ao editar');}
+    }
+  });
+
+  fetchClientes();
+})();

--- a/public/admin/content.js
+++ b/public/admin/content.js
@@ -1,18 +1,34 @@
 (function () {
   const form = document.getElementById('cadastro-form');
   const pinInput = document.getElementById('pin');
+  const saveBtn = document.getElementById('save-pin');
+
+  function getPin(){
+    let pin = localStorage.getItem('ADMIN_PIN');
+    if(!pin){
+      pin = prompt('Informe o PIN do admin');
+      if(pin) localStorage.setItem('ADMIN_PIN', pin);
+    }
+    return pin || '';
+  }
 
   if (pinInput) {
     const storedPin = localStorage.getItem('ADMIN_PIN');
     if (storedPin) pinInput.value = storedPin;
+  }
+  if(saveBtn){
+    saveBtn.addEventListener('click',()=>{
+      const val = pinInput.value.trim();
+      localStorage.setItem('ADMIN_PIN', val);
+      alert('PIN salvo!');
+    });
   }
 
   if (!form) return;
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
-    const pin = (pinInput?.value || localStorage.getItem('ADMIN_PIN') || '2468').trim();
-    localStorage.setItem('ADMIN_PIN', pin);
+    const pin = getPin();
     const nome = document.getElementById('nome').value.trim();
     const email = document.getElementById('email').value.trim();
     const telefone = document.getElementById('telefone').value.trim();
@@ -29,7 +45,8 @@
         alert('Cliente cadastrado!');
       } else {
         const { error } = await resp.json().catch(() => ({ error: `HTTP ${resp.status}` }));
-        alert(error);
+        if(resp.status===401) alert('PIN inválido');
+        else alert(error);
       }
     } catch (err) {
       alert(err.message || 'Erro ao cadastrar');

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<title>Admin</title>
+<link rel="stylesheet" href="/assets/app.css">
+</head>
+<body>
+<header>
+  <nav>
+    <a href="/admin/cadastro.html">Cadastro</a>
+    <a href="/admin/clientes.html">Clientes</a>
+    <a href="/deploy-check.html">Status/Health</a>
+  </nav>
+  <div>
+    <label>PIN <input type="password" id="pin" class="pin-input"></label>
+    <button id="save-pin">Salvar PIN</button>
+  </div>
+</header>
+<main class="card">
+  <ul>
+    <li><a href="/admin/cadastro.html">Cadastro de Clientes</a></li>
+    <li><a href="/admin/clientes.html">Listar Clientes</a></li>
+  </ul>
+</main>
+<script>
+(function(){
+  const pinInput=document.getElementById('pin');
+  const save=document.getElementById('save-pin');
+  const stored=localStorage.getItem('ADMIN_PIN');
+  if(stored) pinInput.value=stored;
+  save.addEventListener('click',()=>{
+    localStorage.setItem('ADMIN_PIN',pinInput.value.trim());
+    alert('PIN salvo!');
+  });
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create clientes list page with filters, pagination and edit/remove actions
- persist admin PIN in localStorage and send as x-admin-pin header
- add simple index and navbar links for admin area

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b31239078c832bace696028255afcc