### PR TITLE
feat: manage admin PIN for cadastro

### DIFF
--- a/public/admin/cadastro.html
+++ b/public/admin/cadastro.html
@@ -30,7 +30,8 @@
       </label>
       <button type="submit">Cadastrar</button>
     </form>
-  </main>
-  <script src="content.js"></script>
-  </body>
-  </html>
+    </main>
+    <script src="clientes-common.js"></script>
+    <script src="content.js"></script>
+    </body>
+    </html>

--- a/public/admin/clientes-common.js
+++ b/public/admin/clientes-common.js
@@ -1,0 +1,8 @@
+function getPin(){
+  let pin = localStorage.getItem('ADMIN_PIN');
+  if(!pin){
+    pin = prompt('Informe o PIN do admin');
+    if(pin) localStorage.setItem('ADMIN_PIN', pin);
+  }
+  return pin || '';
+}

--- a/public/admin/clientes.html
+++ b/public/admin/clientes.html
@@ -52,7 +52,8 @@
     <button id="prev">Anterior</button>
     <button id="next">Próxima</button>
   </div>
-</main>
-<script src="clientes.js"></script>
-</body>
-</html>
+  </main>
+  <script src="clientes-common.js"></script>
+  <script src="clientes.js"></script>
+  </body>
+  </html>

--- a/public/admin/clientes.js
+++ b/public/admin/clientes.js
@@ -15,15 +15,6 @@
     alert('PIN salvo!');
   });
 
-  function getPin(){
-    let pin = localStorage.getItem('ADMIN_PIN');
-    if(!pin){
-      pin = prompt('Informe o PIN do admin');
-      if(pin) localStorage.setItem('ADMIN_PIN', pin);
-    }
-    return pin || '';
-  }
-
   async function fetchClientes(params={}){
     const pin = getPin();
     const query = new URLSearchParams({ limit, offset, ...params });

--- a/public/admin/content.js
+++ b/public/admin/content.js
@@ -3,15 +3,6 @@
   const pinInput = document.getElementById('pin');
   const saveBtn = document.getElementById('save-pin');
 
-  function getPin(){
-    let pin = localStorage.getItem('ADMIN_PIN');
-    if(!pin){
-      pin = prompt('Informe o PIN do admin');
-      if(pin) localStorage.setItem('ADMIN_PIN', pin);
-    }
-    return pin || '';
-  }
-
   if (pinInput) {
     const storedPin = localStorage.getItem('ADMIN_PIN');
     if (storedPin) pinInput.value = storedPin;
@@ -40,14 +31,17 @@
         body: JSON.stringify({ nome, email, telefone })
       });
 
-      if (resp.ok) {
-        form.reset();
-        alert('Cliente cadastrado!');
-      } else {
-        const { error } = await resp.json().catch(() => ({ error: `HTTP ${resp.status}` }));
-        if(resp.status===401) alert('PIN inválido');
-        else alert(error);
+      const data = await resp.json().catch(() => ({}));
+      if (resp.status === 401 && data.error === 'invalid_pin') {
+        alert('PIN inválido. Por favor, revise o PIN.');
+        return;
       }
+      if (!resp.ok) {
+        alert(data.error || 'Erro ao cadastrar');
+        return;
+      }
+      form.reset();
+      alert('Cliente cadastrado!');
     } catch (err) {
       alert(err.message || 'Erro ao cadastrar');
     }


### PR DESCRIPTION
## Summary
- add shared admin PIN helper for admin pages
- submit cadastro form with x-admin-pin header and friendly error

## Testing
- `npm test`
- `ADMIN_PIN=1234 node server.js` (in background)
- `curl -i -X POST http://localhost:8080/admin/clientes -H 'Content-Type: application/json' -d '{"nome":"Teste","telefone":"123"}'`
- `curl -i -X POST http://localhost:8080/admin/clientes -H 'Content-Type: application/json' -H 'x-admin-pin: 1234' -d '{"nome":"Fulano","email":"a@b.com","telefone":"11999999999"}'`


------
https://chatgpt.com/codex/tasks/task_e_68b314b66f24832b85616ffc87db42fe