### PR TITLE
feat(admin): finalize clientes page with filters and pagination

### DIFF
--- a/public/admin/admin-common.js
+++ b/public/admin/admin-common.js
@@ -1,0 +1,11 @@
+function getPin() {
+  return localStorage.getItem('ADMIN_PIN') || '';
+}
+
+function setPin(pin) {
+  localStorage.setItem('ADMIN_PIN', pin);
+}
+
+function withPinHeaders(headers = {}) {
+  return { ...headers, 'x-admin-pin': getPin() };
+}

--- a/public/admin/cadastro.html
+++ b/public/admin/cadastro.html
@@ -10,7 +10,7 @@
   <nav>
     <a href="/admin/cadastro.html">Cadastro</a>
     <a href="/admin/clientes.html">Clientes</a>
-    <a href="/deploy-check.html">Status/Health</a>
+    <a href="/status/health">Status/Health</a>
   </nav>
   <div>
     <label>PIN <input type="password" id="pin" class="pin-input"></label>
@@ -31,7 +31,7 @@
       <button type="submit">Cadastrar</button>
     </form>
     </main>
-    <script src="clientes-common.js"></script>
+    <script src="admin-common.js"></script>
     <script src="content.js"></script>
     </body>
     </html>

--- a/public/admin/clientes-common.js
+++ b/public/admin/clientes-common.js
@@ -1,8 +1,0 @@
-function getPin(){
-  let pin = localStorage.getItem('ADMIN_PIN');
-  if(!pin){
-    pin = prompt('Informe o PIN do admin');
-    if(pin) localStorage.setItem('ADMIN_PIN', pin);
-  }
-  return pin || '';
-}

--- a/public/admin/clientes.html
+++ b/public/admin/clientes.html
@@ -10,7 +10,7 @@
   <nav>
     <a href="/admin/cadastro.html">Cadastro</a>
     <a href="/admin/clientes.html">Clientes</a>
-    <a href="/deploy-check.html">Status/Health</a>
+    <a href="/status/health">Status/Health</a>
   </nav>
   <div>
     <label>PIN <input type="password" id="pin" class="pin-input"></label>
@@ -27,9 +27,9 @@
     </select>
     <select name="plano">
       <option value="">Todos os planos</option>
-      <option value="mensal">Mensal</option>
-      <option value="semestral">Semestral</option>
-      <option value="anual">Anual</option>
+      <option value="Mensal">Mensal</option>
+      <option value="Semestral">Semestral</option>
+      <option value="Anual">Anual</option>
     </select>
     <button type="submit">Buscar</button>
     <button type="button" id="limpar">Limpar</button>
@@ -38,6 +38,7 @@
   <table id="lista" class="card">
     <thead>
       <tr>
+        <th>CPF</th>
         <th>Nome</th>
         <th>Email</th>
         <th>Telefone</th>
@@ -50,10 +51,11 @@
   </table>
   <div class="paginacao">
     <button id="prev">Anterior</button>
+    <span id="info"></span>
     <button id="next">Próxima</button>
   </div>
   </main>
-  <script src="clientes-common.js"></script>
+  <script src="admin-common.js"></script>
   <script src="clientes.js"></script>
   </body>
   </html>

--- a/public/admin/clientes.js
+++ b/public/admin/clientes.js
@@ -1,100 +1,131 @@
 (function(){
   const limit = 20;
   let offset = 0;
+  let total = 0;
+
   const form = document.getElementById('filtros');
   const tbody = document.querySelector('#lista tbody');
   const pinInput = document.getElementById('pin');
   const savePinBtn = document.getElementById('save-pin');
+  const prevBtn = document.getElementById('prev');
+  const nextBtn = document.getElementById('next');
+  const infoSpan = document.getElementById('info');
+  const clearBtn = document.getElementById('limpar');
+  const searchBtn = form.querySelector('button[type="submit"]');
 
-  const stored = localStorage.getItem('ADMIN_PIN');
-  if (stored) pinInput.value = stored;
-
+  pinInput.value = getPin();
   savePinBtn.addEventListener('click', () => {
-    const val = pinInput.value.trim();
-    localStorage.setItem('ADMIN_PIN', val);
+    setPin(pinInput.value.trim());
     alert('PIN salvo!');
   });
 
+  function setLoading(state){
+    [prevBtn, nextBtn, clearBtn, searchBtn].forEach(b => b.disabled = state);
+    if(state){
+      tbody.innerHTML = '<tr><td colspan="7">Carregando...</td></tr>';
+    }
+  }
+
+  function updateInfo(){
+    const start = total === 0 ? 0 : offset + 1;
+    const end = Math.min(offset + limit, total);
+    infoSpan.textContent = `Exibindo ${start}-${end} de ${total}`;
+    prevBtn.disabled = offset <= 0;
+    nextBtn.disabled = offset + limit >= total;
+  }
+
   async function fetchClientes(params={}){
-    const pin = getPin();
+    setLoading(true);
     const query = new URLSearchParams({ limit, offset, ...params });
     try{
-      const resp = await fetch(`/admin/clientes?${query.toString()}`, {
-        headers: { 'x-admin-pin': pin }
-      });
+      const resp = await fetch(`/admin/clientes?${query.toString()}`, { headers: withPinHeaders() });
+      const data = await resp.json().catch(()=>({rows:[], total:0}));
       if(resp.status === 401){
-        alert('PIN inválido');
+        alert('PIN inválido. Ajuste o PIN no topo e tente novamente.');
         return;
       }
-      const data = await resp.json().catch(()=>[]);
       if(!resp.ok){
         alert(data.error || 'Erro ao buscar');
         return;
       }
-      tbody.innerHTML='';
-      data.forEach(c=>{
-        const tr=document.createElement('tr');
-        tr.innerHTML=`<td>${c.nome||''}</td><td>${c.email||''}</td><td>${c.telefone||''}</td><td>${c.status||''}</td><td>${c.plano||''}</td><td><button class="editar" data-cpf="${c.cpf}">Editar</button> <button class="remover" data-cpf="${c.cpf}">Remover</button></td>`;
-        tbody.appendChild(tr);
-      });
+      const rows = data.rows || [];
+      total = data.total || 0;
+      if(rows.length === 0){
+        tbody.innerHTML = '<tr><td colspan="7">Nenhum cliente encontrado</td></tr>';
+      }else{
+        tbody.innerHTML = '';
+        rows.forEach(c => {
+          const tr = document.createElement('tr');
+          tr.innerHTML = `<td>${c.cpf||''}</td><td>${c.nome||''}</td><td>${c.email||''}</td><td>${c.telefone||''}</td><td>${c.status||''}</td><td>${c.plano||''}</td><td><button class="editar" data-cpf="${c.cpf}">Editar</button> <button class="remover" data-cpf="${c.cpf}">Remover</button></td>`;
+          tbody.appendChild(tr);
+        });
+      }
+      updateInfo();
     }catch(err){
-      alert(err.message||'Erro ao buscar');
+      alert(err.message || 'Erro ao buscar');
+    }finally{
+      setLoading(false);
     }
   }
 
-  form.addEventListener('submit',e=>{
+  form.addEventListener('submit', e => {
     e.preventDefault();
-    offset=0;
-    const params=Object.fromEntries(new FormData(form).entries());
+    offset = 0;
+    const params = Object.fromEntries(new FormData(form).entries());
     fetchClientes(params);
   });
 
-  document.getElementById('limpar').addEventListener('click',()=>{
+  clearBtn.addEventListener('click', () => {
     form.reset();
-    offset=0;
+    offset = 0;
     fetchClientes();
   });
 
-  document.getElementById('prev').addEventListener('click',()=>{
-    if(offset>=limit){
-      offset-=limit;
-      const params=Object.fromEntries(new FormData(form).entries());
+  prevBtn.addEventListener('click', () => {
+    if(offset >= limit){
+      offset -= limit;
+      const params = Object.fromEntries(new FormData(form).entries());
       fetchClientes(params);
     }
   });
-  document.getElementById('next').addEventListener('click',()=>{
-    offset+=limit;
-    const params=Object.fromEntries(new FormData(form).entries());
-    fetchClientes(params);
+  nextBtn.addEventListener('click', () => {
+    if(offset + limit < total){
+      offset += limit;
+      const params = Object.fromEntries(new FormData(form).entries());
+      fetchClientes(params);
+    }
   });
 
-  tbody.addEventListener('click',async e=>{
-    const btn=e.target;
+  tbody.addEventListener('click', async e => {
+    const btn = e.target;
+    const cpf = btn.dataset.cpf;
     if(btn.classList.contains('remover')){
-      const cpf=btn.dataset.cpf;
       if(!confirm('Remover este cliente?')) return;
       try{
-        const resp=await fetch(`/admin/clientes/${cpf}`,{method:'DELETE',headers:{'x-admin-pin':getPin()}});
-        if(resp.status===401){alert('PIN inválido');return;}
-        const data=await resp.json().catch(()=>({}));
-        if(!resp.ok){alert(data.error||'Erro ao remover');return;}
+        const resp = await fetch(`/admin/clientes/${cpf}`, { method: 'DELETE', headers: withPinHeaders() });
+        const data = await resp.json().catch(()=>({}));
+        if(resp.status === 401){alert('PIN inválido. Ajuste o PIN no topo e tente novamente.');return;}
+        if(!resp.ok){alert(data.error || 'Erro ao remover');return;}
         fetchClientes(Object.fromEntries(new FormData(form).entries()));
-      }catch(err){alert(err.message||'Erro ao remover');}
+      }catch(err){alert(err.message || 'Erro ao remover');}
     }
     if(btn.classList.contains('editar')){
-      const cpf=btn.dataset.cpf;
-      const status=prompt('Status (ativo/inativo):');
-      const plano=prompt('Plano (mensal/semestral/anual):');
-      const body={};
-      if(status) body.status=status;
-      if(plano) body.plano=plano;
+      const status = prompt('Status (ativo/inativo):');
+      const plano = prompt('Plano (Mensal/Semestral/Anual):');
+      const body = {};
+      if(status) body.status = status;
+      if(plano) body.plano = plano;
       try{
-        const resp=await fetch(`/admin/clientes/${cpf}`,{method:'PUT',headers:{'Content-Type':'application/json','x-admin-pin':getPin()},body:JSON.stringify(body)});
-        if(resp.status===401){alert('PIN inválido');return;}
-        const data=await resp.json().catch(()=>({}));
-        if(!resp.ok){alert(data.error||'Erro ao editar');return;}
+        const resp = await fetch(`/admin/clientes/${cpf}`, {
+          method: 'PUT',
+          headers: withPinHeaders({ 'Content-Type': 'application/json' }),
+          body: JSON.stringify(body)
+        });
+        const data = await resp.json().catch(()=>({}));
+        if(resp.status === 401){alert('PIN inválido. Ajuste o PIN no topo e tente novamente.');return;}
+        if(!resp.ok){alert(data.error || 'Erro ao editar');return;}
         fetchClientes(Object.fromEntries(new FormData(form).entries()));
-      }catch(err){alert(err.message||'Erro ao editar');}
+      }catch(err){alert(err.message || 'Erro ao editar');}
     }
   });
 

--- a/public/admin/content.js
+++ b/public/admin/content.js
@@ -4,13 +4,12 @@
   const saveBtn = document.getElementById('save-pin');
 
   if (pinInput) {
-    const storedPin = localStorage.getItem('ADMIN_PIN');
+    const storedPin = getPin();
     if (storedPin) pinInput.value = storedPin;
   }
-  if(saveBtn){
-    saveBtn.addEventListener('click',()=>{
-      const val = pinInput.value.trim();
-      localStorage.setItem('ADMIN_PIN', val);
+  if (saveBtn) {
+    saveBtn.addEventListener('click', () => {
+      setPin(pinInput.value.trim());
       alert('PIN salvo!');
     });
   }
@@ -19,7 +18,6 @@
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
-    const pin = getPin();
     const nome = document.getElementById('nome').value.trim();
     const email = document.getElementById('email').value.trim();
     const telefone = document.getElementById('telefone').value.trim();
@@ -27,13 +25,13 @@
     try {
       const resp = await fetch('/admin/clientes', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'x-admin-pin': pin },
+        headers: withPinHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({ nome, email, telefone })
       });
 
       const data = await resp.json().catch(() => ({}));
-      if (resp.status === 401 && data.error === 'invalid_pin') {
-        alert('PIN inválido. Por favor, revise o PIN.');
+      if (resp.status === 401) {
+        alert('PIN inválido. Ajuste o PIN no topo e tente novamente.');
         return;
       }
       if (!resp.ok) {


### PR DESCRIPTION
## Summary
- add reusable admin PIN helpers for all admin pages
- enhance clientes admin page with filters, pagination, and edit/remove actions
- wire cadastro page to shared PIN utilities

## Testing
- `npm test`
- `curl -i -H "x-admin-pin: $PIN" "$API/admin/clientes?q=tes&limit=20&offset=0"` *(fails: CONNECT tunnel failed, response 403)*
- `curl -i -X PUT -H "x-admin-pin: $PIN" -H "Content-Type: application/json" -d '{"cpf":"12345678901","nome":"Fulano","plano":"Mensal","status":"ativo","metodo_pagamento":"pix"}' "$API/admin/clientes/12345678901"` *(fails: CONNECT tunnel failed, response 403)*
- `curl -i -X DELETE -H "x-admin-pin: $PIN" "$API/admin/clientes/12345678901"` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b31763b718832b89e470fc0f204fbb