### PR TITLE
Serve admin static without PIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ API em Node.js para gerenciamento de assinaturas, transações e administração
 - `GET /mp/status` – Status da integração com Mercado Pago.
 
 ## Rotas Administrativas (`/admin/*`)
-Todas as rotas administrativas exigem o cabeçalho `x-admin-pin` com o valor
+As páginas estáticas sob `/admin` (HTML, JS, CSS) podem ser acessadas sem PIN.
+Já as APIs administrativas requerem o cabeçalho `x-admin-pin` com o valor
 definido na variável de ambiente `ADMIN_PIN`.
 
 Exemplos de endpoints:
@@ -130,10 +131,11 @@ A API expõe páginas estáticas acessíveis diretamente pelo navegador:
 - `/etiquetas.html` – impressão de etiquetas.
 - `/config.html` – configurações diversas.
 
-As páginas de administração exibem um campo de **PIN** no topo. O PIN é
-armazenado em `sessionStorage` e enviado automaticamente como cabeçalho
-`x-admin-pin` nas requisições. Se o PIN estiver ausente ou incorreto, uma
-mensagem de erro é exibida.
+As páginas de administração exibem um campo de **PIN** no topo. O acesso a
+essas páginas não exige PIN, mas o valor informado é armazenado em
+`sessionStorage` e enviado automaticamente como cabeçalho `x-admin-pin` nas
+requisições às APIs. Se o PIN estiver ausente ou incorreto, uma mensagem de
+erro é exibida.
 
 O dashboard inicial mostra métricas básicas do endpoint
 `GET /admin/report`, como quantidade de transações, valores bruto e

--- a/routes/admin.routes.js
+++ b/routes/admin.routes.js
@@ -1,9 +1,11 @@
 const router = require('express').Router();
 const c = require('../controllers/clientesController');
-router.get('/clientes', c.list);
-router.post('/clientes', c.upsertOne);      // mantém create via upsert
-router.put('/clientes/:cpf', c.upsertOne);
-router.delete('/clientes/:cpf', c.remove);
-router.post('/clientes:bulk', c.bulkUpsert);
-router.post('/clientes:generate-ids', c.generateIds);
+
+router.get('/', c.list);
+router.post('/', c.upsertOne); // mantém create via upsert
+router.put('/:cpf', c.upsertOne);
+router.delete('/:cpf', c.remove);
+router.post('/bulk', c.bulkUpsert);
+router.post('/generate-ids', c.generateIds);
+
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -42,10 +42,16 @@ const planosRouter = require('./src/features/planos/planos.routes.js');
 app.use('/planos', planosRouter);
 app.use('/api/planos', planosRouter);
 
-// ADMIN (ANTES do static)
+// ADMIN (static pages + API)
+const path = require('path');
 const { requireAdminPin } = require('./middlewares/requireAdminPin');
-const adminRoutes = require('./routes/admin.routes');
-app.use('/admin', requireAdminPin, adminRoutes);
+const clientesRouter = require('./routes/admin.routes');
+
+// páginas estáticas de /admin sem PIN
+app.use('/admin', express.static(path.join(__dirname, 'public', 'admin')));
+
+// rotas de API de admin protegidas por PIN
+app.use('/admin/clientes', requireAdminPin, clientesRouter);
 
 // /__routes opcional e protegido por PIN
 function listRoutesSafe(app) {


### PR DESCRIPTION
## Summary
- Serve static /admin pages before PIN checks
- Protect admin clientes API under /admin/clientes
- Document that admin pages are public and APIs require `x-admin-pin`

## Testing
- `node - <<'NODE' ... NODE`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b33e181b18832bb45f4457573bee15