### PR TITLE
feat: exigir CPF no cadastro e flexibilizar cliente

### DIFF
--- a/public/admin/cadastro.html
+++ b/public/admin/cadastro.html
@@ -20,6 +20,10 @@
 <div id="message"></div>
 <main>
     <form id="cadastro-form" class="card">
+      <div>
+        <label>CPF</label>
+        <input id="cpf" type="text" placeholder="___.___.___-__" required />
+      </div>
       <label>Nome
         <input id="nome" required>
       </label>
@@ -27,7 +31,7 @@
         <input id="email" type="email">
       </label>
       <label>Telefone
-        <input id="telefone" required>
+        <input id="telefone">
       </label>
       <button type="submit">Cadastrar</button>
     </form>

--- a/public/admin/content.js
+++ b/public/admin/content.js
@@ -18,15 +18,20 @@
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
+    const cpf = document.getElementById('cpf').value.trim();
     const nome = document.getElementById('nome').value.trim();
     const email = document.getElementById('email').value.trim();
     const telefone = document.getElementById('telefone').value.trim();
+
+    const payload = { cpf, nome };
+    if (email) payload.email = email;
+    if (telefone) payload.telefone = telefone;
 
     try {
       const resp = await fetch('/admin/clientes', {
         method: 'POST',
         headers: withPinHeaders({ 'Content-Type': 'application/json' }),
-        body: JSON.stringify({ nome, email, telefone })
+        body: JSON.stringify(payload)
       });
 
       const data = await resp.json().catch(() => ({}));


### PR DESCRIPTION
## Summary
- exigir CPF e aplicar validações flexíveis para clientes
- permitir cadastro mínimo via formulário de admin

## Testing
- `npm test`
- `curl -i http://localhost:8080/health`
- `curl -i "http://localhost:8080/__routes?pin=2468"`
- `curl -i -X POST "http://localhost:8080/admin/clientes?pin=2468" -H "Content-Type: application/json" -d '{"cpf":"123.456.789-09","nome":"Teste UI","email":"opcional@ex.com","telefone":"64999999999"}'` (fails: supabase_not_configured)
- `curl -i -X POST "http://localhost:8080/admin/clientes?pin=2468" -H "Content-Type: application/json" -d '{"cpf":"123","nome":"Sem CPF válido"}'` (fails: supabase_not_configured)


------
https://chatgpt.com/codex/tasks/task_e_68b3467e7a90832b8d7d4bfd70731e3f