### PR TITLE
Handle missing column error during client ID generation

### DIFF
--- a/public/admin/clientes.js
+++ b/public/admin/clientes.js
@@ -105,15 +105,25 @@
   });
 
   generateBtn.addEventListener('click', async () => {
+    generateBtn.disabled = true;
     try{
       const resp = await fetch('/admin/clientes/generate-ids', { method:'POST', headers: withPinHeaders() });
       const data = await resp.json().catch(()=>({}));
       if(resp.status === 401){ showMessage('PIN inválido', 'error'); return; }
-      if(!resp.ok){ showMessage(data.error || 'Erro ao gerar IDs', 'error'); return; }
+      if(!resp.ok){
+        if(data.error === 'missing_column'){
+          showMessage("Coluna 'id_interno' não existe. Crie no Supabase.", 'error');
+        }else{
+          showMessage(data.error || 'Erro ao gerar IDs', 'error');
+        }
+        return;
+      }
       showMessage(`IDs atualizados: ${data.updated || 0}`, 'success');
       fetchList();
     }catch(err){
       showMessage(err.message || 'Erro ao gerar IDs', 'error');
+    }finally{
+      generateBtn.disabled = false;
     }
   });
 


### PR DESCRIPTION
## Summary
- handle Postgres missing column errors when generating internal IDs
- harden admin "Gerar IDs" button with disabled state and error feedback

## Testing
- `npm test`
- `curl -i -X POST -H "x-admin-pin:1234" http://localhost:8080/admin/clientes/generate-ids`
- `curl -i -X POST -H "x-admin-pin:1234" http://localhost:8080/admin/clientes/generate-ids` (stubbed Postgres column error)


------
https://chatgpt.com/codex/tasks/task_e_68b34bfdc5fc832b93ea74d584a1062c