### PR TITLE
feat(clientes): add id_interno column and robust ID generator

### DIFF
--- a/controllers/clientesController.js
+++ b/controllers/clientesController.js
@@ -274,7 +274,7 @@ exports.remove = async (req, res, next) => {
 exports.generateIds = async (req, res, next) => {
   if (!assertSupabase(res)) return;
   try {
-    const updated = await generateClientIds();
+    const { updated } = await generateClientIds();
     return res.json({ updated });
   } catch (err) {
     // Postgres: missing column

--- a/db/migrations/20250821000000_add-id_interno-clientes.sql
+++ b/db/migrations/20250821000000_add-id_interno-clientes.sql
@@ -1,0 +1,6 @@
+alter table public.clientes
+  add column if not exists id_interno text;
+
+create unique index if not exists clientes_id_interno_key
+  on public.clientes (id_interno)
+  where id_interno is not null;

--- a/public/admin/clientes.js
+++ b/public/admin/clientes.js
@@ -122,7 +122,7 @@ const table = document.querySelector('table');
         }
         return;
       }
-      showMessage(`IDs atualizados: ${data.updated || 0}`, 'success');
+      showMessage(`${data.updated || 0} IDs gerados`, 'success');
       fetchList();
     }catch(err){
       showMessage(err.message || 'Erro ao gerar IDs', 'error');

--- a/tests/clientes.test.js
+++ b/tests/clientes.test.js
@@ -217,7 +217,7 @@ describe('Clientes Controller', () => {
   });
 
   test('generateIds sucesso', async () => {
-    generateClientIds.mockResolvedValue(5);
+    generateClientIds.mockResolvedValue({ updated: 5 });
     const res = await request(app).post('/clientes/generate-ids');
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ updated: 5 });

--- a/utils/generateClientIds.js
+++ b/utils/generateClientIds.js
@@ -1,5 +1,9 @@
-const { supabase, assertSupabase } = require('../supabaseClient');
-const { gerarIdUnico } = require('./idGenerator');
+const { supabase } = require('../supabaseClient');
+const crypto = require('crypto');
+
+function shortId() {
+  return crypto.randomUUID().replace(/-/g, '').slice(0, 12);
+}
 
 async function generateClientIds() {
   const { data: clientes, error } = await supabase
@@ -10,15 +14,23 @@ async function generateClientIds() {
 
   let updated = 0;
   for (const cli of clientes || []) {
-    const novoId = await gerarIdUnico(supabase);
-    const { error: updErr } = await supabase
-      .from('clientes')
-      .update({ id_interno: novoId })
-      .eq('id', cli.id);
-    if (!updErr) updated += 1;
+    for (let i = 0; i < 3; i++) {
+      const novoId = shortId();
+      const { error: updErr } = await supabase
+        .from('clientes')
+        .update({ id_interno: novoId })
+        .eq('id', cli.id);
+      if (!updErr) {
+        updated += 1;
+        break;
+      }
+      if (!(updErr?.code === '23505' || /duplicate key value/.test(updErr?.message || ''))) {
+        throw updErr;
+      }
+    }
   }
 
-  return updated;
+  return { updated };
 }
 
 module.exports = generateClientIds;


### PR DESCRIPTION
## Summary
- add migration for optional `id_interno` column with unique index
- generate short internal IDs for clients lacking one, retrying on conflicts
- show how many IDs were generated in admin UI and update tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b35a6d4d9c832b971a71f2089e164f