### PR TITLE
feat(clientes): tornar plano/método opcionais e default status=ativo

### DIFF
--- a/controllers/clientesController.js
+++ b/controllers/clientesController.js
@@ -61,25 +61,29 @@ function parseCliente(raw = {}) {
   if (!isValidCpf(cpf)) errors.push('cpf inválido');
   if (!nome) errors.push('nome obrigatório');
 
-  if (plano !== undefined && plano !== null && plano !== '') {
-    if (!PLANOS.has(plano)) errors.push('plano inválido');
-  } else {
+  if (plano === undefined) {
     plano = undefined;
+  } else if (plano === null || plano === '') {
+    plano = null;
+  } else if (!PLANOS.has(plano)) {
+    errors.push('plano inválido');
   }
 
-  if (status !== undefined && status !== null && status !== '') {
-    if (!STATUS.has(status)) errors.push('status inválido');
+  if (status === undefined || status === null || status === '') {
+    status = 'ativo';
+  } else if (!STATUS.has(status)) {
+    errors.push('status inválido');
+  }
+
+  if (metodo_pagamento === undefined) {
+    metodo_pagamento = undefined;
+  } else if (metodo_pagamento === null || metodo_pagamento === '') {
+    metodo_pagamento = null;
   } else {
-    status = undefined;
-  }
-
-  if (metodo_pagamento !== undefined && metodo_pagamento !== null && metodo_pagamento !== '') {
     metodo_pagamento = metodo_pagamento.toString().trim();
     if (!METODOS_PAGAMENTO.has(metodo_pagamento)) {
       errors.push('metodo_pagamento inválido');
     }
-  } else {
-    metodo_pagamento = undefined;
   }
 
   if (pagamento_em_dia !== undefined) {

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -2,10 +2,10 @@ create table if not exists public.clientes (
   id bigserial primary key,
   nome text not null,
   cpf text not null unique,
-  plano text not null,
+  plano text check (plano in ('Mensal','Semestral','Anual')),
   data_adesao timestamp not null default now(),
-  metodo_pagamento text not null check (metodo_pagamento in ('pix','cartao_debito','cartao_credito','dinheiro')),
-  status text not null
+  metodo_pagamento text check (metodo_pagamento in ('pix','cartao_debito','cartao_credito','dinheiro')),
+  status text not null default 'ativo' check (status in ('ativo','inativo'))
 );
 create table if not exists public.transacoes (
   id bigserial primary key,

--- a/public/admin/clientes.js
+++ b/public/admin/clientes.js
@@ -173,7 +173,7 @@ const table = document.querySelector('table');
     editForm.nome.value = c.nome || '';
     editForm.plano.value = c.plano || '';
     editForm.status.value = c.status || 'ativo';
-    editForm.metodo_pagamento.value = c.metodo_pagamento || 'pix';
+    editForm.metodo_pagamento.value = c.metodo_pagamento || '';
     editForm.email.value = c.email || '';
     editForm.telefone.value = c.telefone || '';
     editDialog.showModal();
@@ -185,8 +185,12 @@ const table = document.querySelector('table');
     e.preventDefault();
     const payload = {};
     const fd = new FormData(editForm);
-    for(const [k,v] of fd.entries()){
-      if(v !== '') payload[k] = v;
+    for (const [k, v] of fd.entries()) {
+      if (v !== '') {
+        payload[k] = v;
+      } else if (k === 'plano' || k === 'metodo_pagamento') {
+        payload[k] = null;
+      }
     }
     try{
       const resp = await fetch('/admin/clientes', {

--- a/public/admin/importar.js
+++ b/public/admin/importar.js
@@ -42,17 +42,37 @@
     const errors = [];
     const cpf = sanitizeCpf(raw.cpf || '');
     const nome = (raw.nome || '').toString().trim();
-    const plano = raw.plano;
-    const status = raw.status;
-    const metodo_pagamento = (raw.metodo_pagamento || '').toString().trim();
+    let plano = raw.plano;
+    let status = raw.status;
+    let metodo_pagamento = raw.metodo_pagamento;
     let pagamento_em_dia = raw.pagamento_em_dia;
     let vencimento = raw.vencimento;
 
     if(!cpf || cpf.length !== 11) errors.push('cpf inválido');
     if(!nome) errors.push('nome obrigatório');
-    if(!PLANOS.has(plano)) errors.push('plano inválido');
-    if(!STATUS.has(status)) errors.push('status inválido');
-    if(!METODOS.has(metodo_pagamento)) errors.push('metodo_pagamento inválido');
+
+    if(plano === undefined) {
+      plano = undefined;
+    } else if(plano === null || plano === '') {
+      plano = null;
+    } else if(!PLANOS.has(plano)) {
+      errors.push('plano inválido');
+    }
+
+    if(status === undefined || status === null || status === '') {
+      status = 'ativo';
+    } else if(!STATUS.has(status)) {
+      errors.push('status inválido');
+    }
+
+    if(metodo_pagamento === undefined) {
+      metodo_pagamento = undefined;
+    } else if(metodo_pagamento === null || metodo_pagamento === '') {
+      metodo_pagamento = null;
+    } else {
+      metodo_pagamento = metodo_pagamento.toString().trim();
+      if(!METODOS.has(metodo_pagamento)) errors.push('metodo_pagamento inválido');
+    }
 
     if(pagamento_em_dia !== undefined){
       pagamento_em_dia = pagamento_em_dia === true || pagamento_em_dia === 'true' || pagamento_em_dia === 1 || pagamento_em_dia === '1';

--- a/tests/clientes.test.js
+++ b/tests/clientes.test.js
@@ -81,6 +81,41 @@ describe('Clientes Controller', () => {
     expect(res.body).toHaveProperty('ok', true);
   });
 
+  test('upsertOne aplica defaults e campos opcionais', async () => {
+    const upsert = jest.fn().mockReturnValue({
+      select: jest.fn().mockResolvedValue({ data: [{}], error: null }),
+    });
+    supabase.from.mockReturnValue({ upsert });
+
+    const res = await request(app)
+      .post('/clientes')
+      .send({ cpf: '02655274148', nome: 'Fulano' });
+
+    expect(res.status).toBe(200);
+    const payload = upsert.mock.calls[0][0];
+    expect(payload).toEqual({ cpf: '02655274148', nome: 'Fulano', status: 'ativo' });
+  });
+
+  test('upsertOne metodo vazio vira null', async () => {
+    const upsert = jest.fn().mockReturnValue({
+      select: jest.fn().mockResolvedValue({ data: [{}], error: null }),
+    });
+    supabase.from.mockReturnValue({ upsert });
+
+    const res = await request(app)
+      .post('/clientes')
+      .send({ cpf: '02655274148', nome: 'Fulano', metodo_pagamento: '' });
+
+    expect(res.status).toBe(200);
+    const payload = upsert.mock.calls[0][0];
+    expect(payload).toEqual({
+      cpf: '02655274148',
+      nome: 'Fulano',
+      status: 'ativo',
+      metodo_pagamento: null,
+    });
+  });
+
   test('upsertOne validação falha retorna 400', async () => {
     const res = await request(app)
       .post('/clientes')


### PR DESCRIPTION
## Summary
- allow optional plan and payment method in client payloads
- default client status to `ativo` when omitted
- document nullable fields in clientes schema

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b35ba57ed4832b9194397c9ecaaba4