### PR TITLE
feat(admin): enable inline edit of clients via PUT by CPF

### DIFF
--- a/public/admin/clientes.html
+++ b/public/admin/clientes.html
@@ -77,7 +77,7 @@
 
 <dialog id="editDialog">
   <form id="editForm" method="dialog">
-    <input type="hidden" name="cpf">
+    <label>CPF <input type="text" name="cpf" disabled></label>
     <label>Nome <input type="text" name="nome" required></label>
     <label>Plano
       <select name="plano">
@@ -103,6 +103,7 @@
     </label>
     <label>Email <input type="text" name="email"></label>
     <label>Telefone <input type="text" name="telefone"></label>
+    <label>Vencimento <input type="date" name="vencimento"></label>
     <menu>
       <button type="submit">Salvar</button>
       <button type="button" id="cancelEdit">Cancelar</button>

--- a/routes/admin.routes.js
+++ b/routes/admin.routes.js
@@ -4,6 +4,7 @@ const { requireAdminPin } = require('../middlewares/requireAdminPin');
 
 router.get('/', requireAdminPin, c.list);
 router.post('/', requireAdminPin, c.upsertOne);
+router.put('/:cpf', requireAdminPin, c.updateByCpf);
 router.post('/bulk', requireAdminPin, c.bulkUpsert);
 router.delete('/:cpf', requireAdminPin, c.remove);
 router.post('/generate-ids', requireAdminPin, c.generateIds);


### PR DESCRIPTION
## Summary
- allow editing clients from admin table via inline modal
- add PUT /admin/clientes/:cpf endpoint with validation
- update frontend to PUT client updates and refresh row

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3765908d4832bb1164dadd76bfbbc