### PR TITLE
feat: ensure unique id_interno for clientes

### DIFF
--- a/db/migrations/20250821000000_add-id_interno-clientes.sql
+++ b/db/migrations/20250821000000_add-id_interno-clientes.sql
@@ -1,6 +1,22 @@
+-- migrate:up
+create extension if not exists "pgcrypto";
+
 alter table public.clientes
-  add column if not exists id_interno text;
+  add column if not exists id_interno uuid;
+
+alter table public.clientes
+  alter column id_interno set default gen_random_uuid();
+
+update public.clientes
+   set id_interno = gen_random_uuid()
+ where id_interno is null;
 
 create unique index if not exists clientes_id_interno_key
-  on public.clientes (id_interno)
-  where id_interno is not null;
+  on public.clientes (id_interno);
+
+-- migrate:down
+drop index if exists clientes_id_interno_key;
+
+alter table public.clientes
+  drop column if exists id_interno;
+


### PR DESCRIPTION
## Summary
- ensure pgcrypto extension and id_interno UUID with default
- backfill missing ids and enforce uniqueness

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b377a351f0832bbe8e00646abe77ce