### PR TITLE
feat: gerar IDs internos ausentes

### DIFF
--- a/controllers/clientesController.js
+++ b/controllers/clientesController.js
@@ -325,8 +325,8 @@ exports.remove = async (req, res, next) => {
 exports.generateIds = async (req, res, next) => {
   if (!assertSupabase(res)) return;
   try {
-    const { updated } = await generateClientIds();
-    return res.json({ updated });
+    const { scanned, updated } = await generateClientIds();
+    return res.json({ scanned, updated });
   } catch (err) {
     // Postgres: missing column
     if (


### PR DESCRIPTION
## Summary
- percorre clientes em lotes gerando id_interno ausente com UUID
- expõe estatísticas scanned/updated na rota de utilidade

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b378859480832bbc4d51dcb2923538