### PR TITLE
Expose admin route to generate client IDs

### DIFF
--- a/__tests__/admin.generate-ids.test.js
+++ b/__tests__/admin.generate-ids.test.js
@@ -1,0 +1,33 @@
+process.env.NODE_ENV = 'test';
+process.env.ADMIN_PIN = '2468';
+
+jest.mock('../supabaseClient', () => ({
+  supabase: {},
+  assertSupabase: () => true,
+}));
+
+jest.mock('../utils/generateClientIds', () =>
+  jest.fn().mockResolvedValue({ scanned: 2, updated: 1 })
+);
+
+const request = require('supertest');
+const app = require('../server');
+
+const generateClientIds = require('../utils/generateClientIds');
+
+describe('POST /admin/clientes/generate-ids', () => {
+  test('requires valid PIN', async () => {
+    const res = await request(app).post('/admin/clientes/generate-ids');
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ ok: false, error: 'invalid_pin' });
+  });
+
+  test('returns stats when PIN is valid', async () => {
+    const res = await request(app)
+      .post('/admin/clientes/generate-ids')
+      .set('x-admin-pin', '2468');
+    expect(generateClientIds).toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, scanned: 2, updated: 1 });
+  });
+});

--- a/controllers/clientesController.js
+++ b/controllers/clientesController.js
@@ -326,7 +326,7 @@ exports.generateIds = async (req, res, next) => {
   if (!assertSupabase(res)) return;
   try {
     const { scanned, updated } = await generateClientIds();
-    return res.json({ scanned, updated });
+    return res.json({ ok: true, scanned, updated });
   } catch (err) {
     // Postgres: missing column
     if (

--- a/tests/clientes.test.js
+++ b/tests/clientes.test.js
@@ -252,10 +252,10 @@ describe('Clientes Controller', () => {
   });
 
   test('generateIds sucesso', async () => {
-    generateClientIds.mockResolvedValue({ updated: 5 });
+    generateClientIds.mockResolvedValue({ scanned: 10, updated: 5 });
     const res = await request(app).post('/clientes/generate-ids');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ updated: 5 });
+    expect(res.body).toEqual({ ok: true, scanned: 10, updated: 5 });
   });
 
   test('generateIds erro retorna 500', async () => {


### PR DESCRIPTION
## Summary
- return {ok:true, scanned, updated} from generateIds controller
- add tests for POST /admin/clientes/generate-ids endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b379486160832bbed89a84fc302183