### PR TITLE
feat: inline edit for admin clients with partial update

### DIFF
--- a/public/admin/clientes.html
+++ b/public/admin/clientes.html
@@ -75,13 +75,13 @@
   </div>
 </main>
 
-<dialog id="editDialog">
-  <form id="editForm" method="dialog">
-    <label>CPF <input type="text" name="cpf" disabled></label>
-    <label>Nome <input type="text" name="nome" required></label>
+<dialog id="edit-modal">
+  <form id="edit-form" method="dialog">
+    <label>CPF <input type="text" name="cpf" readonly></label>
+    <label>Nome <input type="text" name="nome"></label>
     <label>Plano
       <select name="plano">
-        <option value="">—</option>
+        <option value=""></option>
         <option value="Mensal">Mensal</option>
         <option value="Semestral">Semestral</option>
         <option value="Anual">Anual</option>
@@ -89,12 +89,13 @@
     </label>
     <label>Status
       <select name="status">
-        <option value="ativo">Ativo</option>
-        <option value="inativo">Inativo</option>
+        <option value="ativo">ativo</option>
+        <option value="inativo">inativo</option>
       </select>
     </label>
-    <label>Método
+    <label>Método de Pagamento
       <select name="metodo_pagamento">
+        <option value=""></option>
         <option value="pix">pix</option>
         <option value="cartao_debito">cartao_debito</option>
         <option value="cartao_credito">cartao_credito</option>
@@ -105,8 +106,8 @@
     <label>Telefone <input type="text" name="telefone"></label>
     <label>Vencimento <input type="date" name="vencimento"></label>
     <menu>
-      <button type="submit">Salvar</button>
-      <button type="button" id="cancelEdit">Cancelar</button>
+      <button type="button" id="cancel-edit">Cancelar</button>
+      <button type="submit" id="save-edit">Salvar</button>
     </menu>
   </form>
 </dialog>

--- a/routes/admin.routes.js
+++ b/routes/admin.routes.js
@@ -4,7 +4,7 @@ const { requireAdminPin } = require('../middlewares/requireAdminPin');
 
 router.get('/', requireAdminPin, c.list);
 router.post('/', requireAdminPin, c.upsertOne);
-router.put('/:cpf', requireAdminPin, c.updateByCpf);
+router.put('/:cpf', requireAdminPin, c.updateOne);
 router.post('/bulk', requireAdminPin, c.bulkUpsert);
 router.delete('/:cpf', requireAdminPin, c.remove);
 router.post('/generate-ids', requireAdminPin, c.generateIds);


### PR DESCRIPTION
## Summary
- enable inline client editing via modal and PUT requests
- support partial updates of clients by CPF on the API
- polish admin UX with loading state on save button

## Testing
- `npm test`
- `curl -i -X PUT "$API/admin/clientes/02655274148?pin=$PIN" -H "Content-Type: application/json" -d '{"nome":"Cliente Editado","status":"ativo","plano":"Mensal"}'`
- `curl -i -X PUT "$API/admin/clientes/02655274148?pin=$PIN" -H "Content-Type: application/json" -d '{"status":"suspenso"}'`


------
https://chatgpt.com/codex/tasks/task_e_68b37d28b4e0832b810d5cc906a6598b