### PR TITLE
feat: export clientes csv

### DIFF
--- a/public/admin/clientes.html
+++ b/public/admin/clientes.html
@@ -12,6 +12,10 @@
   #filters .actions { margin-left: auto; display: flex; gap: 8px; }
   #pager { margin-top: 8px; }
   dialog form { display: flex; flex-direction: column; gap: 8px; }
+  #loading { position: fixed; inset: 0; background: rgba(255,255,255,0.7); display: flex; align-items: center; justify-content: center; z-index: 1000; }
+  #loading[hidden] { display: none; }
+  #loading .spinner { width: 40px; height: 40px; border: 4px solid #ccc; border-top-color: #333; border-radius: 50%; animation: spin 1s linear infinite; }
+  @keyframes spin { to { transform: rotate(360deg); } }
 </style>
 </head>
 <body>
@@ -43,14 +47,24 @@
       <option value="Semestral">Semestral</option>
       <option value="Anual">Anual</option>
     </select>
+    <label>Itens por página
+      <select id="page-size">
+        <option value="25">25</option>
+        <option value="50">50</option>
+        <option value="100">100</option>
+        <option value="200">200</option>
+      </select>
+    </label>
     <button id="filtrar">Filtrar</button>
     <button id="limpar" type="button">Limpar</button>
     <div class="actions">
       <button id="btn-generate-ids" type="button">Gerar IDs</button>
       <a href="/admin/importar.html" id="importar-csv">Importar CSV</a>
+      <button id="btn-export" type="button">Exportar CSV</button>
+      <label><input type="checkbox" id="export-all"> Exportar tudo</label>
     </div>
   </section>
-  <div id="loading" hidden>Carregando...</div>
+  <div id="loading" hidden><div class="spinner"></div></div>
 
   <table class="card">
     <thead>

--- a/routes/admin.routes.js
+++ b/routes/admin.routes.js
@@ -3,6 +3,7 @@ const c = require('../controllers/clientesController');
 const { requireAdminPin } = require('../middlewares/requireAdminPin');
 
 router.get('/', requireAdminPin, c.list);
+router.get('/export', requireAdminPin, c.exportCsv);
 router.post('/', requireAdminPin, c.upsertOne);
 router.put('/:cpf', requireAdminPin, c.updateOne);
 router.post('/bulk', requireAdminPin, c.bulkUpsert);


### PR DESCRIPTION
## Summary
- add PIN-protected route to export filtered clients as CSV
- enhance admin UI with CSV export button, page size selector, debounced search and loading overlay

## Testing
- `npm test`
- `curl -i "$API/health"`
- `curl -i -H "x-admin-pin: $PIN" "$API/admin/clientes/export?q=jo&status=ativo&plano=Anual&limit=50&offset=0"`
- `curl -i -H "x-admin-pin: $PIN" "$API/admin/clientes/export?export_all=1"`


------
https://chatgpt.com/codex/tasks/task_e_68b380257424832b94c309eec8454475