### PR TITLE
feat: add admin audit log interface

### DIFF
--- a/controllers/auditController.js
+++ b/controllers/auditController.js
@@ -3,7 +3,14 @@ const { supabase, assertSupabase } = require('../supabaseClient');
 exports.list = async (req, res, next) => {
   try {
     if (!assertSupabase(res)) return;
-    let { limit = 50, offset = 0, action, route } = req.query || {};
+    let {
+      limit = 50,
+      offset = 0,
+      action,
+      route,
+      date_from,
+      date_to
+    } = req.query || {};
     limit = Math.min(parseInt(limit, 10) || 50, 200);
     offset = parseInt(offset, 10) || 0;
     let query = supabase
@@ -13,9 +20,83 @@ exports.list = async (req, res, next) => {
       .range(offset, offset + limit - 1);
     if (action) query = query.eq('action', action);
     if (route) query = query.eq('route', route);
+    if (date_from) {
+      const from = new Date(`${date_from}T00:00:00`);
+      if (!isNaN(from)) query = query.gte('created_at', from.toISOString());
+    }
+    if (date_to) {
+      const to = new Date(`${date_to}T23:59:59`);
+      if (!isNaN(to)) query = query.lte('created_at', to.toISOString());
+    }
     const { data, count, error } = await query;
     if (error) return next(error);
     return res.json({ rows: data || [], total: count || 0 });
+  } catch (err) {
+    return next(err);
+  }
+};
+
+exports.exportCsv = async (req, res, next) => {
+  try {
+    if (!assertSupabase(res)) return;
+    const {
+      action = '',
+      route = '',
+      date_from = '',
+      date_to = '',
+      limit = 50,
+      offset = 0,
+      export_all
+    } = req.query || {};
+    const lim = Math.min(parseInt(limit, 10) || 50, 200);
+    const off = parseInt(offset, 10) || 0;
+    let query = supabase
+      .from('audit_logs')
+      .select(
+        'created_at,route,action,admin_pin_hash,client_cpf,payload'
+      )
+      .order('created_at', { ascending: false });
+    if (action) query = query.eq('action', action);
+    if (route) query = query.eq('route', route);
+    if (date_from) {
+      const from = new Date(`${date_from}T00:00:00`);
+      if (!isNaN(from)) query = query.gte('created_at', from.toISOString());
+    }
+    if (date_to) {
+      const to = new Date(`${date_to}T23:59:59`);
+      if (!isNaN(to)) query = query.lte('created_at', to.toISOString());
+    }
+    const exportAll =
+      export_all === true ||
+      export_all === 'true' ||
+      export_all === '1' ||
+      export_all === 1;
+    if (!exportAll) {
+      query = query.range(off, off + lim - 1);
+    }
+    const { data, error } = await query;
+    if (error) return next(error);
+    const header =
+      'created_at,route,action,admin_pin_hash,client_cpf,payload';
+    const lines = (data || []).map(r =>
+      [
+        r.created_at,
+        r.route,
+        r.action,
+        r.admin_pin_hash,
+        r.client_cpf,
+        JSON.stringify(r.payload)
+      ]
+        .map(v => '"' + String(v ?? '').replace(/"/g, '""') + '"')
+        .join(',')
+    );
+    const csv = [header, ...lines].join('\n');
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader(
+      'Content-Disposition',
+      'attachment; filename="audit.csv"'
+    );
+    return res.send(csv);
   } catch (err) {
     return next(err);
   }

--- a/public/admin/assinatura.html
+++ b/public/admin/assinatura.html
@@ -12,6 +12,7 @@
     <a href="/admin/cadastro.html">Clientes &gt; Novo</a>
     <a href="/admin/assinatura.html">Assinaturas</a>
     <a href="/deploy-check.html">Status/Health</a>
+    <a href="/admin/audit.html">Auditoria</a>
   </nav>
   <div><label>PIN <input type="password" id="pin" class="pin-input"></label></div>
 </header>

--- a/public/admin/audit.html
+++ b/public/admin/audit.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<title>Auditoria</title>
+<link rel="stylesheet" href="/assets/app.css">
+<style>
+  button { cursor: pointer; }
+  table { width: 100%; border-collapse: collapse; }
+  th, td { border: 1px solid #ccc; padding: 4px; }
+  #filters { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+  #pager { margin-top: 8px; }
+  #loading { position: fixed; inset: 0; background: rgba(255,255,255,0.7); display: flex; align-items: center; justify-content: center; z-index: 1000; }
+  #loading[hidden] { display: none; }
+  #loading .spinner { width: 40px; height: 40px; border: 4px solid #ccc; border-top-color: #333; border-radius: 50%; animation: spin 1s linear infinite; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  dialog pre { max-height: 400px; overflow: auto; }
+</style>
+</head>
+<body>
+<header>
+  <nav>
+    <a href="/admin/cadastro.html">Cadastro</a>
+    <a href="/admin/clientes.html">Clientes</a>
+    <a href="/status/health">Status/Health</a>
+    <a href="/admin/audit.html">Auditoria</a>
+  </nav>
+  <div>
+    <label>PIN <input type="password" id="pin" class="pin-input"></label>
+    <button id="save-pin">Salvar PIN</button>
+  </div>
+</header>
+<div id="message"></div>
+<main>
+  <section id="filters" class="card">
+    <input type="text" id="route" placeholder="Rota">
+    <select id="action">
+      <option value="">Todas as ações</option>
+      <option value="create">create</option>
+      <option value="update">update</option>
+      <option value="delete">delete</option>
+      <option value="generate_ids">generate_ids</option>
+      <option value="import">import</option>
+    </select>
+    <label>De <input type="date" id="date-from"></label>
+    <label>Até <input type="date" id="date-to"></label>
+    <label>Itens por página
+      <select id="page-size">
+        <option value="25">25</option>
+        <option value="50">50</option>
+        <option value="100">100</option>
+        <option value="200">200</option>
+      </select>
+    </label>
+    <button id="filtrar">Filtrar</button>
+    <button id="limpar" type="button">Limpar</button>
+    <button id="export" type="button">Exportar CSV</button>
+  </section>
+  <div id="loading" hidden><div class="spinner"></div></div>
+  <table class="card">
+    <thead>
+      <tr>
+        <th>Data/Hora</th>
+        <th>Rota</th>
+        <th>Ação</th>
+        <th>CPF</th>
+        <th>Admin</th>
+        <th>Detalhes</th>
+      </tr>
+    </thead>
+    <tbody id="rows"></tbody>
+  </table>
+  <div id="pager">
+    <button id="prev" type="button">Anterior</button>
+    <span id="info"></span>
+    <button id="next" type="button">Próxima</button>
+  </div>
+</main>
+<dialog id="detail-modal">
+  <pre id="detail-pre"></pre>
+  <button id="detail-more" hidden>Mostrar mais</button>
+  <menu>
+    <button id="close-detail" type="button">Fechar</button>
+  </menu>
+</dialog>
+<script src="/admin/admin-common.js"></script>
+<script type="module" src="/admin/audit.js"></script>
+</body>
+</html>

--- a/public/admin/audit.js
+++ b/public/admin/audit.js
@@ -1,0 +1,184 @@
+const PAGE_SIZE_KEY = 'ADMIN_PAGE_SIZE';
+const savedSize = parseInt(localStorage.getItem(PAGE_SIZE_KEY), 10);
+const initialSize = [25,50,100,200].includes(savedSize) ? savedSize : 25;
+const state = { route:'', action:'', date_from:'', date_to:'', limit:initialSize, offset:0, total:0, rows:[] };
+
+const routeInput = document.getElementById('route');
+const actionSel = document.getElementById('action');
+const dateFromInput = document.getElementById('date-from');
+const dateToInput = document.getElementById('date-to');
+const pageSizeSel = document.getElementById('page-size');
+const filterBtn = document.getElementById('filtrar');
+const clearBtn = document.getElementById('limpar');
+const exportBtn = document.getElementById('export');
+const prevBtn = document.getElementById('prev');
+const nextBtn = document.getElementById('next');
+const infoSpan = document.getElementById('info');
+const rowsTbody = document.getElementById('rows');
+const loadingDiv = document.getElementById('loading');
+const detailModal = document.getElementById('detail-modal');
+const detailPre = document.getElementById('detail-pre');
+const detailMore = document.getElementById('detail-more');
+const closeDetail = document.getElementById('close-detail');
+const pinInput = document.getElementById('pin');
+const savePinBtn = document.getElementById('save-pin');
+
+if(pinInput){ pinInput.value = getPin(); }
+savePinBtn?.addEventListener('click', ()=> setPin(pinInput.value.trim()));
+
+function setLoading(flag){ loadingDiv.hidden = !flag; }
+function applyFiltersFromUI(){
+  state.route = routeInput.value.trim();
+  state.action = actionSel.value;
+  state.date_from = dateFromInput.value;
+  state.date_to = dateToInput.value;
+}
+function syncUIFromState(){
+  routeInput.value = state.route;
+  actionSel.value = state.action;
+  dateFromInput.value = state.date_from;
+  dateToInput.value = state.date_to;
+  if(pageSizeSel) pageSizeSel.value = String(state.limit);
+}
+async function fetchList(){
+  const params = new URLSearchParams();
+  if(state.route) params.append('route', state.route);
+  if(state.action) params.append('action', state.action);
+  if(state.date_from) params.append('date_from', state.date_from);
+  if(state.date_to) params.append('date_to', state.date_to);
+  params.append('limit', state.limit);
+  params.append('offset', state.offset);
+  setLoading(true);
+  prevBtn.disabled = true; nextBtn.disabled = true;
+  try{
+    const resp = await fetch('/admin/audit?'+params.toString(), { headers: withPinHeaders() });
+    const data = await resp.json().catch(()=>({rows:[], total:0}));
+    if(resp.status === 401){ showMessage('PIN inválido', 'error'); return; }
+    if(!resp.ok){ showMessage(data.error || 'Erro ao buscar', 'error'); return; }
+    state.rows = data.rows || [];
+    state.total = data.total || 0;
+    renderRows();
+  }catch(err){
+    showMessage(err.message || 'Erro ao buscar', 'error');
+  }finally{
+    updatePager();
+    setLoading(false);
+  }
+}
+function renderRows(){
+  if(state.rows.length === 0){
+    rowsTbody.innerHTML = '<tr><td colspan="6">Nenhum log encontrado.</td></tr>';
+    return;
+  }
+  rowsTbody.innerHTML = '';
+  state.rows.forEach((r,i)=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${new Date(r.created_at).toLocaleString()}</td><td>${r.route}</td><td>${r.action}</td><td>${r.client_cpf||''}</td><td>${(r.admin_pin_hash||'').slice(0,8)}</td><td><button type="button" class="btn-detail" data-idx="${i}">Ver Detalhes</button></td>`;
+    rowsTbody.appendChild(tr);
+  });
+  rowsTbody.querySelectorAll('.btn-detail').forEach(btn=>{
+    btn.addEventListener('click', ()=>{
+      const idx = parseInt(btn.dataset.idx,10);
+      openDetail(state.rows[idx]);
+    });
+  });
+}
+function updatePager(){
+  const start = state.total===0?0:state.offset+1;
+  const end = state.offset + state.rows.length;
+  infoSpan.textContent = `Mostrando ${start}-${end} de ${state.total}`;
+  prevBtn.disabled = state.offset === 0;
+  nextBtn.disabled = state.offset + state.rows.length >= state.total;
+}
+function openDetail(row){
+  const text = JSON.stringify(row.payload, null, 2) || '';
+  const MAX = 1000;
+  if(text.length > MAX){
+    detailPre.textContent = text.slice(0,MAX) + '...';
+    detailMore.hidden = false;
+    detailMore.onclick = ()=>{ detailPre.textContent = text; detailMore.hidden = true; };
+  }else{
+    detailPre.textContent = text;
+    detailMore.hidden = true;
+  }
+  detailModal.showModal();
+}
+closeDetail.addEventListener('click', ()=> detailModal.close());
+let routeTimer;
+routeInput.addEventListener('input', ()=>{
+  clearTimeout(routeTimer);
+  routeTimer = setTimeout(()=>{
+    applyFiltersFromUI();
+    state.offset = 0;
+    fetchList();
+  },300);
+});
+routeInput.addEventListener('keydown', e=>{
+  if(e.key === 'Enter'){
+    e.preventDefault();
+    clearTimeout(routeTimer);
+    applyFiltersFromUI();
+    state.offset = 0;
+    fetchList();
+  }
+});
+pageSizeSel?.addEventListener('change', ()=>{
+  const val = parseInt(pageSizeSel.value,10);
+  state.limit = val;
+  localStorage.setItem(PAGE_SIZE_KEY, String(val));
+  state.offset = 0;
+  fetchList();
+});
+filterBtn.addEventListener('click', ()=>{
+  applyFiltersFromUI();
+  state.offset = 0;
+  fetchList();
+});
+clearBtn.addEventListener('click', ()=>{
+  state.route='';
+  state.action='';
+  state.date_from='';
+  state.date_to='';
+  syncUIFromState();
+  state.offset = 0;
+  fetchList();
+});
+prevBtn.addEventListener('click', ()=>{
+  if(state.offset === 0) return;
+  state.offset = Math.max(0, state.offset - state.limit);
+  fetchList();
+});
+nextBtn.addEventListener('click', ()=>{
+  if(state.offset + state.rows.length >= state.total) return;
+  state.offset += state.limit;
+  fetchList();
+});
+exportBtn.addEventListener('click', async ()=>{
+  const params = new URLSearchParams();
+  if(state.route) params.append('route', state.route);
+  if(state.action) params.append('action', state.action);
+  if(state.date_from) params.append('date_from', state.date_from);
+  if(state.date_to) params.append('date_to', state.date_to);
+  params.append('limit', state.limit);
+  params.append('offset', state.offset);
+  exportBtn.disabled = true;
+  setLoading(true);
+  try{
+    const resp = await fetch('/admin/audit/export?'+params.toString(), { headers: withPinHeaders() });
+    if(!resp.ok) throw new Error('http '+resp.status);
+    const blob = await resp.blob();
+    const a = document.createElement('a');
+    const now = new Date().toISOString().slice(0,10);
+    a.href = URL.createObjectURL(blob);
+    a.download = `audit-${now}.csv`;
+    a.click();
+  }catch(err){
+    showMessage('Falha ao exportar. Tente novamente.', 'error');
+  }finally{
+    exportBtn.disabled = false;
+    setLoading(false);
+  }
+});
+
+syncUIFromState();
+fetchList();

--- a/public/admin/cadastro.html
+++ b/public/admin/cadastro.html
@@ -11,6 +11,7 @@
     <a href="/admin/cadastro.html">Cadastro</a>
     <a href="/admin/clientes.html">Clientes</a>
     <a href="/status/health">Status/Health</a>
+    <a href="/admin/audit.html">Auditoria</a>
   </nav>
   <div>
     <label>PIN <input type="password" id="pin" class="pin-input"></label>

--- a/public/admin/clientes.html
+++ b/public/admin/clientes.html
@@ -24,6 +24,7 @@
     <a href="/admin/cadastro.html">Cadastro</a>
     <a href="/admin/clientes.html">Clientes</a>
     <a href="/status/health">Status/Health</a>
+    <a href="/admin/audit.html">Auditoria</a>
   </nav>
   <div>
     <label>PIN <input type="password" id="pin" class="pin-input"></label>

--- a/public/admin/importar.html
+++ b/public/admin/importar.html
@@ -12,6 +12,7 @@
     <a href="/admin/clientes.html">Clientes</a>
     <a href="/admin/importar.html">Importar</a>
     <a href="/status/health">Status/Health</a>
+    <a href="/admin/audit.html">Auditoria</a>
   </nav>
   <div>
     <label>PIN <input type="password" id="pin" class="pin-input"></label>

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -11,6 +11,7 @@
     <a href="/admin/cadastro.html">Cadastro</a>
     <a href="/admin/clientes.html">Clientes</a>
     <a href="/deploy-check.html">Status/Health</a>
+    <a href="/admin/audit.html">Auditoria</a>
   </nav>
   <div>
     <label>PIN <input type="password" id="pin" class="pin-input"></label>

--- a/server.js
+++ b/server.js
@@ -54,6 +54,7 @@ app.use('/admin', express.static(path.join(__dirname, 'public', 'admin')));
 // rotas de API de admin
 app.use('/admin/clientes', clientesRouter);
 app.get('/admin/audit', requireAdminPin, auditController.list);
+app.get('/admin/audit/export', requireAdminPin, auditController.exportCsv);
 
 // /__routes opcional e protegido por PIN
 function listRoutesSafe(app) {


### PR DESCRIPTION
## Summary
- add audit log export and date filters to `/admin/audit`
- expose `/admin/audit/export` for CSV downloads
- create admin UI for browsing audit logs with filters, pagination and export

## Testing
- `npm test`
- `curl -i http://localhost:3000/health`
- `curl -s -H "x-admin-pin: 1234" "http://localhost:3000/admin/audit?limit=25&action=update"`
- `curl -i -H "x-admin-pin: 1234" "http://localhost:3000/admin/audit/export?export_all=1&action=delete"`


------
https://chatgpt.com/codex/tasks/task_e_68b38518cff0832b9753243f23019502