### PR TITLE
feat: enhance admin reports and UI

### DIFF
--- a/__tests__/admin.report.test.js
+++ b/__tests__/admin.report.test.js
@@ -9,6 +9,7 @@ const queryBuilder = {
   gte: jest.fn(() => queryBuilder),
   lte: jest.fn(() => queryBuilder),
   order: jest.fn(() => queryBuilder),
+  limit: jest.fn(() => queryBuilder),
   then: (resolve) => Promise.resolve(resolve(queryResult)),
 };
 
@@ -64,14 +65,12 @@ describe('GET /admin/report/csv', () => {
     queryResult = {
       data: [
         {
-          cpf: '12345678900',
-          nome: 'Fulano',
-          email: 'f@e.com',
-          telefone: '11999999999',
-          plano: 'Mensal',
-          status: 'ativo',
-          metodo_pagamento: 'pix',
           created_at: '2023-01-01T00:00:00Z',
+          route: '/x',
+          action: 'do',
+          admin_pin_hash: 'hash',
+          client_cpf: '12345678900',
+          payload: { a: 1 },
         },
       ],
       error: null,
@@ -81,6 +80,6 @@ describe('GET /admin/report/csv', () => {
       .set('x-admin-pin', '2468');
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toMatch(/text\/csv/);
-    expect(res.text).toContain('cpf;nome');
+    expect(res.text).toContain('created_at;rota;action;admin_pin_hash;client_cpf;payload');
   });
 });

--- a/controllers/adminReportController.js
+++ b/controllers/adminReportController.js
@@ -43,56 +43,39 @@ exports.summary = async (req, res, next) => {
 exports.csv = async (req, res, next) => {
   try {
     if (!assertSupabase(res)) return;
-    let q = supabase
-      .from('clientes')
-      .select(
-        'cpf,nome,email,telefone,plano,status,metodo_pagamento,created_at'
-      )
-      .order('created_at', { ascending: true });
+    const exportAll = String(req.query.export_all || '') === '1';
+    const limit = exportAll ? 5000 : Math.min(Number(req.query.limit || 500), 5000);
 
-    const { status, plano, metodo, from, to } = req.query || {};
-    if (status) q = q.eq('status', status);
-    if (plano) q = q.eq('plano', plano);
-    if (metodo) q = q.eq('metodo_pagamento', metodo);
-    if (from) q = q.gte('created_at', new Date(from + 'T00:00:00').toISOString());
-    if (to) q = q.lte('created_at', new Date(to + 'T23:59:59').toISOString());
-
-    const { data, error } = await q;
+    const { data: logs, error } = await supabase
+      .from('audit_logs')
+      .select('created_at,route,action,admin_pin_hash,client_cpf,payload')
+      .order('created_at', { ascending: false })
+      .limit(limit);
     if (error) throw error;
 
     const headers = [
-      'cpf',
-      'nome',
-      'email',
-      'telefone',
-      'plano',
-      'status',
-      'metodo_pagamento',
       'created_at',
+      'rota',
+      'action',
+      'admin_pin_hash',
+      'client_cpf',
+      'payload',
     ];
 
-    const rows = (data || []).map((c) => [
-      keepAsText(c.cpf ?? ''),
-      cell(c.nome ?? ''),
-      cell(c.email ?? ''),
-      keepAsText(c.telefone ?? ''),
-      cell(c.plano ?? ''),
-      cell(c.status ?? ''),
-      cell(c.metodo_pagamento ?? ''),
-      cell(formatDate(c.created_at)),
+    const rows = (logs || []).map((r) => [
+      cell(formatDate(r.created_at)),
+      cell(r.route ?? ''),
+      cell(r.action ?? ''),
+      cell(r.admin_pin_hash ?? ''),
+      keepAsText(r.client_cpf ?? ''),
+      cell(r.payload ? JSON.stringify(r.payload) : ''),
     ]);
 
     const csv = toCSV({ headers, rows });
 
     res.setHeader('Content-Type', 'text/csv; charset=utf-8');
-    const now = new Date();
-    const pad = (n) => String(n).padStart(2, '0');
-    const fname = `clientes-report-${now.getFullYear()}${pad(
-      now.getMonth() + 1
-    )}${pad(now.getDate())}-${pad(now.getHours())}${pad(
-      now.getMinutes()
-    )}.csv`;
-    res.setHeader('Content-Disposition', `attachment; filename="${fname}"`);
+    const today = new Date().toISOString().slice(0, 10);
+    res.setHeader('Content-Disposition', `attachment; filename="relatorio-${today}.csv"`);
 
     return res.status(200).send(csv);
   } catch (err) {

--- a/public/admin/admin-common.js
+++ b/public/admin/admin-common.js
@@ -6,13 +6,31 @@ function setPin(pin) {
   localStorage.setItem('ADMIN_PIN', pin);
 }
 
-function withPinHeaders(headers = {}) {
-  return { ...headers, 'x-admin-pin': getPin() };
+function withPinHeaders(init = {}) {
+  const headers = new Headers(init.headers || {});
+  const pin = getPin();
+  if (pin) headers.set('x-admin-pin', pin);
+  return { ...init, headers };
 }
 
 function showMessage(message, type = 'success') {
   const el = document.getElementById('message');
   if (!el) return;
   el.textContent = message;
-  el.style.color = type === 'error' ? 'red' : 'green';
+  el.className = type === 'error' ? 'error' : 'success';
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+  const pinInput = document.getElementById('pin');
+  const saveBtn = document.getElementById('save-pin');
+  if (pinInput) pinInput.value = getPin();
+  saveBtn?.addEventListener('click', () => {
+    setPin(pinInput?.value || '');
+    showMessage('PIN salvo', 'success');
+  });
+});
+
+window.getPin = getPin;
+window.setPin = setPin;
+window.withPinHeaders = withPinHeaders;
+window.showMessage = showMessage;

--- a/public/admin/clientes.html
+++ b/public/admin/clientes.html
@@ -19,24 +19,23 @@
 </style>
 </head>
 <body>
-<header>
-  <nav>
+<header class="container">
+  <nav class="grid" style="grid-auto-flow:column;gap:12px;align-items:center;">
     <a href="/admin/dashboard.html">Dashboard</a>
     <a href="/admin/cadastro.html">Cadastro</a>
     <a href="/admin/clientes.html">Clientes</a>
     <a href="/status/health">Status/Health</a>
     <a href="/admin/relatorios.html">Relatórios</a>
     <a href="/admin/audit.html">Auditoria</a>
+    <span style="margin-left:auto;">PIN</span>
+    <input type="password" id="pin" class="pin-input" />
+    <button id="save-pin" class="btn primary">Salvar PIN</button>
   </nav>
-  <div>
-    <label>PIN <input type="password" id="pin" class="pin-input"></label>
-    <button id="save-pin">Salvar PIN</button>
-  </div>
 </header>
 
-<div id="message"></div>
+<div id="message" class="container muted"></div>
 
-<main>
+<main class="container">
   <section id="filters" class="card">
     <input type="text" id="q" placeholder="Buscar por CPF/Nome">
     <select id="status">
@@ -58,17 +57,17 @@
         <option value="200">200</option>
       </select>
     </label>
-    <button id="filtrar">Filtrar</button>
-    <button id="limpar" type="button">Limpar</button>
+    <button id="filtrar" class="btn primary">Filtrar</button>
+    <button id="limpar" type="button" class="btn ghost">Limpar</button>
     <div class="actions">
-      <button id="btn-generate-ids" type="button">Gerar IDs</button>
-      <a href="/admin/importar.html" id="importar-csv">Importar CSV</a>
-      <button id="export-csv" type="button">Exportar CSV</button>
+      <button id="btn-generate-ids" type="button" class="btn ghost">Gerar IDs</button>
+      <a href="/admin/importar.html" id="importar-csv" class="btn ghost">Importar CSV</a>
+      <button id="export-csv" type="button" class="btn ghost">Exportar CSV</button>
     </div>
   </section>
   <div id="loading" hidden><div class="spinner"></div></div>
 
-  <table class="card">
+  <table class="card table">
     <thead>
       <tr>
         <th>CPF</th>
@@ -84,10 +83,10 @@
     <tbody id="rows"></tbody>
   </table>
 
-  <div id="pager">
-    <button id="prev" type="button">Anterior</button>
+  <div id="pager" class="grid" style="grid-template-columns:auto 1fr auto;align-items:center;gap:8px;">
+    <button id="prev" type="button" class="btn">Anterior</button>
     <span id="info"></span>
-    <button id="next" type="button">Próxima</button>
+    <button id="next" type="button" class="btn">Próxima</button>
   </div>
 </main>
 

--- a/public/admin/clientes.js
+++ b/public/admin/clientes.js
@@ -17,8 +17,6 @@ const nextBtn = document.getElementById('next');
 const infoSpan = document.getElementById('info');
 const rowsTbody = document.getElementById('rows');
 const loadingDiv = document.getElementById('loading');
-const pinInput = document.getElementById('pin');
-const savePinBtn = document.getElementById('save-pin');
 
 const editModal = document.getElementById('edit-modal');
 const editForm = document.getElementById('edit-form');
@@ -194,12 +192,6 @@ const table = document.querySelector('table');
       el.textContent = `Erro ao gerar IDs: ${e.message}`;
       el.style.color = 'red';
     }
-  });
-
-  pinInput.value = getPin();
-  savePinBtn.addEventListener('click', () => {
-    setPin(pinInput.value.trim());
-    showMessage('PIN salvo', 'success');
   });
 
   table.addEventListener('click', async (ev) => {

--- a/public/admin/dashboard.html
+++ b/public/admin/dashboard.html
@@ -6,69 +6,49 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="/assets/app.css" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <script defer src="/admin/admin-common.js"></script>
-  <style>
-    .grid { display: grid; gap: 16px; }
-    .cards { grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
-    .card { background:#fff; border-radius:12px; padding:16px; box-shadow: 0 2px 10px rgba(0,0,0,.06); }
-    .muted { color:#666; font-size:.9rem; }
-    .wrap { max-width: 1100px; margin: 24px auto; padding: 0 16px; }
-    table { width:100%; border-collapse: collapse; }
-    th, td { border-bottom:1px solid #eee; padding:8px 6px; text-align:left; }
-    h1 { margin: 12px 0 8px; }
-  </style>
+  <script src="/admin/admin-common.js"></script>
 </head>
 <body>
-  <header class="wrap">
-    <nav style="display:flex; gap:12px; align-items:center;">
+  <header class="container">
+    <nav class="grid" style="grid-auto-flow:column;gap:12px;align-items:center;">
       <a href="/admin/dashboard.html">Dashboard</a>
       <a href="/admin/cadastro.html">Cadastro</a>
       <a href="/admin/clientes.html">Clientes</a>
       <a href="/admin/relatorios.html">Relatórios</a>
       <a href="/admin/audit.html">Auditoria</a>
-      <strong style="margin-left:auto;">PIN</strong>
-      <input id="pin" class="pin-input" type="password" placeholder="••••" style="width:90px" />
-      <button id="save-pin">Salvar PIN</button>
+      <span style="margin-left:auto;">PIN</span>
+      <input id="pin" class="pin-input" type="password" placeholder="••••" />
+      <button id="save-pin" class="btn primary">Salvar PIN</button>
     </nav>
     <h1>Dashboard</h1>
     <p class="muted">Visão geral dos clientes e assinaturas</p>
   </header>
+  <div id="message" class="container muted"></div>
 
-  <main class="wrap grid" style="gap:24px;">
-    <section class="grid cards">
-      <div class="card"><div class="muted">Total</div><div id="m-total" style="font-size:2rem;">—</div></div>
-      <div class="card"><div class="muted">Ativos</div><div id="m-ativos" style="font-size:2rem;color:#27ae60;">—</div></div>
-      <div class="card"><div class="muted">Inativos</div><div id="m-inativos" style="font-size:2rem;color:#e74c3c;">—</div></div>
-      <div class="card"><div class="muted">Novos (30d)</div><div id="m-novos30" style="font-size:2rem;">—</div></div>
+  <main class="container grid" style="gap:24px;">
+    <section class="grid grid-cards">
+      <div class="card"><div class="muted">Total</div><div id="m-total" class="kpi">—</div></div>
+      <div class="card"><div class="muted">Ativos</div><div id="m-ativos" class="kpi" style="color:#27ae60;">—</div></div>
+      <div class="card"><div class="muted">Inativos</div><div id="m-inativos" class="kpi" style="color:#e74c3c;">—</div></div>
+      <div class="card"><div class="muted">Novos (30d)</div><div id="m-novos30" class="kpi">—</div></div>
     </section>
 
     <section class="grid" style="grid-template-columns:1fr 1fr;">
       <div class="card">
         <h3>Por Plano</h3>
         <canvas id="chartPlano" height="180"></canvas>
-        <table id="tblPlano"><thead><tr><th>Plano</th><th>Qtd</th></tr></thead><tbody></tbody></table>
+        <table id="tblPlano" class="table"><thead><tr><th>Plano</th><th>Qtd</th></tr></thead><tbody></tbody></table>
       </div>
       <div class="card">
         <h3>Por Método</h3>
         <canvas id="chartMetodo" height="180"></canvas>
-        <table id="tblMetodo"><thead><tr><th>Método</th><th>Qtd</th></tr></thead><tbody></tbody></table>
+        <table id="tblMetodo" class="table"><thead><tr><th>Método</th><th>Qtd</th></tr></thead><tbody></tbody></table>
       </div>
     </section>
   </main>
 
   <script>
     (function () {
-      const $ = (q) => document.querySelector(q);
-
-      const pinInput = $('#pin');
-      const saveBtn = $('#save-pin');
-      pinInput.value = window.getPin?.() || '';
-      saveBtn.addEventListener('click', () => {
-        window.setPin?.(pinInput.value || '');
-        window.showMessage?.('PIN salvo', 'success');
-        load();
-      });
-
       async function fetchJSON(url) {
         const headers = window.withPinHeaders?.({}) || {};
         const resp = await fetch(url, { headers });

--- a/public/admin/relatorios.html
+++ b/public/admin/relatorios.html
@@ -5,35 +5,26 @@
   <title>Relatórios • Clube de Vantagens</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="/assets/app.css" />
-  <script defer src="/admin/admin-common.js"></script>
-  <style>
-    .grid { display: grid; gap: 16px; }
-    .cards { grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
-    .card { background:#fff; border-radius:12px; padding:16px; box-shadow:0 2px 10px rgba(0,0,0,.06); }
-    .muted { color:#666; font-size:.9rem; }
-    .wrap { max-width:1100px; margin:24px auto; padding:0 16px; }
-    table { width:100%; border-collapse: collapse; }
-    th, td { border-bottom:1px solid #eee; padding:8px 6px; text-align:left; }
-    h1 { margin:12px 0 8px; }
-  </style>
+  <script src="/admin/admin-common.js"></script>
 </head>
 <body>
-  <header class="wrap">
-    <nav style="display:flex; gap:12px; align-items:center;">
+  <header class="container">
+    <nav class="grid" style="grid-auto-flow:column;gap:12px;align-items:center;">
       <a href="/admin/dashboard.html">Dashboard</a>
       <a href="/admin/cadastro.html">Cadastro</a>
       <a href="/admin/clientes.html">Clientes</a>
       <a href="/admin/relatorios.html">Relatórios</a>
       <a href="/admin/audit.html">Auditoria</a>
-      <strong style="margin-left:auto;">PIN</strong>
-      <input id="pin" class="pin-input" type="password" placeholder="••••" style="width:90px" />
-      <button id="save-pin">Salvar PIN</button>
+      <span style="margin-left:auto;">PIN</span>
+      <input id="pin" class="pin-input" type="password" placeholder="••••" />
+      <button id="save-pin" class="btn primary">Salvar PIN</button>
     </nav>
     <h1>Relatórios</h1>
     <p class="muted">Resumo e exportação de clientes</p>
   </header>
+  <div id="message" class="container muted"></div>
 
-  <main class="wrap grid" style="gap:24px;">
+  <main class="container grid" style="gap:24px;">
     <section class="card grid" style="gap:8px;">
       <h3>Filtros</h3>
       <div class="grid" style="grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap:8px;">
@@ -57,88 +48,29 @@
         </select>
         <label>De <input type="date" id="f-from"></label>
         <label>Até <input type="date" id="f-to"></label>
-        <button id="btn-aplicar" type="button">Aplicar</button>
-        <button id="btn-csv" type="button">Gerar CSV</button>
+        <button id="btn-aplicar" type="button" class="btn primary">Aplicar</button>
+        <button id="btn-csv" type="button" class="btn ghost">Gerar CSV</button>
       </div>
     </section>
 
-    <section class="grid cards">
-      <div class="card"><div class="muted">Total</div><div id="s-total" style="font-size:2rem;">—</div></div>
-      <div class="card"><div class="muted">Ativos</div><div id="s-ativos" style="font-size:2rem;color:#27ae60;">—</div></div>
-      <div class="card"><div class="muted">Inativos</div><div id="s-inativos" style="font-size:2rem;color:#e74c3c;">—</div></div>
+    <section class="grid grid-cards">
+      <div class="card"><div class="muted">Total</div><div id="s-total" class="kpi">—</div></div>
+      <div class="card"><div class="muted">Ativos</div><div id="s-ativos" class="kpi" style="color:#27ae60;">—</div></div>
+      <div class="card"><div class="muted">Inativos</div><div id="s-inativos" class="kpi" style="color:#e74c3c;">—</div></div>
     </section>
 
     <section class="grid" style="grid-template-columns:1fr 1fr;">
       <div class="card">
         <h3>Por Plano</h3>
-        <table id="tblPlano"><thead><tr><th>Plano</th><th>Qtd</th></tr></thead><tbody></tbody></table>
+        <table id="tblPlano" class="table"><thead><tr><th>Plano</th><th>Qtd</th></tr></thead><tbody></tbody></table>
       </div>
       <div class="card">
         <h3>Por Método</h3>
-        <table id="tblMetodo"><thead><tr><th>Método</th><th>Qtd</th></tr></thead><tbody></tbody></table>
+        <table id="tblMetodo" class="table"><thead><tr><th>Método</th><th>Qtd</th></tr></thead><tbody></tbody></table>
       </div>
     </section>
   </main>
 
-  <script>
-    (function(){
-      const $ = (q) => document.querySelector(q);
-      const pinInput = $('#pin');
-      const saveBtn = $('#save-pin');
-      pinInput.value = window.getPin?.() || '';
-      saveBtn.addEventListener('click', () => {
-        window.setPin?.(pinInput.value || '');
-        window.showMessage?.('PIN salvo', 'success');
-        load();
-      });
-
-      function buildParams(){
-        const p = new URLSearchParams();
-        const pin = window.getPin?.();
-        if(pin) p.set('pin', pin);
-        const status = $('#f-status').value;
-        const plano = $('#f-plano').value;
-        const metodo = $('#f-metodo').value;
-        const from = $('#f-from').value;
-        const to = $('#f-to').value;
-        if(status) p.set('status', status);
-        if(plano) p.set('plano', plano);
-        if(metodo) p.set('metodo', metodo);
-        if(from) p.set('from', from);
-        if(to) p.set('to', to);
-        return p;
-      }
-
-      function fillTable(tid, obj){
-        const tb = document.querySelector(tid + ' tbody');
-        const rows = Object.entries(obj || {}).map(([k,v]) => `<tr><td>${k}</td><td>${v}</td></tr>`).join('');
-        tb.innerHTML = rows || '<tr><td colspan="2">—</td></tr>';
-      }
-
-      async function load(){
-        try {
-          const params = buildParams();
-          const resp = await fetch('/admin/report/summary?' + params.toString());
-          if(!resp.ok) throw new Error('HTTP ' + resp.status);
-          const json = await resp.json();
-          $('#s-total').textContent = json.total;
-          $('#s-ativos').textContent = json.ativos;
-          $('#s-inativos').textContent = json.inativos;
-          fillTable('#tblPlano', json.porPlano);
-          fillTable('#tblMetodo', json.porMetodo);
-        } catch(err) {
-          window.showMessage?.('Falha ao carregar', 'error');
-        }
-      }
-
-      $('#btn-aplicar').addEventListener('click', load);
-      $('#btn-csv').addEventListener('click', () => {
-        const params = buildParams();
-        window.location.href = '/admin/report/csv?' + params.toString();
-      });
-
-      load();
-    })();
-  </script>
+  <script src="/admin/relatorios.js"></script>
 </body>
 </html>

--- a/public/admin/relatorios.js
+++ b/public/admin/relatorios.js
@@ -1,0 +1,100 @@
+(function(){
+  const $ = (q) => document.querySelector(q);
+  const btnAplicar = $('#btn-aplicar');
+  const btnCsv = $('#btn-csv');
+
+  function getFilters(){
+    const p = new URLSearchParams();
+    const status = $('#f-status').value;
+    const plano = $('#f-plano').value;
+    const metodo = $('#f-metodo').value;
+    const from = $('#f-from').value;
+    const to = $('#f-to').value;
+    if(status) p.set('status', status);
+    if(plano) p.set('plano', plano);
+    if(metodo) p.set('metodo', metodo);
+    if(from) p.set('from', from);
+    if(to) p.set('to', to);
+    return p;
+  }
+
+  function fillTable(id, obj){
+    const tb = document.querySelector(id + ' tbody');
+    const rows = Object.entries(obj || {}).map(([k,v]) => `<tr><td>${k}</td><td>${v}</td></tr>`).join('');
+    tb.innerHTML = rows || '<tr><td colspan="2">—</td></tr>';
+  }
+
+  function showLoading(flag){
+    btnAplicar.disabled = btnCsv.disabled = flag;
+  }
+
+  function showEmpty(){
+    $('#s-total').textContent = '0';
+    $('#s-ativos').textContent = '0';
+    $('#s-inativos').textContent = '0';
+    fillTable('#tblPlano', {});
+    fillTable('#tblMetodo', {});
+  }
+
+  function showError(msg){
+    showMessage(msg, 'error');
+  }
+
+  async function loadSummary(){
+    if(!getPin()){ showError('Informe o PIN no topo e clique em Salvar.'); return; }
+    showLoading(true);
+    try{
+      const params = getFilters();
+      const resp = await fetch('/admin/report/summary?' + params.toString(), withPinHeaders());
+      if(resp.status === 401){ showError('Informe o PIN no topo e clique em Salvar.'); showEmpty(); return; }
+      if(!resp.ok) throw new Error('HTTP '+resp.status);
+      const json = await resp.json();
+      $('#s-total').textContent = json.total;
+      $('#s-ativos').textContent = json.ativos;
+      $('#s-inativos').textContent = json.inativos;
+      fillTable('#tblPlano', json.porPlano);
+      fillTable('#tblMetodo', json.porMetodo);
+      if(json.total === 0) showEmpty();
+    }catch(err){
+      showError('Falha ao carregar');
+      showEmpty();
+    }finally{
+      showLoading(false);
+    }
+  }
+
+  async function downloadCsv(){
+    if(!getPin()){ showError('Informe o PIN no topo e clique em Salvar.'); return; }
+    const params = getFilters();
+    params.set('export_all','1');
+    showLoading(true);
+    try{
+      const resp = await fetch('/admin/report/csv?' + params.toString(), withPinHeaders());
+      if(resp.status === 401){ showError('Informe o PIN no topo e clique em Salvar.'); return; }
+      if(!resp.ok){
+        const txt = await resp.text().catch(()=> '');
+        try{ const j = JSON.parse(txt); showError(j.error || 'Falha ao exportar'); }
+        catch{ showError('Falha ao exportar'); }
+        return;
+      }
+      const blob = await resp.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      const today = new Date().toISOString().slice(0,10);
+      a.href = url;
+      a.download = `relatorio-${today}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    }catch(err){
+      showError('Falha ao exportar');
+    }finally{
+      showLoading(false);
+    }
+  }
+
+  btnAplicar.addEventListener('click', loadSummary);
+  btnCsv.addEventListener('click', downloadCsv);
+  loadSummary();
+})();

--- a/public/assets/app.css
+++ b/public/assets/app.css
@@ -14,3 +14,29 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .alert{margin-top:10px;padding:8px;border-radius:4px}
 .alert.error{background:#fdd;border:1px solid #f99}
 .alert.success{background:#dfd;border:1px solid #9f9}
+
+/* new layout helpers */
+.container{max-width:1100px;margin:0 auto;padding:16px}
+.grid{display:grid;gap:16px}
+.grid-cards{grid-template-columns:repeat(auto-fit,minmax(180px,1fr))}
+.card{background:#fff;border-radius:8px;padding:16px;box-shadow:0 2px 4px rgba(0,0,0,.06)}
+.card h3{margin-top:0;margin-bottom:8px}
+.kpi{font-size:2rem;font-weight:bold}
+.btn{padding:8px 12px;border-radius:4px;cursor:pointer;border:1px solid transparent;display:inline-block}
+.btn.primary{background:#007bff;color:#fff}
+.btn.ghost{background:transparent;border-color:#007bff;color:#007bff}
+.btn.is-loading{opacity:.6;pointer-events:none}
+.table{width:100%;border-collapse:collapse}
+.table th,.table td{padding:8px;border-bottom:1px solid #eee}
+.table th{position:sticky;top:0;background:#f5f5f5}
+.table tr:hover{background:#f9f9f9}
+.empty{text-align:center;padding:16px;color:#666}
+.error{color:#e74c3c}
+.muted{color:#666;font-size:.9rem}
+input,select{padding:10px;border:1px solid #ccc;border-radius:4px}
+@media (prefers-color-scheme:dark){
+  body{background:#111;color:#eee}
+  .card{background:#222;box-shadow:0 2px 4px rgba(0,0,0,.4)}
+  .table th{background:#333}
+  .table tr:hover{background:#2a2a2a}
+}


### PR DESCRIPTION
## Summary
- add shared admin helper to inject PIN headers and show messages
- export audit logs as CSV with semicolon separator and BOM
- refresh admin pages with responsive layout, buttons and loading states

## Testing
- `npm test`
- `curl -s http://localhost:8080/health`
- `curl -s -H "x-admin-pin: 2468" "http://localhost:8080/admin/report/summary?from=2025-08-01&to=2025-09-30"`
- `curl -i -H "x-admin-pin: 2468" "http://localhost:8080/admin/report/csv?from=2025-08-01&to=2025-09-30&export_all=1"`

------
https://chatgpt.com/codex/tasks/task_e_68b3bb7ea32c832b8e6811292b2d4032