### PR TITLE
feat: support per-admin pins

### DIFF
--- a/README-quickstart.md
+++ b/README-quickstart.md
@@ -5,7 +5,7 @@
 |---------|-----------|
 | `SUPABASE_URL` | URL do projeto Supabase. |
 | `SUPABASE_ANON` | Chave pública do Supabase. |
-| `ADMIN_PIN` | PIN exigido em rotas administrativas (`x-admin-pin`). |
+| `ADMIN_PIN` | PIN global de fallback para rotas administrativas (`x-admin-pin`). |
 | `ALLOWED_ORIGIN` | Domínio permitido para CORS (ex.: `https://seusite.netlify.app`). |
 
 ## Como testar

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ API em Node.js para gerenciamento de assinaturas, transações e administração
 |---------|-----------|
 | `SUPABASE_URL` | URL do projeto Supabase |
 | `SUPABASE_ANON` | Chave pública do Supabase |
-| `ADMIN_PIN` | PIN exigido em rotas administrativas (`x-admin-pin`) |
+| `ADMIN_PIN` | PIN global de fallback para rotas administrativas (`x-admin-pin`) |
 | `PORT` | Porta do servidor (padrão 3000) |
 | `ALLOWED_ORIGIN` | Lista de origens CORS permitidas separadas por vírgula |
 | `RECAPTCHA_SECRET` | Chave do reCAPTCHA usada na captura de leads |
@@ -58,8 +58,7 @@ API em Node.js para gerenciamento de assinaturas, transações e administração
 
 ## Rotas Administrativas (`/admin/*`)
 As páginas estáticas sob `/admin` (HTML, JS, CSS) podem ser acessadas sem PIN.
-Já as APIs administrativas requerem o cabeçalho `x-admin-pin` com o valor
-definido na variável de ambiente `ADMIN_PIN`.
+Já as APIs administrativas requerem o cabeçalho `x-admin-pin`, validado contra a tabela `admins` no Supabase (ou contra `ADMIN_PIN` se definido para compatibilidade).
 
 Exemplos de endpoints:
 

--- a/__tests__/admin.report.test.js
+++ b/__tests__/admin.report.test.js
@@ -69,6 +69,8 @@ describe('GET /admin/report/csv', () => {
           route: '/x',
           action: 'do',
           admin_pin_hash: 'hash',
+          admin_id: 1,
+          admin_nome: 'Admin',
           client_cpf: '12345678900',
           payload: { a: 1 },
         },
@@ -80,6 +82,6 @@ describe('GET /admin/report/csv', () => {
       .set('x-admin-pin', '2468');
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toMatch(/text\/csv/);
-    expect(res.text).toContain('created_at;rota;action;admin_pin_hash;client_cpf;payload');
+    expect(res.text).toContain('created_at;rota;action;admin_pin_hash;admin_id;admin_nome;client_cpf;payload');
   });
 });

--- a/controllers/adminReportController.js
+++ b/controllers/adminReportController.js
@@ -48,7 +48,7 @@ exports.csv = async (req, res, next) => {
 
     const { data: logs, error } = await supabase
       .from('audit_logs')
-      .select('created_at,route,action,admin_pin_hash,client_cpf,payload')
+      .select('created_at,route,action,admin_pin_hash,admin_id,admin_nome,client_cpf,payload')
       .order('created_at', { ascending: false })
       .limit(limit);
     if (error) throw error;
@@ -58,6 +58,8 @@ exports.csv = async (req, res, next) => {
       'rota',
       'action',
       'admin_pin_hash',
+      'admin_id',
+      'admin_nome',
       'client_cpf',
       'payload',
     ];
@@ -67,6 +69,8 @@ exports.csv = async (req, res, next) => {
       cell(r.route ?? ''),
       cell(r.action ?? ''),
       cell(r.admin_pin_hash ?? ''),
+      keepAsText(r.admin_id ?? ''),
+      cell(r.admin_nome ?? ''),
       keepAsText(r.client_cpf ?? ''),
       cell(r.payload ? JSON.stringify(r.payload) : ''),
     ]);

--- a/controllers/auditController.js
+++ b/controllers/auditController.js
@@ -45,7 +45,7 @@ exports.exportAudit = async (req, res, next) => {
 
     const { data: logs, error } = await supabase
       .from('audit_logs')
-      .select('created_at,route,action,admin_pin_hash,client_cpf,payload')
+      .select('created_at,route,action,admin_pin_hash,admin_id,admin_nome,client_cpf,payload')
       .order('created_at', { ascending: false })
       .limit(limit);
 
@@ -56,6 +56,8 @@ exports.exportAudit = async (req, res, next) => {
       'rota',
       'acao',
       'admin_pin_hash',
+      'admin_id',
+      'admin_nome',
       'cpf',
       'detalhes',
     ];
@@ -65,6 +67,8 @@ exports.exportAudit = async (req, res, next) => {
       cell(r.route ?? ''),
       cell(r.action ?? ''),
       cell(r.admin_pin_hash ?? ''),
+      keepAsText(r.admin_id ?? ''),
+      cell(r.admin_nome ?? ''),
       keepAsText(r.client_cpf ?? ''),
       cell(r.payload ? JSON.stringify(r.payload) : ''),
     ]);

--- a/controllers/mpController.js
+++ b/controllers/mpController.js
@@ -27,8 +27,15 @@ exports.checkout = async (req, res, next) => {
       raw: pref
     });
 
-    const pin = req.headers['x-admin-pin'] || req.query.pin;
-    await logAdminAction({ route: '/admin/mp/checkout', action: 'create', pin, client_cpf: cpf, payload: { valor } });
+    await logAdminAction({
+      route: '/admin/mp/checkout',
+      action: 'create',
+      adminId: req.adminId,
+      adminNome: req.adminNome,
+      pinHash: req.adminPinHash,
+      clientCpf: cpf,
+      payload: { valor }
+    });
 
     return res.json({ ok: true, init_point: pref.init_point, sandbox_init_point: pref.sandbox_init_point, preference_id: pref.id });
   } catch (err) {

--- a/db/migrations/20250823000000_add-admins.sql
+++ b/db/migrations/20250823000000_add-admins.sql
@@ -1,0 +1,29 @@
+-- migrate:up
+create table if not exists public.admins (
+  id bigserial primary key,
+  nome text not null,
+  pin text not null unique,
+  pin_hash text not null unique,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists admins_pin_idx on public.admins(pin_hash);
+
+alter table if exists public.audit_logs
+  add column if not exists admin_id bigint,
+  add column if not exists admin_nome text;
+
+alter table if exists public.clientes
+  add column if not exists last_admin_id bigint,
+  add column if not exists last_admin_nome text;
+
+-- migrate:down
+drop table if exists public.admins;
+
+alter table if exists public.audit_logs
+  drop column if exists admin_id,
+  drop column if exists admin_nome;
+
+alter table if exists public.clientes
+  drop column if exists last_admin_id,
+  drop column if exists last_admin_nome;

--- a/middlewares/requireAdminPin.js
+++ b/middlewares/requireAdminPin.js
@@ -1,8 +1,44 @@
-function requireAdminPin(req,res,next){
-  const pin = (req.query.pin || req.headers['x-admin-pin'] || '').toString();
-  if(!process.env.ADMIN_PIN || pin !== process.env.ADMIN_PIN){
-    return res.status(401).json({ ok:false, error:'invalid_pin' });
+const { supabase, assertSupabase } = require('../supabaseClient');
+const { hashPin } = require('../utils/adminPin');
+
+async function requireAdminPin(req, res, next){
+  try {
+    const pin = (req.query.pin || req.headers['x-admin-pin'] || '').toString();
+    if(!pin){
+      return res.status(401).json({ ok:false, error:'invalid_pin' });
+    }
+
+    // Fallback para PIN global via env (útil em testes/legacy)
+    if(process.env.ADMIN_PIN && pin === process.env.ADMIN_PIN){
+      req.adminId = 0;
+      req.adminNome = process.env.ADMIN_NOME || 'admin';
+      req.adminPinHash = hashPin(pin);
+      return next();
+    }
+
+    if(!supabase || typeof supabase.from !== 'function'){
+      return res.status(401).json({ ok:false, error:'invalid_pin' });
+    }
+    if(!assertSupabase(res)) return;
+
+    const pinHash = hashPin(pin);
+    const { data, error } = await supabase
+      .from('admins')
+      .select('id,nome')
+      .eq('pin_hash', pinHash)
+      .maybeSingle();
+
+    if(error || !data){
+      return res.status(401).json({ ok:false, error:'invalid_pin' });
+    }
+
+    req.adminId = data.id;
+    req.adminNome = data.nome;
+    req.adminPinHash = pinHash;
+    next();
+  } catch (err) {
+    return res.status(500).json({ ok:false, error:'pin_check_failed' });
   }
-  next();
 }
+
 module.exports = { requireAdminPin };

--- a/public/admin/admin-common.js
+++ b/public/admin/admin-common.js
@@ -6,6 +6,15 @@ function setPin(pin) {
   localStorage.setItem('ADMIN_PIN', pin);
 }
 
+function getNome() {
+  return localStorage.getItem('ADMIN_NOME') || '';
+}
+
+function setNome(nome) {
+  if (nome) localStorage.setItem('ADMIN_NOME', nome);
+  else localStorage.removeItem('ADMIN_NOME');
+}
+
 function withPinHeaders(init = {}) {
   const headers = new Headers(init.headers || {});
   const pin = getPin();
@@ -20,13 +29,49 @@ function showMessage(message, type = 'success') {
   el.className = type === 'error' ? 'error' : 'success';
 }
 
+function updateNomeDisplay() {
+  const el = document.getElementById('admin-name-display');
+  if (!el) return;
+  const nome = getNome();
+  el.textContent = nome ? `Logado como: ${nome}` : '';
+}
+
+async function refreshAdminInfo() {
+  try {
+    const resp = await fetch('/admin/whoami', { headers: withPinHeaders() });
+    if (!resp.ok) throw new Error('invalid');
+    const data = await resp.json().catch(() => null);
+    const nome = data?.admin?.nome || '';
+    setNome(nome);
+    updateNomeDisplay();
+    return true;
+  } catch (_) {
+    setNome('');
+    updateNomeDisplay();
+    return false;
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const pinInput = document.getElementById('pin');
   const saveBtn = document.getElementById('save-pin');
   if (pinInput) pinInput.value = getPin();
-  saveBtn?.addEventListener('click', () => {
+
+  let nameEl = document.getElementById('admin-name-display');
+  if (!nameEl && saveBtn?.parentNode) {
+    nameEl = document.createElement('span');
+    nameEl.id = 'admin-name-display';
+    nameEl.style.marginLeft = '8px';
+    saveBtn.parentNode.appendChild(nameEl);
+  }
+
+  updateNomeDisplay();
+  if (getPin()) refreshAdminInfo();
+
+  saveBtn?.addEventListener('click', async () => {
     setPin(pinInput?.value || '');
-    showMessage('PIN salvo', 'success');
+    const ok = await refreshAdminInfo();
+    showMessage(ok ? 'PIN salvo' : 'PIN inválido', ok ? 'success' : 'error');
   });
 });
 
@@ -34,3 +79,4 @@ window.getPin = getPin;
 window.setPin = setPin;
 window.withPinHeaders = withPinHeaders;
 window.showMessage = showMessage;
+window.refreshAdminInfo = refreshAdminInfo;

--- a/public/admin/audit.js
+++ b/public/admin/audit.js
@@ -78,7 +78,8 @@ function renderRows(){
   rowsTbody.innerHTML = '';
   state.rows.forEach((r,i)=>{
     const tr = document.createElement('tr');
-    tr.innerHTML = `<td>${new Date(r.created_at).toLocaleString()}</td><td>${r.route}</td><td>${r.action}</td><td>${r.client_cpf||''}</td><td>${(r.admin_pin_hash||'').slice(0,8)}</td><td><button type="button" class="btn-detail" data-idx="${i}">Ver Detalhes</button></td>`;
+    const admin = r.admin_nome || (r.admin_pin_hash||'').slice(0,8);
+    tr.innerHTML = `<td>${new Date(r.created_at).toLocaleString()}</td><td>${r.route}</td><td>${r.action}</td><td>${r.client_cpf||''}</td><td>${admin}</td><td><button type="button" class="btn-detail" data-idx="${i}">Ver Detalhes</button></td>`;
     rowsTbody.appendChild(tr);
   });
   rowsTbody.querySelectorAll('.btn-detail').forEach(btn=>{

--- a/public/admin/clientes.html
+++ b/public/admin/clientes.html
@@ -77,6 +77,7 @@
         <th>Método</th>
         <th>Email</th>
         <th>Telefone</th>
+        <th>Último admin</th>
         <th>Ações</th>
       </tr>
     </thead>

--- a/public/admin/clientes.js
+++ b/public/admin/clientes.js
@@ -69,7 +69,7 @@ const table = document.querySelector('table');
 
   function renderClientes(){
     if(state.currentRows.length === 0){
-      rowsTbody.innerHTML = '<tr><td colspan="8">Nenhum cliente encontrado. <button type="button" id="btn-clear-inline">Limpar filtros</button></td></tr>';
+      rowsTbody.innerHTML = '<tr><td colspan="9">Nenhum cliente encontrado. <button type="button" id="btn-clear-inline">Limpar filtros</button></td></tr>';
       document.getElementById('btn-clear-inline')?.addEventListener('click', ()=> clearBtn.click());
       return;
     }
@@ -78,7 +78,7 @@ const table = document.querySelector('table');
       const cpfSan = sanitizeCpf(c.cpf);
       const tr = document.createElement('tr');
       tr.dataset.cpf = cpfSan;
-      tr.innerHTML = `<td>${formatCpf(c.cpf)}</td><td>${c.nome||''}</td><td>${c.plano||'—'}</td><td>${c.status||''}</td><td>${c.metodo_pagamento||''}</td><td>${c.email||''}</td><td>${c.telefone||''}</td><td><button type="button" class="btn" onclick="cobrarCliente('${cpfSan}')">Cobrar</button> <button type="button" class="btn-edit" data-cpf="${cpfSan}">Editar</button> <button type="button" class="btn-remove" data-cpf="${cpfSan}">Remover</button></td>`;
+      tr.innerHTML = `<td>${formatCpf(c.cpf)}</td><td>${c.nome||''}</td><td>${c.plano||'—'}</td><td>${c.status||''}</td><td>${c.metodo_pagamento||''}</td><td>${c.email||''}</td><td>${c.telefone||''}</td><td>${c.last_admin_nome||''}</td><td><button type="button" class="btn" onclick="cobrarCliente('${cpfSan}')">Cobrar</button> <button type="button" class="btn-edit" data-cpf="${cpfSan}">Editar</button> <button type="button" class="btn-remove" data-cpf="${cpfSan}">Remover</button></td>`;
       rowsTbody.appendChild(tr);
     });
   }

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -26,17 +26,6 @@
     <li><a href="/admin/clientes.html">Listar Clientes</a></li>
   </ul>
 </main>
-<script>
-(function(){
-  const pinInput=document.getElementById('pin');
-  const save=document.getElementById('save-pin');
-  const stored=localStorage.getItem('ADMIN_PIN');
-  if(stored) pinInput.value=stored;
-  save.addEventListener('click',()=>{
-    localStorage.setItem('ADMIN_PIN',pinInput.value.trim());
-    alert('PIN salvo!');
-  });
-})();
-</script>
+<script src="/admin/admin-common.js"></script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -66,6 +66,12 @@ app.get('/admin/report/csv', requireAdminPin, adminReportController.csv);
 app.post('/admin/mp/checkout', requireAdminPin, mpController.checkout);
 app.post('/webhooks/mp', mpController.webhook);
 
+const whoami = (req, res) => {
+  res.json({ ok: true, admin: { id: req.adminId, nome: req.adminNome } });
+};
+app.get('/admin/whoami', requireAdminPin, whoami);
+app.get('/admin/status/ping-supabase', requireAdminPin, whoami);
+
 // /__routes opcional e protegido por PIN
 function listRoutesSafe(app) {
   const out = [];
@@ -87,12 +93,8 @@ function listRoutesSafe(app) {
   return out;
 }
 if (process.env.DIAG_ROUTES === '1') {
-    app.get('/__routes', (req, res) => {
+    app.get('/__routes', requireAdminPin, (req, res) => {
       try {
-        const pin = String(req.query.pin || req.headers['x-admin-pin'] || '');
-        if (!process.env.ADMIN_PIN || pin !== process.env.ADMIN_PIN) {
-          return res.status(401).json({ ok: false, error: 'invalid_pin' });
-        }
         const routes = listRoutesSafe(app);
         return res.json({ ok: true, count: routes.length, routes });
       } catch (e) {

--- a/utils/adminPin.js
+++ b/utils/adminPin.js
@@ -1,0 +1,9 @@
+const crypto = require('crypto');
+
+const SALT = process.env.ADMIN_PIN_SALT || '';
+
+function hashPin(pin){
+  return crypto.createHash('sha256').update(String(pin) + SALT).digest('hex');
+}
+
+module.exports = { hashPin };


### PR DESCRIPTION
## Summary
- add admins table and tracking fields for clients and audit logs
- validate admin PINs against database and log admin details
- show last editor and logged admin in admin UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3c1c1f640832b8cc4987b82ddc822