### PR TITLE
feat: guard MP routes when Supabase envs missing

### DIFF
--- a/controllers/mpController.js
+++ b/controllers/mpController.js
@@ -1,11 +1,11 @@
-const { createClient } = require('@supabase/supabase-js');
 const { createPreference, getPayment } = require('../lib/mp');
 const logAdminAction = require('../utils/logAdminAction');
-
-const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const { supabase, assertSupabase } = require('../supabaseClient');
 
 exports.checkout = async (req, res, next) => {
   try {
+    assertSupabase(res);
+
     const { cpf, valor, titulo } = req.body;
     if (!cpf || !valor) {
       return res.status(400).json({ ok: false, error: 'cpf_e_valor_obrigatorios' });
@@ -39,6 +39,7 @@ exports.checkout = async (req, res, next) => {
 
     return res.json({ ok: true, init_point: pref.init_point, sandbox_init_point: pref.sandbox_init_point, preference_id: pref.id });
   } catch (err) {
+    if (err.message === 'supabase_unconfigured') return;
     return next(err);
   }
 };
@@ -46,6 +47,8 @@ exports.checkout = async (req, res, next) => {
 // webhook público chamado pelo MP
 exports.webhook = async (req, res, next) => {
   try {
+    assertSupabase(res);
+
     const { type, data } = req.body || {};
     if (type !== 'payment' || !data || !data.id) {
       return res.json({ ok: true, ignored: true });
@@ -76,6 +79,7 @@ exports.webhook = async (req, res, next) => {
 
     return res.json({ ok: true });
   } catch (err) {
+    if (err.message === 'supabase_unconfigured') return;
     return next(err);
   }
 };

--- a/server.js
+++ b/server.js
@@ -50,7 +50,6 @@ const auditController = require('./controllers/auditController');
 const adminsController = require('./controllers/adminsController');
 const adminController = require('./controllers/adminController');
 const adminReportController = require('./controllers/adminReportController');
-const mpController = require('./controllers/mpController');
 const requireAdminPin = require('./middlewares/requireAdminPin');
 
 // páginas estáticas de /admin sem PIN
@@ -67,8 +66,18 @@ app.delete('/admin/admins/:id', requireAdminPin, adminsController.deleteAdmin);
 app.get('/admin/metrics', requireAdminPin, adminController.metrics);
 app.get('/admin/report/summary', requireAdminPin, adminReportController.summary);
 app.get('/admin/report/csv', requireAdminPin, adminReportController.csv);
-app.post('/admin/mp/checkout', requireAdminPin, mpController.checkout);
-app.post('/webhooks/mp', mpController.webhook);
+
+const hasSupabase =
+  !!process.env.SUPABASE_URL &&
+  !!(process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY);
+
+if (hasSupabase) {
+  const mpController = require('./controllers/mpController');
+  app.post('/admin/mp/checkout', requireAdminPin, mpController.checkout);
+  app.post('/webhooks/mp', mpController.webhook);
+} else {
+  console.log('[MP] Rotas de MP não montadas: variáveis do Supabase ausentes.');
+}
 
 const whoami = (req, res) => {
   res.json({ ok: true, admin: { id: req.adminId, nome: req.adminNome } });

--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -1,25 +1,32 @@
 const { createClient } = require('@supabase/supabase-js');
 
-let supabase = null;
-function getSupabase() {
-  if (!supabase) {
-    const url = process.env.SUPABASE_URL;
-    const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
-    if (url && key) {
-      supabase = createClient(url, key, { auth: { persistSession: false } });
-    }
+let cached;
+function getClient() {
+  if (cached) return cached;
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
+  if (!url || !key) {
+    cached = null;
+    return cached;
   }
-  return supabase;
+  cached = createClient(url, key, { auth: { persistSession: false } });
+  return cached;
 }
 
 function assertSupabase(res) {
-  const client = getSupabase();
+  const client = getClient();
   if (!client) {
-    if (res) res.status(500).json({ ok: false, error: 'supabase_not_configured' });
-    return null;
+    if (res && !res.headersSent) {
+      res.status(503).json({ ok: false, error: 'supabase_unconfigured' });
+    }
+    throw new Error('supabase_unconfigured');
   }
   return client;
 }
 
-module.exports = { getSupabase, assertSupabase };
-Object.defineProperty(module.exports, 'supabase', { get: getSupabase });
+module.exports = {
+  get supabase() {
+    return getClient();
+  },
+  assertSupabase
+};


### PR DESCRIPTION
## Summary
- guard Mercado Pago routes when Supabase env vars missing
- lazy-load Supabase client with assertion helper
- require Supabase in MP controller only when configured

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b49cf1cf9c832ba55cd3dc606e97d9