### PR TITLE
fix: unify supabase env vars and client initialization

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -5,6 +5,7 @@ AUDIT_SALT=test_salt
 ALLOWED_ORIGIN=http://localhost:8888,http://localhost:3000
 SUPABASE_URL=http://localhost
 SUPABASE_ANON=public-anon-key
+SUPABASE_SERVICE_ROLE_KEY=service-role-key
 
 MP_ACCESS_TOKEN=fake
 MP_COLLECTOR_ID=fake

--- a/config/env.js
+++ b/config/env.js
@@ -6,6 +6,7 @@ require('dotenv').config({
 const envSchema = z.object({
   SUPABASE_URL: z.string().url(),
   SUPABASE_ANON: z.string().min(1),
+  SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
   ADMIN_PIN: z.string().min(1),
   MP_ACCESS_TOKEN: z.string().optional(),
   MP_COLLECTOR_ID: z.string().optional(),

--- a/server.js
+++ b/server.js
@@ -70,7 +70,7 @@ app.get('/admin/report/csv', requireAdminPin, adminReportController.csv);
 
 const hasSupabase =
   !!process.env.SUPABASE_URL &&
-  !!(process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY);
+  !!(process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON);
 
 if (hasSupabase) {
   const mpController = require('./controllers/mpController');

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,2 +1,2 @@
-const { supabase, assertSupabase } = require('../../supabaseClient');
-module.exports = { supabase, assertSupabase };
+const { supabase, supabasePublic, assertSupabase } = require('../../supabaseClient');
+module.exports = { supabase, supabasePublic, assertSupabase };

--- a/tests/assinaturas.routes.test.js
+++ b/tests/assinaturas.routes.test.js
@@ -10,7 +10,8 @@ function startServer(scenario, port) {
         ADMIN_PIN: '1234',
         PORT: port,
         SUPABASE_URL: 'http://localhost',
-        SUPABASE_ANON_KEY: 'anon',
+        SUPABASE_ANON: 'anon',
+        SUPABASE_SERVICE_ROLE_KEY: 'service',
       },
     });
     proc.stdout.on('data', (d) => {

--- a/tests/clientes.routes.test.js
+++ b/tests/clientes.routes.test.js
@@ -10,7 +10,8 @@ function startServer(scenario, port) {
         ADMIN_PIN: '1234',
         PORT: port,
         SUPABASE_URL: 'http://localhost',
-        SUPABASE_ANON_KEY: 'anon',
+        SUPABASE_ANON: 'anon',
+        SUPABASE_SERVICE_ROLE_KEY: 'service',
       },
     });
     proc.stdout.on('data', (d) => {

--- a/tests/health.test.js
+++ b/tests/health.test.js
@@ -1,4 +1,7 @@
 process.env.NODE_ENV = 'test';
+process.env.SUPABASE_URL = 'http://localhost';
+process.env.SUPABASE_ANON = 'anon';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
 const request = require('supertest');
 const app = require('../server');
 

--- a/tests/mp.test.js
+++ b/tests/mp.test.js
@@ -3,6 +3,7 @@ const express = require('express');
 
 process.env.SUPABASE_URL = 'https://example.com';
 process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
+process.env.SUPABASE_ANON = 'anon-key';
 
 const mpController = require('../controllers/mpController');
 const requireAdminPin = (req, _res, next) => { next(); };


### PR DESCRIPTION
## Summary
- centralize Supabase setup using SUPABASE_URL, SUPABASE_ANON and SUPABASE_SERVICE_ROLE_KEY
- update server and config to rely on new variable names
- adjust tests and env files to new Supabase env scheme

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5c0d5629c832bba27769fdd30d185