### PR TITLE
feat: add admin clientes module with supabase integration

### DIFF
--- a/server.js
+++ b/server.js
@@ -46,6 +46,7 @@ app.use('/api/planos', planosRouter);
 const path = require('path');
 const clientesRouter = require('./routes/admin.routes');
 const clientesController = require('./controllers/clientesController');
+const clientesRoutes = require('./src/features/clientes/clientes.routes.js');
 const auditController = require('./controllers/auditController');
 const adminsController = require('./controllers/adminsController');
 const adminController = require('./controllers/adminController');
@@ -57,8 +58,9 @@ const adminDiagRoutes = require('./routes/adminDiag');
 app.use('/admin', express.static(path.join(__dirname, 'public', 'admin')));
 
 // rotas de API de admin
-app.use('/admin/clientes', clientesRouter);
 app.get('/admin/clientes/export', requireAdminPin, clientesController.exportCsv);
+app.use('/admin/clientes', clientesRouter);
+app.use('/admin/clientes', requireAdminPin, clientesRoutes);
 app.get('/admin/audit', requireAdminPin, auditController.list);
 app.get('/admin/audit/export', requireAdminPin, auditController.exportAudit);
 app.get('/admin/admins', requireAdminPin, adminsController.listAdmins);

--- a/sql/001_clientes.sql
+++ b/sql/001_clientes.sql
@@ -1,0 +1,14 @@
+create extension if not exists "uuid-ossp";
+
+create table if not exists public.clientes (
+  id uuid primary key default uuid_generate_v4(),
+  nome text not null,
+  cpf text,
+  telefone text,
+  email text,
+  plano text,
+  status text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_clientes_created_at on public.clientes(created_at desc);

--- a/src/features/clientes/clientes.controller.js
+++ b/src/features/clientes/clientes.controller.js
@@ -1,0 +1,73 @@
+const { ClienteCreateSchema, ClienteUpdateSchema } = require('./clientes.validation');
+const service = require('./clientes.service');
+
+function ok(res, data) {
+  return res.json({ ok: true, data });
+}
+function fail(res, status, error) {
+  return res.status(status).json({ ok: false, error: String(error?.message || error) });
+}
+
+async function list(req, res) {
+  try {
+    const { q, limit, offset } = req.query;
+    const parsedLimit = Number(limit) > 0 ? Number(limit) : 50;
+    const parsedOffset = Number(offset) >= 0 ? Number(offset) : 0;
+    const out = await service.list({ q, limit: parsedLimit, offset: parsedOffset });
+    return ok(res, out);
+  } catch (err) {
+    return fail(res, 500, err);
+  }
+}
+
+async function get(req, res) {
+  try {
+    const { id } = req.params;
+    const row = await service.getById(id);
+    return ok(res, row);
+  } catch (err) {
+    return fail(res, 404, err);
+  }
+}
+
+async function create(req, res) {
+  try {
+    const parsed = ClienteCreateSchema.parse(req.body || {});
+    const created = await service.create(parsed);
+    return res.status(201).json({ ok: true, data: created });
+  } catch (err) {
+    const status = err?.name === 'ZodError' ? 400 : 500;
+    return fail(res, status, err);
+  }
+}
+
+async function update(req, res) {
+  try {
+    const { id } = req.params;
+    const parsed = ClienteUpdateSchema.parse(req.body || {});
+    const updated = await service.update(id, parsed);
+    return ok(res, updated);
+  } catch (err) {
+    const status = err?.name === 'ZodError' ? 400 : 404;
+    return fail(res, status, err);
+  }
+}
+
+async function remove(req, res) {
+  try {
+    const { id } = req.params;
+    const out = await service.remove(id);
+    if (!out.deleted) return fail(res, 404, new Error('Cliente não encontrado'));
+    return ok(res, out);
+  } catch (err) {
+    return fail(res, 500, err);
+  }
+}
+
+module.exports = {
+  list,
+  get,
+  create,
+  update,
+  remove,
+};

--- a/src/features/clientes/clientes.routes.js
+++ b/src/features/clientes/clientes.routes.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const ctrl = require('./clientes.controller');
+
+const router = express.Router();
+
+router.get('/', ctrl.list);
+router.get('/:id', ctrl.get);
+router.post('/', ctrl.create);
+router.patch('/:id', ctrl.update);
+router.delete('/:id', ctrl.remove);
+
+module.exports = router;

--- a/src/features/clientes/clientes.service.js
+++ b/src/features/clientes/clientes.service.js
@@ -1,0 +1,50 @@
+const supabase = require('../../../services/supabase');
+
+const TABLE = 'clientes';
+
+async function list({ q, limit = 50, offset = 0 }) {
+  let query = supabase.from(TABLE).select('*', { count: 'exact' }).order('created_at', { ascending: false }).range(offset, offset + limit - 1);
+
+  if (q && q.trim()) {
+    const term = `%${q.trim()}%`;
+    // Fazer ilike em múltiplos campos usando or()
+    query = query.or(`nome.ilike.${term},email.ilike.${term},cpf.ilike.${term},telefone.ilike.${term}`);
+  }
+
+  const { data, error, count } = await query;
+  if (error) throw new Error(error.message || 'Erro ao listar clientes');
+  return { rows: data, count: count ?? data?.length ?? 0 };
+}
+
+async function getById(id) {
+  const { data, error } = await supabase.from(TABLE).select('*').eq('id', id).single();
+  if (error) throw new Error(error.message || 'Cliente não encontrado');
+  return data;
+}
+
+async function create(payload) {
+  const { data, error } = await supabase.from(TABLE).insert(payload).select('*').single();
+  if (error) throw new Error(error.message || 'Erro ao criar cliente');
+  return data;
+}
+
+async function update(id, payload) {
+  const { data, error } = await supabase.from(TABLE).update(payload).eq('id', id).select('*').maybeSingle();
+  if (error) throw new Error(error.message || 'Erro ao atualizar cliente');
+  if (!data) throw new Error('Cliente não encontrado para atualizar');
+  return data;
+}
+
+async function remove(id) {
+  const { error, count } = await supabase.from(TABLE).delete({ count: 'exact' }).eq('id', id);
+  if (error) throw new Error(error.message || 'Erro ao remover cliente');
+  return { deleted: (count ?? 0) > 0 };
+}
+
+module.exports = {
+  list,
+  getById,
+  create,
+  update,
+  remove,
+};

--- a/src/features/clientes/clientes.validation.js
+++ b/src/features/clientes/clientes.validation.js
@@ -1,0 +1,33 @@
+const { z } = require('zod');
+
+const cleanDigits = (s) => (typeof s === 'string' ? s.replace(/\D+/g, '') : s);
+
+const ClienteCreateSchema = z.object({
+  nome: z.string().min(2, 'Nome muito curto'),
+  cpf: z.string().optional().transform(cleanDigits),
+  telefone: z.string().optional(),
+  email: z.string().email('E-mail inválido').optional(),
+  plano: z.enum(['Essencial', 'Platinum', 'Black']).optional(),
+  status: z.enum(['ativo', 'inativo']).optional(),
+});
+
+const ClienteUpdateSchema = z.object({
+  nome: z.string().min(2).optional(),
+  cpf: z.string().optional().transform(cleanDigits),
+  telefone: z.string().optional(),
+  email: z.string().email('E-mail inválido').optional(),
+  plano: z.enum(['Essencial', 'Platinum', 'Black']).optional(),
+  status: z.enum(['ativo', 'inativo']).optional(),
+}).refine((obj) => Object.keys(obj).length > 0, {
+  message: 'Nada para atualizar',
+});
+
+/**
+ * @typedef {import('zod').infer<typeof ClienteCreateSchema>} ClienteCreate
+ * @typedef {import('zod').infer<typeof ClienteUpdateSchema>} ClienteUpdate
+ */
+
+module.exports = {
+  ClienteCreateSchema,
+  ClienteUpdateSchema,
+};


### PR DESCRIPTION
## Summary
- add SQL schema for clientes table
- implement admin clientes module with validation, service and routing
- wire new admin clientes routes in server

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6e6985550832badd229f03e554656