### PR TITLE
Normalize customer input and expose available plans

### DIFF
--- a/__tests__/admin.report.test.js
+++ b/__tests__/admin.report.test.js
@@ -37,9 +37,9 @@ describe('GET /admin/report/summary', () => {
   test('returns summary', async () => {
     queryResult = {
       data: [
-        { status: 'ativo', plano: 'Mensal', metodo_pagamento: 'pix' },
-        { status: 'inativo', plano: 'Mensal', metodo_pagamento: 'cartao_credito' },
-        { status: 'ativo', plano: 'Anual', metodo_pagamento: 'pix' },
+        { status: 'ativo', plano: 'Essencial', metodo_pagamento: 'pix' },
+        { status: 'inativo', plano: 'Essencial', metodo_pagamento: 'cartao_credito' },
+        { status: 'ativo', plano: 'Black', metodo_pagamento: 'pix' },
       ],
       count: 3,
       error: null,
@@ -52,7 +52,7 @@ describe('GET /admin/report/summary', () => {
       total: 3,
       ativos: 2,
       inativos: 1,
-      porPlano: { Mensal: 2, Anual: 1 },
+      porPlano: { Essencial: 2, Black: 1 },
       porMetodo: { pix: 2, cartao_credito: 1 },
     });
   });

--- a/__tests__/planos.routes.test.js
+++ b/__tests__/planos.routes.test.js
@@ -27,10 +27,9 @@ describe('Planos Routes', () => {
   });
 
   test('GET /planos - lista todos os planos', async () => {
-    planosService.getAll.mockResolvedValue({ data: [{ id: 1 }], error: null });
     const res = await request(app).get('/planos');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ ok: true, source: 'planos.routes' });
+    expect(res.body).toEqual({ ok: true, planos: ['Essencial', 'Platinum', 'Black'] });
   });
 
   test('POST /planos - cria plano', async () => {

--- a/__tests__/smoke.test.js
+++ b/__tests__/smoke.test.js
@@ -1,7 +1,8 @@
 process.env.NODE_ENV = 'test';
 
 jest.mock('../services/supabase', () => {
-  const select = jest.fn().mockResolvedValue({ data: [{ id: 1 }], error: null });
+  const single = jest.fn().mockResolvedValue({ data: { id: 1 }, error: null });
+  const select = jest.fn(() => ({ single }));
   const upsert = jest.fn(() => ({ select }));
   const from = jest.fn(() => ({ upsert }));
   return { from };
@@ -39,11 +40,11 @@ describe('basic API smoke', () => {
         .send({
           cpf: '02655274148',
           nome: 'John',
-          plano: 'Mensal',
+          plano: 'Essencial',
           status: 'ativo',
           metodo_pagamento: 'pix'
         });
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       expect(res.body.ok).toBe(true);
       expect(res.body.data).toBeTruthy();
     });

--- a/controllers/leadController.js
+++ b/controllers/leadController.js
@@ -1,5 +1,5 @@
 const supabase = require('../services/supabase');
-const PLANOS = new Set(['Mensal', 'Semestral', 'Anual']);
+const PLANOS = new Set(['Essencial', 'Platinum', 'Black']);
 const onlyDigits = s => (String(s||'').match(/\d/g) || []).join('');
 function isEmail(s){ return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(s||'')); }
 

--- a/controllers/transacaoController.js
+++ b/controllers/transacaoController.js
@@ -29,8 +29,8 @@ async function getClienteByCpf(cpf) {
 }
 
 function calcularDesconto(plano, valor) {
-  // regra simples: Mensal 10%, Semestral 15%, Anual 30% (ajuste se quiser)
-  const mapa = { Mensal: 10, Semestral: 15, Anual: 30 };
+  // regra simples: Essencial 10%, Platinum 20%, Black 30% (ajuste se quiser)
+  const mapa = { Essencial: 10, Platinum: 20, Black: 30 };
   const pct = mapa[plano] || 0;
   const valorFinal = Number((valor * (1 - pct / 100)).toFixed(2));
   return { pct, valorFinal };

--- a/src/features/planos/planos.routes.js
+++ b/src/features/planos/planos.routes.js
@@ -1,12 +1,13 @@
 const express = require('express');
 const requireAdminPin = require('../../../middlewares/requireAdminPin.js');
 const ctrl = require('./planos.controller.js');
+const { PLANOS_ACEITOS } = require('../../../controllers/clientesController.js');
 
 const router = express.Router();
 
-// Endpoint simples para diagnóstico
+// Lista de planos aceitos
 router.get('/', (_req, res) => {
-  res.json({ ok: true, source: 'planos.routes' });
+  res.json({ ok: true, planos: PLANOS_ACEITOS });
 });
 
 // admin com PIN

--- a/tests/assinaturas.test.js
+++ b/tests/assinaturas.test.js
@@ -21,7 +21,7 @@ describe('Rotas de assinaturas', () => {
       select: jest.fn().mockReturnThis(),
       eq: jest.fn().mockReturnThis(),
       maybeSingle: jest.fn().mockResolvedValue({
-        data: { nome: 'João', plano: 'Mensal', status: 'ativo' },
+        data: { nome: 'João', plano: 'Essencial', status: 'ativo' },
         error: null,
       }),
     });

--- a/tests/clientes.test.js
+++ b/tests/clientes.test.js
@@ -57,55 +57,55 @@ describe('Clientes Controller', () => {
   });
 
   test('upsertOne sucesso', async () => {
-    supabase.from.mockReturnValue({
-      upsert: jest.fn().mockReturnValue({
-        select: jest.fn().mockResolvedValue({
-          data: [{ cpf: '02655274148', nome: 'Fulano', metodo_pagamento: 'pix' }],
-          error: null,
-        }),
-      }),
-    });
+      const single = jest.fn().mockResolvedValue({
+        data: { cpf: '02655274148', nome: 'Fulano', metodo_pagamento: 'pix' },
+        error: null,
+      });
+      const select = jest.fn().mockReturnValue({ single });
+      supabase.from.mockReturnValue({
+        upsert: jest.fn().mockReturnValue({ select }),
+      });
 
     const res = await request(app)
       .post('/clientes')
       .send({
         cpf: '02655274148',
         nome: 'Fulano',
-        plano: 'Mensal',
+        plano: 'Essencial',
         status: 'ativo',
         metodo_pagamento: 'pix',
       });
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     expect(res.body).toHaveProperty('ok', true);
   });
 
   test('upsertOne aplica defaults e campos opcionais', async () => {
-    const upsert = jest.fn().mockReturnValue({
-      select: jest.fn().mockResolvedValue({ data: [{}], error: null }),
-    });
-    supabase.from.mockReturnValue({ upsert });
+      const single = jest.fn().mockResolvedValue({ data: {}, error: null });
+      const select = jest.fn().mockReturnValue({ single });
+      const upsert = jest.fn().mockReturnValue({ select });
+      supabase.from.mockReturnValue({ upsert });
 
     const res = await request(app)
       .post('/clientes')
       .send({ cpf: '02655274148', nome: 'Fulano' });
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     const payload = upsert.mock.calls[0][0];
     expect(payload).toEqual({ cpf: '02655274148', nome: 'Fulano', status: 'ativo' });
   });
 
   test('upsertOne metodo vazio vira null', async () => {
-    const upsert = jest.fn().mockReturnValue({
-      select: jest.fn().mockResolvedValue({ data: [{}], error: null }),
-    });
-    supabase.from.mockReturnValue({ upsert });
+      const single = jest.fn().mockResolvedValue({ data: {}, error: null });
+      const select = jest.fn().mockReturnValue({ single });
+      const upsert = jest.fn().mockReturnValue({ select });
+      supabase.from.mockReturnValue({ upsert });
 
     const res = await request(app)
       .post('/clientes')
       .send({ cpf: '02655274148', nome: 'Fulano', metodo_pagamento: '' });
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     const payload = upsert.mock.calls[0][0];
     expect(payload).toEqual({
       cpf: '02655274148',
@@ -121,7 +121,7 @@ describe('Clientes Controller', () => {
       .send({
         cpf: '123',
         nome: '',
-        plano: 'Mensal',
+        plano: 'Essencial',
         status: 'ativo',
         metodo_pagamento: 'pix',
       });
@@ -131,20 +131,18 @@ describe('Clientes Controller', () => {
   });
 
   test('upsertOne erro do banco retorna 500', async () => {
-    supabase.from.mockReturnValue({
-      upsert: jest.fn().mockReturnValue({
-        select: jest
-          .fn()
-          .mockResolvedValue({ data: null, error: { message: 'db' } }),
-      }),
-    });
+      const single = jest.fn().mockResolvedValue({ data: null, error: { message: 'db' } });
+      const select = jest.fn().mockReturnValue({ single });
+      supabase.from.mockReturnValue({
+        upsert: jest.fn().mockReturnValue({ select }),
+      });
 
     const res = await request(app)
       .post('/clientes')
       .send({
         cpf: '02655274148',
         nome: 'Fulano',
-        plano: 'Mensal',
+        plano: 'Essencial',
         status: 'ativo',
         metodo_pagamento: 'pix',
       });
@@ -173,7 +171,7 @@ describe('Clientes Controller', () => {
           {
             cpf: '02655274148',
             nome: 'Fulano',
-            plano: 'Mensal',
+              plano: 'Essencial',
             status: 'ativo',
             metodo_pagamento: 'pix',
           },
@@ -213,7 +211,7 @@ describe('Clientes Controller', () => {
           {
             cpf: '02655274148',
             nome: 'Fulano',
-            plano: 'Mensal',
+            plano: 'Essencial',
             status: 'ativo',
             metodo_pagamento: 'pix',
           },

--- a/tests/leads.test.js
+++ b/tests/leads.test.js
@@ -36,7 +36,7 @@ describe('Rotas de leads', () => {
 
     const res = await request(app)
       .post('/public/lead')
-      .send({ nome: 'João', cpf: '02655274148', plano: 'Mensal' });
+      .send({ nome: 'João', cpf: '02655274148', plano: 'Essencial' });
 
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('id', 1);
@@ -45,7 +45,7 @@ describe('Rotas de leads', () => {
   test('validação falha retorna 400', async () => {
     const res = await request(app)
       .post('/public/lead')
-      .send({ cpf: '123', plano: 'Mensal' });
+      .send({ cpf: '123', plano: 'Essencial' });
     expect(res.status).toBe(400);
   });
 

--- a/tests/report.test.js
+++ b/tests/report.test.js
@@ -66,7 +66,7 @@ describe('Report Controller', () => {
       created_at: '2024-01-01',
       cpf: '123',
       cliente_nome: 'Fulano',
-      plano: 'Mensal',
+      plano: 'Essencial',
       valor_bruto: 10,
       desconto_aplicado: 0,
       valor_final: 10,

--- a/tests/transacoes.test.js
+++ b/tests/transacoes.test.js
@@ -25,7 +25,7 @@ describe('Rotas de transações', () => {
         select: jest.fn().mockReturnThis(),
         eq: jest.fn().mockReturnThis(),
         maybeSingle: jest.fn().mockResolvedValue({
-          data: { nome: 'João', plano: 'Mensal' },
+          data: { nome: 'João', plano: 'Essencial' },
           error: null,
         }),
       });
@@ -70,7 +70,7 @@ describe('Rotas de transações', () => {
             select: jest.fn().mockReturnThis(),
             eq: jest.fn().mockReturnThis(),
             maybeSingle: jest.fn().mockResolvedValue({
-              data: { nome: 'João', plano: 'Anual' },
+              data: { nome: 'João', plano: 'Black' },
               error: null,
             }),
           };
@@ -126,7 +126,7 @@ describe('Rotas de transações', () => {
             select: jest.fn().mockReturnThis(),
             eq: jest.fn().mockReturnThis(),
             maybeSingle: jest.fn().mockResolvedValue({
-              data: { nome: 'João', plano: 'Mensal' },
+              data: { nome: 'João', plano: 'Essencial' },
               error: null,
             }),
           };


### PR DESCRIPTION
## Summary
- add normalization utilities for CPF and plan names
- validate and clean customer create/update payloads
- expose GET /planos with accepted plan names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6ee309aac832b91d67a62cb556464