### PR TITLE
feat: add transacoes module with preview and create

### DIFF
--- a/server.js
+++ b/server.js
@@ -53,6 +53,7 @@ const adminController = require('./controllers/adminController');
 const adminReportController = require('./controllers/adminReportController');
 const requireAdminPin = require('./middlewares/requireAdminPin');
 const adminDiagRoutes = require('./routes/adminDiag');
+const transacoesRoutes = require('./src/features/transacoes/transacoes.routes');
 
 // páginas estáticas de /admin sem PIN
 app.use('/admin', express.static(path.join(__dirname, 'public', 'admin')));
@@ -84,6 +85,9 @@ if (hasSupabase) {
 } else {
   console.log('[MP] Rotas de MP não montadas: variáveis do Supabase ausentes.');
 }
+
+// transações (protegidas por PIN)
+app.use('/transacao', requireAdminPin, transacoesRoutes);
 
 
 // /__routes opcional e protegido por PIN

--- a/sql/002_transacoes.sql
+++ b/sql/002_transacoes.sql
@@ -1,0 +1,23 @@
+create extension if not exists "uuid-ossp";
+
+create table if not exists public.transacoes (
+  id uuid primary key default uuid_generate_v4(),
+  cliente_id bigint,
+  plano text,
+  valor_original numeric(12,2) not null,
+  desconto_aplicado numeric(5,2) not null,
+  valor_final numeric(12,2) not null,
+  metodo_pagamento text,
+  status_pagamento text default 'pendente',
+  documento text,
+  email text,
+  observacoes text,
+  vencimento date,
+  created_at timestamptz not null default now(),
+  last_admin_id text,
+  last_admin_nome text,
+  last_admin_name text
+);
+
+create index if not exists idx_transacoes_created_at on public.transacoes(created_at desc);
+create index if not exists idx_transacoes_cliente  on public.transacoes(cliente_id);

--- a/src/features/transacoes/transacoes.controller.js
+++ b/src/features/transacoes/transacoes.controller.js
@@ -1,0 +1,128 @@
+const supabase = require('../../../services/supabase');
+
+const TB_TRANS = 'transacoes';
+const TB_CLIENTES = 'clientes';
+
+// descontos por plano (em %)
+const DESCONTOS = {
+  Essencial: 5,
+  Platinum: 10,
+  Black: 20,
+};
+
+function normalizePlano(p) {
+  if (!p) return null;
+  const s = String(p).trim().toLowerCase();
+  if (s === 'essencial') return 'Essencial';
+  if (s === 'platinum') return 'Platinum';
+  if (s === 'black') return 'Black';
+  return null;
+}
+
+function round2(n) {
+  return Math.round((Number(n) + Number.EPSILON) * 100) / 100;
+}
+
+async function resolvePlanoFromCliente(cliente_id) {
+  if (!cliente_id) return null;
+  const { data, error } = await supabase
+    .from(TB_CLIENTES)
+    .select('plano')
+    .eq('id', cliente_id)
+    .maybeSingle();
+  if (error) throw new Error(error.message || 'Erro ao consultar cliente');
+  if (data && data.plano) return normalizePlano(data.plano);
+  return null;
+}
+
+async function preview(req, res, next) {
+  try {
+    const body = req.body || {};
+    const valorOriginal = Number(body.valor_original);
+    if (!Number.isFinite(valorOriginal) || valorOriginal <= 0) {
+      return res.status(400).json({ ok: false, error: 'valor_original inválido' });
+    }
+
+    let plano = normalizePlano(body.plano);
+    if (!plano && body.cliente_id != null) {
+      plano = await resolvePlanoFromCliente(body.cliente_id);
+    }
+    if (!plano) {
+      return res.status(400).json({ ok: false, error: 'plano não informado e não encontrado no cliente' });
+    }
+
+    const desconto = DESCONTOS[plano] ?? 0;
+    const valorFinal = round2(valorOriginal * (1 - desconto / 100));
+
+    return res.json({
+      ok: true,
+      data: {
+        plano,
+        desconto_aplicado: desconto,
+        valor_original: round2(valorOriginal),
+        valor_final: valorFinal,
+      },
+    });
+  } catch (err) {
+    return next(err);
+  }
+}
+
+async function create(req, res, next) {
+  try {
+    const body = req.body || {};
+    const valorOriginal = Number(body.valor_original);
+    if (!Number.isFinite(valorOriginal) || valorOriginal <= 0) {
+      return res.status(400).json({ ok: false, error: 'valor_original inválido' });
+    }
+
+    let plano = normalizePlano(body.plano);
+    if (!plano && body.cliente_id != null) {
+      plano = await resolvePlanoFromCliente(body.cliente_id);
+    }
+    if (!plano) {
+      return res.status(400).json({ ok: false, error: 'plano não informado e não encontrado no cliente' });
+    }
+
+    const desconto = DESCONTOS[plano] ?? 0;
+    const valorFinal = round2(valorOriginal * (1 - desconto / 100));
+
+    const last_admin_id = req.adminId || req.headers['x-admin-id'] || '1';
+    const last_admin_nome = req.adminNome || req.headers['x-admin-name'] || 'admin';
+
+    const payload = {
+      cliente_id: body.cliente_id ?? null,
+      plano,
+      valor_original: round2(valorOriginal),
+      desconto_aplicado: round2(desconto),
+      valor_final: valorFinal,
+      metodo_pagamento: body.metodo_pagamento || 'pix',
+      status_pagamento: body.status_pagamento || 'pendente',
+      documento: body.documento ?? null,
+      email: body.email ?? null,
+      observacoes: body.observacoes ?? null,
+      vencimento: body.vencimento ?? null,
+      last_admin_id,
+      last_admin_nome,
+      last_admin_name: last_admin_nome,
+    };
+
+    const { data, error } = await supabase
+      .from(TB_TRANS)
+      .insert(payload)
+      .select('*')
+      .single();
+    if (error) {
+      return res.status(500).json({ ok: false, error: error.message || 'Erro ao gravar transação' });
+    }
+
+    return res.status(201).json({ ok: true, data });
+  } catch (err) {
+    return next(err);
+  }
+}
+
+module.exports = {
+  preview,
+  create,
+};

--- a/src/features/transacoes/transacoes.routes.js
+++ b/src/features/transacoes/transacoes.routes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const ctrl = require('./transacoes.controller');
+
+const router = express.Router();
+
+router.post('/preview', ctrl.preview);
+router.post('/', ctrl.create);
+
+module.exports = router;

--- a/src/features/transacoes/transacoes.service.js
+++ b/src/features/transacoes/transacoes.service.js
@@ -1,0 +1,2 @@
+// (pode ficar vazio por enquanto ou exportar helpers no futuro)
+module.exports = {};


### PR DESCRIPTION
## Summary
- add SQL migration for `transacoes` table
- implement preview and create endpoints for transacoes
- mount protected `/transacao` routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b701d42490832b92ffe743b8bc10ba