### PR TITLE
feat: add transacao route

### DIFF
--- a/middlewares/requireAdminPin.js
+++ b/middlewares/requireAdminPin.js
@@ -1,6 +1,6 @@
 const supabase = require('../services/supabase');
 
-module.exports = async function requireAdminPin(req, res, next) {
+async function requireAdminPin(req, res, next) {
   try {
     const pin = (req.header('x-admin-pin') || '').trim();
     if (!pin) {
@@ -41,4 +41,7 @@ module.exports = async function requireAdminPin(req, res, next) {
     });
     return res.status(503).json({ ok:false, error:'db_error' });
   }
-};
+}
+
+module.exports = requireAdminPin;
+module.exports.requireAdminPin = requireAdminPin;

--- a/routes/transacao.routes.js
+++ b/routes/transacao.routes.js
@@ -1,3 +1,5 @@
 const express = require('express');
 const router = express.Router();
-module.exports = require('../controllers/transacaoController'); // já exporta um router
+
+// controllers/transacaoController.js já exporta um router
+module.exports = require('../controllers/transacaoController');

--- a/server.js
+++ b/server.js
@@ -51,9 +51,18 @@ const auditController = require('./controllers/auditController');
 const adminsController = require('./controllers/adminsController');
 const adminController = require('./controllers/adminController');
 const adminReportController = require('./controllers/adminReportController');
-const requireAdminPin = require('./middlewares/requireAdminPin');
+const requireAdminPinModule = require('./middlewares/requireAdminPin');
+const { requireAdminPin = requireAdminPinModule } = requireAdminPinModule;
 const adminDiagRoutes = require('./routes/adminDiag');
-const transacaoRoutes = require('./routes/transacao.routes') || require('./src/routes/transacao');
+
+let transacaoRoutes;
+try { transacaoRoutes = require('./routes/transacao.routes'); } catch (e) {}
+if (!transacaoRoutes) {
+  try { transacaoRoutes = require('./src/routes/transacao'); } catch (e) {}
+}
+if (!transacaoRoutes) {
+  transacaoRoutes = require('./controllers/transacaoController');
+}
 
 // páginas estáticas de /admin sem PIN
 app.use('/admin', express.static(path.join(__dirname, 'public', 'admin')));


### PR DESCRIPTION
## Summary
- add transacao route with fallback mounting
- expose requireAdminPin as named export for compatibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b70c038b34832b8adacfccfc68cc3b