### PR TITLE
feat: add planos management and discounts

### DIFF
--- a/__tests__/planos.routes.test.js
+++ b/__tests__/planos.routes.test.js
@@ -1,84 +1,99 @@
 const request = require('supertest');
 const express = require('express');
 
-jest.mock('../src/features/planos/planos.service.js', () => ({
-  getAll: jest.fn(),
-  create: jest.fn(),
-  update: jest.fn(),
-  remove: jest.fn(),
+jest.mock('../services/supabase', () => ({
+  from: jest.fn(),
 }));
-
 jest.mock('../middlewares/requireAdminPin.js', () => (req, res, next) => {
   const pin = req.header('x-admin-pin');
-  if (pin === '1234') { req.adminId = 1; return next(); }
-  return res.status(401).json({ ok:false, error:'invalid_pin' });
+  return pin === '1234' ? next() : res.status(401).json({ ok:false, error:'invalid_pin' });
 });
 
-const planosService = require('../src/features/planos/planos.service.js');
-const planosRoutes = require('../src/features/planos/planos.routes.js');
+const supabase = require('../services/supabase');
+const planosPublicRoutes = require('../routes/planos.public.routes.js');
+const planosAdminRoutes  = require('../routes/planos.admin.routes.js');
+const requireAdminPin = require('../middlewares/requireAdminPin.js');
 
 const app = express();
 app.use(express.json());
-app.use('/planos', planosRoutes);
+app.use('/planos', planosPublicRoutes);
+app.use('/admin/planos', requireAdminPin, planosAdminRoutes);
 
 describe('Planos Routes', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
+  beforeEach(() => { jest.clearAllMocks(); });
 
-  test('GET /planos - lista todos os planos', async () => {
+  test('GET /planos - lista nomes ativos', async () => {
+    const builder = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      data: [{ nome: 'Essencial' }, { nome: 'Platinum' }, { nome: 'Black' }],
+      error: null,
+    };
+    supabase.from.mockReturnValue(builder);
     const res = await request(app).get('/planos');
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ ok: true, planos: ['Essencial', 'Platinum', 'Black'] });
   });
 
-  test('POST /planos - cria plano', async () => {
-    const payload = { nome: 'A', descricao: 'desc', preco: 10 };
-    planosService.create.mockResolvedValue({ data: { id: 1, ...payload }, error: null });
+  test('POST /admin/planos - cria plano', async () => {
+    supabase.from.mockReturnValue({
+      insert: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: { id: 1 }, error: null })
+        })
+      })
+    });
     const res = await request(app)
-      .post('/planos')
+      .post('/admin/planos')
       .set('x-admin-pin', '1234')
-      .send(payload);
-    expect(res.status).toBe(201);
-    expect(res.body).toEqual({ id: 1, ...payload });
-    expect(planosService.create).toHaveBeenCalledWith(payload);
-  });
-
-  test('POST /planos sem PIN retorna 401', async () => {
-    const payload = { nome: 'A' };
-    const res = await request(app).post('/planos').send(payload);
-    expect(res.status).toBe(401);
-    expect(planosService.create).not.toHaveBeenCalled();
-  });
-
-  test('POST /planos com PIN inválido retorna 401', async () => {
-    const payload = { nome: 'A' };
-    const res = await request(app)
-      .post('/planos')
-      .set('x-admin-pin', '0000')
-      .send(payload);
-    expect(res.status).toBe(401);
-    expect(planosService.create).not.toHaveBeenCalled();
-  });
-
-  test('PUT /planos/:id - atualiza plano', async () => {
-    const payload = { nome: 'B' };
-    planosService.update.mockResolvedValue({ data: { id: '1', ...payload }, error: null });
-    const res = await request(app)
-      .put('/planos/1')
-      .set('x-admin-pin', '1234')
-      .send(payload);
+      .send({ nome: 'A', desconto_percent: 10 });
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ id: '1', ...payload });
-    expect(planosService.update).toHaveBeenCalledWith('1', payload);
+    expect(res.body).toHaveProperty('ok', true);
   });
 
-  test('DELETE /planos/:id - remove plano', async () => {
-    planosService.remove.mockResolvedValue({ data: null, error: null });
+  test('POST /admin/planos sem PIN retorna 401', async () => {
     const res = await request(app)
-      .delete('/planos/1')
-      .set('x-admin-pin', '1234');
-    expect(res.status).toBe(204);
-    expect(planosService.remove).toHaveBeenCalledWith('1');
+      .post('/admin/planos')
+      .send({ nome: 'A', desconto_percent: 10 });
+    expect(res.status).toBe(401);
+  });
+
+  test('POST /admin/planos com PIN inválido retorna 401', async () => {
+    const res = await request(app)
+      .post('/admin/planos')
+      .set('x-admin-pin', '0000')
+      .send({ nome: 'A', desconto_percent: 10 });
+    expect(res.status).toBe(401);
+  });
+
+  test('PATCH /admin/planos/:id - atualiza plano', async () => {
+    supabase.from.mockReturnValue({
+      update: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: { id: 1 }, error: null })
+        })
+      })
+    });
+    const res = await request(app)
+      .patch('/admin/planos/1')
+      .set('x-admin-pin', '1234')
+      .send({ nome: 'B' });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('ok', true);
+  });
+
+  test('POST /admin/planos/rename - renomeia plano', async () => {
+    supabase.from.mockReturnValue({
+      update: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+    });
+    const res = await request(app)
+      .post('/admin/planos/rename')
+      .set('x-admin-pin', '1234')
+      .send({ from: 'A', to: 'B' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
   });
 });

--- a/controllers/planosController.js
+++ b/controllers/planosController.js
@@ -1,0 +1,108 @@
+const supabase = require('../services/supabase');
+
+// Lista pública: nomes de planos ativos
+exports.publicList = async (req, res, next) => {
+  try {
+    const { data, error } = await supabase
+      .from('planos')
+      .select('nome')
+      .eq('ativo', true)
+      .order('prioridade', { ascending: false })
+      .order('nome', { ascending: true });
+    if (error) throw error;
+    return res.json({ ok: true, planos: (data || []).map(p => p.nome) });
+  } catch (err) { next(err); }
+};
+
+// Lista admin com paginação e filtro q (ilike no nome)
+exports.adminList = async (req, res, next) => {
+  try {
+    const limit = Math.max(1, Math.min(100, Number(req.query.limit) || 20));
+    const offset = Math.max(0, Number(req.query.offset) || 0);
+    const q = (req.query.q || '').trim();
+
+    let query = supabase
+      .from('planos')
+      .select('id, nome, desconto_percent, preco_centavos, ativo, prioridade, updated_at', { count: 'exact' })
+      .order('prioridade', { ascending: false })
+      .order('nome', { ascending: true })
+      .range(offset, offset + limit - 1);
+
+    if (q) query = query.ilike('nome', `%${q}%`);
+
+    const { data, error, count } = await query;
+    if (error) throw error;
+    return res.json({ ok: true, rows: data || [], total: count || 0 });
+  } catch (err) { next(err); }
+};
+
+// Criação
+exports.create = async (req, res, next) => {
+  try {
+    const { nome, desconto_percent, ativo = true, prioridade = 0, preco_centavos = 0 } = req.body || {};
+    if (!nome || typeof nome !== 'string') return res.status(400).json({ ok:false, error:'nome obrigatório' });
+    const pct = Number(desconto_percent);
+    if (!Number.isFinite(pct) || pct < 0 || pct > 100) return res.status(400).json({ ok:false, error:'desconto_percent inválido' });
+
+    const { data, error } = await supabase
+      .from('planos')
+      .insert({ nome: nome.trim(), desconto_percent: pct, ativo: !!ativo, prioridade: Number(prioridade)||0, preco_centavos: Number(preco_centavos)||0 })
+      .select()
+      .single();
+
+    if (error) throw error;
+    return res.json({ ok:true, data });
+  } catch (err) { next(err); }
+};
+
+// Update por :id
+exports.update = async (req, res, next) => {
+  try {
+    const id = Number(req.params.id);
+    if (!id) return res.status(400).json({ ok:false, error:'id inválido' });
+
+    const patch = {};
+    if ('nome' in req.body) patch.nome = String(req.body.nome || '').trim();
+    if ('desconto_percent' in req.body) {
+      const pct = Number(req.body.desconto_percent);
+      if (!Number.isFinite(pct) || pct < 0 || pct > 100) return res.status(400).json({ ok:false, error:'desconto_percent inválido' });
+      patch.desconto_percent = pct;
+    }
+    if ('ativo' in req.body) patch.ativo = !!req.body.ativo;
+    if ('prioridade' in req.body) patch.prioridade = Number(req.body.prioridade)||0;
+    if ('preco_centavos' in req.body) patch.preco_centavos = Number(req.body.preco_centavos)||0;
+
+    if (Object.keys(patch).length === 0) return res.status(400).json({ ok:false, error:'nada para atualizar' });
+
+    const { data, error } = await supabase
+      .from('planos')
+      .update(patch)
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (error) throw error;
+    return res.json({ ok:true, data });
+  } catch (err) { next(err); }
+};
+
+// Rename (opcionalmente propaga para clientes)
+exports.rename = async (req, res, next) => {
+  try {
+    const from = String(req.body?.from || '').trim();
+    const to   = String(req.body?.to   || '').trim();
+    const updClients = !!req.body?.update_clientes;
+    if (!from || !to) return res.status(400).json({ ok:false, error:'from/to obrigatórios' });
+
+    // Renomeia plano
+    const { error: e1 } = await supabase.from('planos').update({ nome: to }).eq('nome', from);
+    if (e1) throw e1;
+
+    // Propaga em clientes, se pedido
+    if (updClients) {
+      const { error: e2 } = await supabase.from('clientes').update({ plano: to }).eq('plano', from);
+      if (e2) throw e2;
+    }
+    return res.json({ ok:true });
+  } catch (err) { next(err); }
+};

--- a/routes/planos.admin.routes.js
+++ b/routes/planos.admin.routes.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const ctrl = require('../controllers/planosController');
+
+router.get('/', ctrl.adminList);
+router.post('/', ctrl.create);
+router.patch('/:id', ctrl.update);
+router.post('/rename', ctrl.rename);
+
+module.exports = router;

--- a/routes/planos.public.routes.js
+++ b/routes/planos.public.routes.js
@@ -1,0 +1,5 @@
+const express = require('express');
+const router = express.Router();
+const ctrl = require('../controllers/planosController');
+router.get('/', ctrl.publicList);
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -37,23 +37,24 @@ app.get('/health', (req, res) => {
   app.get('/', (req, res) => res.json({ ok:true, service:'clube-vantagens-api' }));
   app.head('/', (req, res) => res.sendStatus(200));
 
-// rotas da API (planos, etc)…
-const planosRouter = require('./src/features/planos/planos.routes.js');
-app.use('/planos', planosRouter);
-app.use('/api/planos', planosRouter);
-
-// ADMIN (static pages + API)
-const path = require('path');
-const clientesRouter = require('./routes/admin.routes');
-const clientesController = require('./controllers/clientesController');
-const clientesRoutes = require('./src/features/clientes/clientes.routes.js');
-const auditController = require('./controllers/auditController');
-const adminsController = require('./controllers/adminsController');
-const adminController = require('./controllers/adminController');
-const adminReportController = require('./controllers/adminReportController');
 const requireAdminPinModule = require('./middlewares/requireAdminPin');
 const { requireAdminPin = requireAdminPinModule } = requireAdminPinModule;
-const adminDiagRoutes = require('./routes/adminDiag');
+const planosPublicRoutes = require('./routes/planos.public.routes');
+const planosAdminRoutes  = require('./routes/planos.admin.routes');
+
+app.use('/planos', planosPublicRoutes);
+app.use('/admin/planos', requireAdminPin, planosAdminRoutes);
+
+// ADMIN (static pages + API)
+  const path = require('path');
+  const clientesRouter = require('./routes/admin.routes');
+  const clientesController = require('./controllers/clientesController');
+  const clientesRoutes = require('./src/features/clientes/clientes.routes.js');
+  const auditController = require('./controllers/auditController');
+  const adminsController = require('./controllers/adminsController');
+  const adminController = require('./controllers/adminController');
+  const adminReportController = require('./controllers/adminReportController');
+  const adminDiagRoutes = require('./routes/adminDiag');
 
 let transacaoRoutes;
 try { transacaoRoutes = require('./routes/transacao.routes'); } catch (e) {}

--- a/tests/clientes.test.js
+++ b/tests/clientes.test.js
@@ -151,17 +151,27 @@ describe('Clientes Controller', () => {
   });
 
   test('bulkUpsert sucesso', async () => {
-    let call = 0;
-    supabase.from.mockImplementation(() => {
-      if (call++ === 0) {
+    let step = 0;
+    supabase.from.mockImplementation((table) => {
+      if (table === 'planos') {
         return {
           select: jest.fn().mockReturnThis(),
-          in: jest.fn().mockResolvedValue({ data: [], error: null }),
+          eq: jest.fn().mockReturnThis(),
+          maybeSingle: jest.fn().mockResolvedValue({ data: { id: 1 }, error: null }),
         };
       }
-      return {
-        upsert: jest.fn().mockResolvedValue({ error: null }),
-      };
+      if (table === 'clientes') {
+        if (step++ === 0) {
+          return {
+            select: jest.fn().mockReturnThis(),
+            in: jest.fn().mockResolvedValue({ data: [], error: null }),
+          };
+        }
+        return {
+          upsert: jest.fn().mockResolvedValue({ error: null }),
+        };
+      }
+      return {};
     });
 
     const res = await request(app)

--- a/tests/transacoes.test.js
+++ b/tests/transacoes.test.js
@@ -21,13 +21,28 @@ describe('Rotas de transações', () => {
 
   describe('GET /transacao/preview', () => {
     test('retorna preview com desconto', async () => {
-      supabase.from.mockReturnValue({
-        select: jest.fn().mockReturnThis(),
-        eq: jest.fn().mockReturnThis(),
-        maybeSingle: jest.fn().mockResolvedValue({
-          data: { nome: 'João', plano: 'Essencial' },
-          error: null,
-        }),
+      supabase.from.mockImplementation((table) => {
+        if (table === 'clientes') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            maybeSingle: jest.fn().mockResolvedValue({
+              data: { nome: 'João', plano: 'Essencial' },
+              error: null,
+            }),
+          };
+        }
+        if (table === 'planos') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            maybeSingle: jest.fn().mockResolvedValue({
+              data: { desconto_percent: 10 },
+              error: null,
+            }),
+          };
+        }
+        return {};
       });
 
       const res = await request(app)
@@ -71,6 +86,16 @@ describe('Rotas de transações', () => {
             eq: jest.fn().mockReturnThis(),
             maybeSingle: jest.fn().mockResolvedValue({
               data: { nome: 'João', plano: 'Black' },
+              error: null,
+            }),
+          };
+        }
+        if (table === 'planos') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            maybeSingle: jest.fn().mockResolvedValue({
+              data: { desconto_percent: 30 },
               error: null,
             }),
           };
@@ -127,6 +152,16 @@ describe('Rotas de transações', () => {
             eq: jest.fn().mockReturnThis(),
             maybeSingle: jest.fn().mockResolvedValue({
               data: { nome: 'João', plano: 'Essencial' },
+              error: null,
+            }),
+          };
+        }
+        if (table === 'planos') {
+          return {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            maybeSingle: jest.fn().mockResolvedValue({
+              data: { desconto_percent: 10 },
               error: null,
             }),
           };


### PR DESCRIPTION
## Summary
- add public and admin routes for planos
- validate cliente plano via database
- compute transaction discounts from planos table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b74220ab6c832b9cde14f62daec144