### PR TITLE
feat: add safe plan deletion

### DIFF
--- a/public/planos-admin.html
+++ b/public/planos-admin.html
@@ -45,6 +45,7 @@
   </header>
 
   <main>
+    <p class="muted">Apagar só funciona se zero clientes estiverem no plano. Para planos em uso, use Renomear (com propagar) para juntar em outro plano, ou desative.</p>
     <div class="toolbar">
       <input id="q" placeholder="Buscar por nome..." />
       <button id="btn-buscar" class="ghost">Buscar</button>

--- a/public/planos-admin.js
+++ b/public/planos-admin.js
@@ -82,6 +82,10 @@
       const btnEdit = document.createElement('button'); btnEdit.textContent = 'Editar';
       btnEdit.addEventListener('click', () => onEdit(r));
       tdAcoes.appendChild(btnEdit);
+      const btnDel = document.createElement('button');
+      btnDel.textContent = 'Apagar';
+      btnDel.addEventListener('click', () => onDelete(r));
+      tdAcoes.appendChild(btnDel);
 
       tr.append(tdNome, tdPct, tdPrio, tdAtivo, tdUpd, tdAcoes);
       tbody.appendChild(tr);
@@ -120,6 +124,18 @@
     prioEl.value = r.prioridade ?? 0;
     ativoEl.checked = !!r.ativo;
     formTitle.textContent = `Editando: ${r.nome}`;
+  }
+
+  async function onDelete(r) {
+    const yes = confirm(`Apagar o plano "${r.nome}"? Esta ação é definitiva e só é permitida se não houver clientes usando este plano.`);
+    if (!yes) return;
+    try {
+      await apiAdmin(`/admin/planos/${r.id}`, { method: 'DELETE' });
+      await load();
+    } catch (err) {
+      // apiAdmin já mostra o alerta do erro; reforçamos a dica aqui
+      alert('Não foi possível apagar. Dica: use "Renomear" com update_clientes=ON para migrar clientes para outro plano, ou edite e desmarque "Ativo".');
+    }
   }
 
   // Eventos de lista

--- a/routes/planos.admin.routes.js
+++ b/routes/planos.admin.routes.js
@@ -5,6 +5,7 @@ const ctrl = require('../controllers/planosController');
 router.get('/', ctrl.adminList);
 router.post('/', ctrl.create);
 router.patch('/:id', ctrl.update);
+router.delete('/:id', ctrl.remove);
 router.post('/rename', ctrl.rename);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add backend endpoint to delete plan only when unused
- expose delete option in admin UI with confirm and tip
- document deletion limits in admin page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b754bcdcbc832b970951c09c266765