### PR TITLE
feat: add admin transaction reports

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
     <a href="/">Dashboard</a>
     <a href="/admin/cadastro.html">Clientes &gt; Novo</a>
     <a href="/admin/assinatura.html">Assinaturas</a>
+    <a href="/transacoes-admin.html">Transações Admin</a>
     <a href="/deploy-check.html">Status/Health</a>
   </nav>
   <div><label>PIN <input type="password" id="pin" class="pin-input"></label></div>

--- a/public/transacoes-admin.html
+++ b/public/transacoes-admin.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Gestão de Transações</title>
+  <link rel="stylesheet" href="/main.css"/>
+</head>
+<body class="container">
+  <h1>Transações</h1>
+  <p>Filtre e exporte as vendas. O CSV usa os mesmos filtros.</p>
+
+  <div class="card">
+    <div class="grid">
+      <div>
+        <label>CPF</label>
+        <input id="f-cpf" placeholder="apenas números"/>
+      </div>
+      <div>
+        <label>Desde</label>
+        <input id="f-desde" type="datetime-local"/>
+      </div>
+      <div>
+        <label>Até</label>
+        <input id="f-ate" type="datetime-local"/>
+      </div>
+      <div>
+        <label>Método</label>
+        <select id="f-metodo">
+          <option value="">(todos)</option>
+          <option value="pix">pix</option>
+          <option value="cartao">cartao</option>
+        </select>
+      </div>
+      <div>
+        <label>Status pgto</label>
+        <select id="f-status">
+          <option value="">(todos)</option>
+          <option value="pendente">pendente</option>
+          <option value="pago">pago</option>
+          <option value="cancelado">cancelado</option>
+        </select>
+      </div>
+    </div>
+
+    <div style="margin-top:8px;">
+      <button id="btn-buscar">Buscar</button>
+      <button id="btn-csv">Exportar CSV</button>
+    </div>
+
+    <table class="table" style="margin-top:12px;">
+      <thead>
+        <tr>
+          <th>ID</th><th>Data</th><th>CPF</th><th>Método</th><th>Status</th>
+          <th>Original</th><th>Desc</th><th>Final</th>
+        </tr>
+      </thead>
+      <tbody id="rows"></tbody>
+    </table>
+
+    <div class="pager">
+      <button id="prev">Anterior</button>
+      <span id="pageinfo"></span>
+      <button id="next">Próxima</button>
+    </div>
+  </div>
+
+  <script src="/transacoes-admin.js"></script>
+</body>
+</html>

--- a/public/transacoes-admin.js
+++ b/public/transacoes-admin.js
@@ -1,0 +1,114 @@
+const API = ''; // vazio = mesmo host (usamos caminhos relativos)
+const PIN_KEY = 'admin_pin';
+
+function getPin() {
+  let p = sessionStorage.getItem(PIN_KEY) || localStorage.getItem(PIN_KEY);
+  if (!p) {
+    p = prompt('PIN do admin:');
+    if (!p) throw new Error('PIN necessário');
+    sessionStorage.setItem(PIN_KEY, p);
+  }
+  return p;
+}
+
+async function apiAdmin(path, opts = {}) {
+  const pin = getPin();
+  const res = await fetch((API || '') + path, {
+    ...opts,
+    headers: {
+      'x-admin-pin': pin,
+      ...(opts.headers || {})
+    }
+  });
+  if (!res.ok) {
+    const txt = await res.text();
+    alert(`Erro ${res.status}: ${txt}`);
+    throw new Error(txt);
+  }
+  const ct = res.headers.get('content-type') || '';
+  if (ct.includes('application/json')) return res.json();
+  return res.text();
+}
+
+let state = { page: 0, limit: 20, total: 0, lastQuery: {} };
+
+function readFilters() {
+  const cpf = document.getElementById('f-cpf').value.replace(/\D/g,'');
+  const desde = document.getElementById('f-desde').value;
+  const ate   = document.getElementById('f-ate').value;
+  const metodo = document.getElementById('f-metodo').value;
+  const status = document.getElementById('f-status').value;
+  return { cpf, desde, ate, metodo_pagamento: metodo, status_pagamento: status };
+}
+
+async function load(page = 0) {
+  state.page = Math.max(0, page);
+  const q = readFilters();
+  state.lastQuery = q;
+  const params = new URLSearchParams({
+    ...Object.fromEntries(Object.entries(q).filter(([_,v]) => v)),
+    limit: String(state.limit),
+    offset: String(state.page * state.limit),
+    order: 'created_at.desc'
+  });
+  const j = await apiAdmin(`/admin/transacoes?` + params.toString());
+  state.total = j.total || 0;
+  renderRows(j.rows || []);
+}
+
+function renderRows(rows) {
+  const tb = document.getElementById('rows');
+  tb.innerHTML = '';
+  for (const r of rows) {
+    const tr = document.createElement('tr');
+    const fmtMoney = (n)=> (n==null?'':Number(n).toLocaleString('pt-BR',{style:'currency',currency:'BRL'}));
+    const dt = r.created_at ? new Date(r.created_at) : null;
+
+    tr.innerHTML = `
+      <td>${r.id}</td>
+      <td>${dt ? dt.toLocaleString('pt-BR') : ''}</td>
+      <td>${r.cpf || ''}</td>
+      <td>${r.metodo_pagamento || ''}</td>
+      <td>${r.status_pagamento || ''}</td>
+      <td>${fmtMoney(r.valor_original)}</td>
+      <td>${r.desconto_aplicado || ''}</td>
+      <td>${fmtMoney(r.valor_final)}</td>
+    `;
+    tb.appendChild(tr);
+  }
+  const start = state.page * state.limit + 1;
+  const end = Math.min((state.page+1)*state.limit, state.total);
+  document.getElementById('pageinfo').textContent =
+    `Página ${state.page+1} — registros ${start}-${end} de ${state.total}`;
+}
+
+document.getElementById('btn-buscar').addEventListener('click', () => load(0));
+document.getElementById('prev').addEventListener('click', () => {
+  if (state.page > 0) load(state.page - 1);
+});
+document.getElementById('next').addEventListener('click', () => {
+  const lastPage = Math.floor((state.total-1) / state.limit);
+  if (state.page < lastPage) load(state.page + 1);
+});
+
+document.getElementById('btn-csv').addEventListener('click', () => {
+  const q = readFilters();
+  const params = new URLSearchParams(Object.fromEntries(Object.entries(q).filter(([_,v])=>v)));
+  const pin = getPin();
+  // Abre em nova aba com o header via query fallback (?pin=...), e também tentamos header via fetch+blob se preferir
+  const url = `/admin/transacoes/csv?${params.toString()}`;
+  // Usamos fetch para mandar o header x-admin-pin
+  fetch(url, { headers: { 'x-admin-pin': pin } })
+    .then(r => r.blob())
+    .then(b => {
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(b);
+      a.download = 'transacoes.csv';
+      a.click();
+      URL.revokeObjectURL(a.href);
+    })
+    .catch(e => alert('Falha ao baixar CSV: ' + e.message));
+});
+
+// carregamento inicial
+load(0).catch(e => console.error(e));


### PR DESCRIPTION
## Summary
- add admin transaction listing and CSV export routes
- add simple admin transactions page with filters, pagination and CSV download
- link transactions admin page in dashboard nav

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b75867e5d0832bba211ad096ebba84