### PR TITLE
feat: add plan migration and usage APIs

### DIFF
--- a/public/planos-admin.html
+++ b/public/planos-admin.html
@@ -133,6 +133,27 @@
     </dialog>
   </main>
 
+  <div id="modal-migrar" class="modal" style="display:none">
+    <div class="modal-content">
+      <h3>Migrar clientes</h3>
+      <p id="migra-from"></p>
+      <label>Plano destino</label>
+      <select id="migra-to"></select>
+
+      <label style="display:block;margin-top:8px;">
+        <input type="checkbox" id="migra-ativos"/> Somente clientes ativos
+      </label>
+
+      <div style="margin-top:8px;">
+        <button id="btn-migra-preview">Preview</button>
+        <button id="btn-migra-exec">Executar</button>
+        <button id="btn-migra-close">Fechar</button>
+      </div>
+
+      <div id="migra-result" style="margin-top:8px;color:#333"></div>
+    </div>
+  </div>
+
   <script src="./planos-admin.js"></script>
 </body>
 </html>

--- a/routes/planos.admin.routes.js
+++ b/routes/planos.admin.routes.js
@@ -1,11 +1,96 @@
 const express = require('express');
 const router = express.Router();
 const ctrl = require('../controllers/planosController');
+const supabase = require('../services/supabase');
 
 router.get('/', ctrl.adminList);
 router.post('/', ctrl.create);
 router.patch('/:id', ctrl.update);
 router.delete('/:id', ctrl.remove);
 router.post('/rename', ctrl.rename);
+
+// ===================== Admin: Planos - Uso e Migração =====================
+
+// GET /admin/planos/uso?nome=Plano
+router.get('/uso', async (req, res, next) => {
+  try {
+    const { nome } = req.query;
+    if (!nome) return res.status(400).json({ ok: false, error: 'nome é obrigatório' });
+
+    const { data, error } = await supabase
+      .from('clientes')
+      .select('status', { count: 'exact', head: false })
+      .eq('plano', nome);
+
+    if (error) return next(error);
+
+    const rows = data || [];
+    const total = rows.length;
+    const porStatus = rows.reduce((acc, cur) => {
+      const k = cur.status || 'desconhecido';
+      acc[k] = (acc[k] || 0) + 1;
+      return acc;
+    }, {});
+
+    return res.json({ ok: true, nome, total, porStatus });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+// POST /admin/planos/migrar
+// body: { from, to, dry_run?: boolean, only_status?: 'ativo' | 'inativo' }
+router.post('/migrar', async (req, res, next) => {
+  try {
+    const { from, to, dry_run = false, only_status } = req.body || {};
+    if (!from || !to) return res.status(400).json({ ok: false, error: 'from e to são obrigatórios' });
+    if (from === to) return res.status(400).json({ ok: false, error: 'from e to devem ser diferentes' });
+
+    const { data: planosTo, error: errTo } = await supabase
+      .from('planos')
+      .select('id, nome, ativo')
+      .eq('nome', to)
+      .limit(1);
+    if (errTo) return next(errTo);
+    if (!planosTo || planosTo.length === 0) {
+      return res.status(400).json({ ok: false, error: `Plano destino '${to}' não existe` });
+    }
+
+    let qBase = supabase.from('clientes').select('id', { count: 'exact' }).eq('plano', from);
+    if (only_status) qBase = qBase.eq('status', only_status);
+
+    const { count, error: errCount } = await qBase;
+    if (errCount) return next(errCount);
+
+    if (dry_run) {
+      return res.json({ ok: true, preview: true, from, to, only_status: only_status || null, count: count || 0 });
+    }
+
+    let qUpd = supabase
+      .from('clientes')
+      .update({
+        plano: to,
+        last_admin_id: String(req.adminId || ''),
+        last_admin_nome: String(req.adminNome || ''),
+        last_action_at: new Date().toISOString()
+      })
+      .eq('plano', from);
+
+    if (only_status) qUpd = qUpd.eq('status', only_status);
+
+    const { data: updData, error: errUpd } = await qUpd.select('id');
+    if (errUpd) return next(errUpd);
+
+    return res.json({
+      ok: true,
+      from,
+      to,
+      only_status: only_status || null,
+      migrated: updData?.length || 0
+    });
+  } catch (err) {
+    return next(err);
+  }
+});
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add endpoints to inspect plan usage and migrate clients between plans
- add migration modal and buttons to admin UI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7674b5c00832b9ff629935dc8680d