### PR TITLE
feat: add admin transactions panel

### DIFF
--- a/public/transacoes-admin.html
+++ b/public/transacoes-admin.html
@@ -1,39 +1,70 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="pt-BR">
 <head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>Gestão de Transações</title>
-  <link rel="stylesheet" href="/main.css"/>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Transações (Admin)</title>
+  <style>
+    body{margin:0;font-family:system-ui,sans-serif;background:#111;color:#eee;}
+    .container{max-width:1200px;margin:0 auto;padding:20px;}
+    h1{margin-top:0;}
+    input,select,button{padding:8px;border-radius:4px;border:1px solid #555;background:#222;color:#eee;font-size:14px;}
+    button{cursor:pointer;}
+    button.primary{background:#2563eb;border-color:#2563eb;color:#fff;}
+    button[disabled]{opacity:.5;cursor:not-allowed;}
+    .card{background:#1e1e1e;border:1px solid #333;border-radius:8px;padding:16px;margin-top:16px;}
+    .grid{display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));}
+    table{width:100%;border-collapse:collapse;margin-top:12px;}
+    th,td{padding:8px;border-bottom:1px solid #333;text-align:left;}
+    th{background:#222;}
+    tr:nth-child(even){background:#1a1a1a;}
+    .pager{display:flex;align-items:center;gap:8px;margin-top:8px;}
+    .kpis{display:grid;gap:12px;margin-top:16px;}
+    .kpi{background:#222;padding:12px;border-radius:8px;text-align:center;}
+    .chip{padding:2px 6px;border-radius:4px;font-size:12px;text-transform:capitalize;color:#fff;}
+    .chip.pago{background:#16a34a;}
+    .chip.pendente{background:#d97706;}
+    .chip.cancelado{background:#dc2626;}
+    @media(max-width:700px){
+      .col-cliente,.col-desc,.col-metodo,.col-obs{display:none;}
+    }
+    .toast-box{position:fixed;bottom:1rem;right:1rem;display:grid;gap:.5rem;}
+    .toast{background:#333;color:#fff;padding:8px 12px;border-radius:4px;}
+    .toast--success{border-left:4px solid #16a34a;}
+    .toast--error{border-left:4px solid #dc2626;}
+    .toast--info{border-left:4px solid #2563eb;}
+    .actions{display:flex;gap:8px;flex-wrap:wrap;}
+  </style>
 </head>
-<body class="container">
-  <h1>Transações</h1>
-  <p>Filtre e exporte as vendas. O CSV usa os mesmos filtros.</p>
+<body>
+<div class="container">
+  <h1>Gestão de Transações</h1>
 
   <div class="card">
+    <label for="admin-pin">PIN Admin</label>
+    <div class="actions">
+      <input id="admin-pin" type="password" placeholder="****">
+      <button id="save-pin">Salvar PIN</button>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>Filtros</h2>
     <div class="grid">
       <div>
         <label>CPF</label>
-        <input id="f-cpf" placeholder="apenas números"/>
+        <input id="f-cpf" placeholder="apenas números">
       </div>
       <div>
         <label>Desde</label>
-        <input id="f-desde" type="datetime-local"/>
+        <input type="date" id="f-desde">
       </div>
       <div>
         <label>Até</label>
-        <input id="f-ate" type="datetime-local"/>
+        <input type="date" id="f-ate">
       </div>
       <div>
-        <label>Método</label>
-        <select id="f-metodo">
-          <option value="">(todos)</option>
-          <option value="pix">pix</option>
-          <option value="cartao">cartao</option>
-        </select>
-      </div>
-      <div>
-        <label>Status pgto</label>
+        <label>Status</label>
         <select id="f-status">
           <option value="">(todos)</option>
           <option value="pendente">pendente</option>
@@ -41,23 +72,54 @@
           <option value="cancelado">cancelado</option>
         </select>
       </div>
+      <div>
+        <label>Método</label>
+        <select id="f-metodo">
+          <option value="">(todos)</option>
+          <option value="pix">pix</option>
+          <option value="credito">credito</option>
+          <option value="debito">debito</option>
+          <option value="dinheiro">dinheiro</option>
+        </select>
+      </div>
     </div>
-
-    <div style="margin-top:8px;">
-      <button id="btn-buscar">Buscar</button>
+    <div class="actions" style="margin-top:8px;">
+      <button id="btn-buscar" class="primary">Buscar</button>
+      <button id="btn-limpar">Limpar filtros</button>
       <button id="btn-csv">Exportar CSV</button>
     </div>
+  </div>
 
-    <table class="table" style="margin-top:12px;">
+  <div class="card">
+    <h2>Resumo</h2>
+    <div class="kpis" id="kpis"></div>
+  </div>
+
+  <div class="card">
+    <div class="actions" style="justify-content:flex-end;margin-bottom:8px;">
+      <button id="bulk-pay" disabled>Pagar selecionadas</button>
+      <button id="bulk-pend" disabled>Marcar pendente</button>
+      <button id="bulk-cancel" disabled>Cancelar</button>
+    </div>
+    <table>
       <thead>
         <tr>
-          <th>ID</th><th>Data</th><th>CPF</th><th>Método</th><th>Status</th>
-          <th>Original</th><th>Desc</th><th>Final</th>
+          <th><input type="checkbox" id="chk-all"></th>
+          <th>ID</th>
+          <th>Data</th>
+          <th>CPF</th>
+          <th class="col-cliente">Cliente</th>
+          <th class="col-desc">% Desc</th>
+          <th>Bruto</th>
+          <th>Final</th>
+          <th>Status</th>
+          <th class="col-metodo">Método</th>
+          <th class="col-obs">Obs</th>
+          <th>Ações</th>
         </tr>
       </thead>
       <tbody id="rows"></tbody>
     </table>
-
     <div class="pager">
       <button id="prev">Anterior</button>
       <span id="pageinfo"></span>
@@ -65,6 +127,8 @@
     </div>
   </div>
 
-  <script src="/transacoes-admin.js"></script>
+</div>
+<div id="toasts" class="toast-box"></div>
+<script src="transacoes-admin.js"></script>
 </body>
 </html>

--- a/public/transacoes-admin.js
+++ b/public/transacoes-admin.js
@@ -1,114 +1,237 @@
-const API = ''; // vazio = mesmo host (usamos caminhos relativos)
-const PIN_KEY = 'admin_pin';
+const PIN_KEY = 'cv_admin_pin';
+const LIMIT = 20;
+const state = { page: 0, total: 0, selected: new Set() };
 
-function getPin() {
-  let p = sessionStorage.getItem(PIN_KEY) || localStorage.getItem(PIN_KEY);
-  if (!p) {
-    p = prompt('PIN do admin:');
-    if (!p) throw new Error('PIN necessário');
-    sessionStorage.setItem(PIN_KEY, p);
-  }
-  return p;
+function getPin(){
+  return localStorage.getItem(PIN_KEY) || '';
 }
-
-async function apiAdmin(path, opts = {}) {
-  const pin = getPin();
-  const res = await fetch((API || '') + path, {
-    ...opts,
-    headers: {
-      'x-admin-pin': pin,
-      ...(opts.headers || {})
-    }
-  });
-  if (!res.ok) {
-    const txt = await res.text();
-    alert(`Erro ${res.status}: ${txt}`);
-    throw new Error(txt);
-  }
-  const ct = res.headers.get('content-type') || '';
-  if (ct.includes('application/json')) return res.json();
-  return res.text();
+function setPin(v){
+  localStorage.setItem(PIN_KEY, v);
 }
-
-let state = { page: 0, limit: 20, total: 0, lastQuery: {} };
-
-function readFilters() {
-  const cpf = document.getElementById('f-cpf').value.replace(/\D/g,'');
-  const desde = document.getElementById('f-desde').value;
-  const ate   = document.getElementById('f-ate').value;
-  const metodo = document.getElementById('f-metodo').value;
-  const status = document.getElementById('f-status').value;
-  return { cpf, desde, ate, metodo_pagamento: metodo, status_pagamento: status };
+function toast(msg, type='info'){
+  const box = document.getElementById('toasts');
+  const el = document.createElement('div');
+  el.className = `toast toast--${type}`;
+  el.textContent = msg;
+  box.appendChild(el);
+  setTimeout(()=>el.remove(),3000);
 }
-
-async function load(page = 0) {
-  state.page = Math.max(0, page);
-  const q = readFilters();
-  state.lastQuery = q;
-  const params = new URLSearchParams({
-    ...Object.fromEntries(Object.entries(q).filter(([_,v]) => v)),
-    limit: String(state.limit),
-    offset: String(state.page * state.limit),
-    order: 'created_at.desc'
-  });
-  const j = await apiAdmin(`/admin/transacoes?` + params.toString());
+function readFilters(){
+  return {
+    cpf: document.getElementById('f-cpf').value.replace(/\D/g,''),
+    desde: document.getElementById('f-desde').value,
+    ate: document.getElementById('f-ate').value,
+    status_pagamento: document.getElementById('f-status').value,
+    metodo_pagamento: document.getElementById('f-metodo').value,
+  };
+}
+function qs(obj){
+  const p = new URLSearchParams();
+  Object.entries(obj).forEach(([k,v])=>{ if(v) p.append(k,v); });
+  return p.toString();
+}
+function fmtMoney(n){
+  if(n==null) return '';
+  return Number(n).toLocaleString('pt-BR',{style:'currency',currency:'BRL'});
+}
+function defaultDates(){
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth()+1).padStart(2,'0');
+  const d = String(now.getDate()).padStart(2,'0');
+  return { desde:`${y}-${m}-01`, ate:`${y}-${m}-${d}` };
+}
+async function fetchResumo(){
+  const f = readFilters();
+  delete f.cpf;
+  const r = await fetch(`/admin/transacoes/resumo?${qs(f)}`,{headers:{'x-admin-pin':getPin()}});
+  if(!r.ok){ toast('Erro ao carregar resumo','error'); return; }
+  const j = await r.json();
+  const k = document.getElementById('kpis');
+  k.innerHTML = `
+    <div class="kpi"><div>Transações</div><strong>${j.total||0}</strong></div>
+    <div class="kpi"><div>Soma Bruta</div><strong>${fmtMoney(j.somaBruta)}</strong></div>
+    <div class="kpi"><div>Soma Final</div><strong>${fmtMoney(j.somaFinal)}</strong></div>
+    <div class="kpi"><div>Desconto Total</div><strong>${fmtMoney(j.descontoTotal)}</strong></div>
+    <div class="kpi"><div>Desconto Médio (%)</div><strong>${Number(j.descontoMedioPercent||0).toFixed(2)}%</strong></div>
+    <div class="kpi"><div>Ticket Médio</div><strong>${fmtMoney(j.ticketMedio)}</strong></div>`;
+}
+async function fetchTransacoes(page=0){
+  state.page = page;
+  const f = readFilters();
+  const params = new URLSearchParams();
+  Object.entries(f).forEach(([k,v])=>{ if(v) params.append(k,v); });
+  params.append('limit', LIMIT);
+  params.append('offset', page*LIMIT);
+  const r = await fetch(`/admin/transacoes?${params.toString()}`,{headers:{'x-admin-pin':getPin()}});
+  if(!r.ok){ toast('Erro ao buscar','error'); return; }
+  const j = await r.json();
   state.total = j.total || 0;
-  renderRows(j.rows || []);
+  renderRows(j.rows||[]);
 }
-
-function renderRows(rows) {
+function renderRows(rows){
   const tb = document.getElementById('rows');
-  tb.innerHTML = '';
-  for (const r of rows) {
-    const tr = document.createElement('tr');
-    const fmtMoney = (n)=> (n==null?'':Number(n).toLocaleString('pt-BR',{style:'currency',currency:'BRL'}));
-    const dt = r.created_at ? new Date(r.created_at) : null;
-
-    tr.innerHTML = `
-      <td>${r.id}</td>
-      <td>${dt ? dt.toLocaleString('pt-BR') : ''}</td>
-      <td>${r.cpf || ''}</td>
-      <td>${r.metodo_pagamento || ''}</td>
-      <td>${r.status_pagamento || ''}</td>
-      <td>${fmtMoney(r.valor_original)}</td>
-      <td>${r.desconto_aplicado || ''}</td>
-      <td>${fmtMoney(r.valor_final)}</td>
-    `;
+  tb.innerHTML='';
+  state.selected.clear();
+  document.getElementById('chk-all').checked=false;
+  if(rows.length===0){
+    const tr=document.createElement('tr');
+    tr.innerHTML = `<td colspan="12" style="text-align:center;">Sem resultados</td>`;
     tb.appendChild(tr);
+  }else{
+    for(const r of rows){
+      const dt = r.created_at? new Date(r.created_at):null;
+      const desc = r.desconto_aplicado!=null? `${r.desconto_aplicado}%`:'';
+      const st = r.status_pagamento||'';
+      const tr=document.createElement('tr');
+      tr.innerHTML=`
+        <td><input type="checkbox" data-id="${r.id}"></td>
+        <td>${r.id}</td>
+        <td>${dt? dt.toLocaleDateString('pt-BR'):''}</td>
+        <td>${r.cpf||''}</td>
+        <td class="col-cliente">${r.cliente||r.nome||''}</td>
+        <td class="col-desc">${desc}</td>
+        <td>${fmtMoney(r.valor_original)}</td>
+        <td>${fmtMoney(r.valor_final)}</td>
+        <td><span class="chip ${st}">${st}</span></td>
+        <td class="col-metodo">${r.metodo_pagamento||''}</td>
+        <td class="col-obs">${r.observacoes||''}</td>
+        <td>
+          <div class="actions">
+            <button data-act="pagar" data-id="${r.id}">Pagar</button>
+            <button data-act="pendente" data-id="${r.id}">Pendente</button>
+            <button data-act="cancelar" data-id="${r.id}">Cancelar</button>
+          </div>
+        </td>`;
+      tb.appendChild(tr);
+    }
   }
-  const start = state.page * state.limit + 1;
-  const end = Math.min((state.page+1)*state.limit, state.total);
-  document.getElementById('pageinfo').textContent =
-    `Página ${state.page+1} — registros ${start}-${end} de ${state.total}`;
+  const totalPages = Math.max(1, Math.ceil(state.total / LIMIT));
+  document.getElementById('pageinfo').textContent = `Página ${state.page+1} de ${totalPages} (${state.total} registros)`;
+  updateBulkButtons();
 }
-
-document.getElementById('btn-buscar').addEventListener('click', () => load(0));
-document.getElementById('prev').addEventListener('click', () => {
-  if (state.page > 0) load(state.page - 1);
+function updateBulkButtons(){
+  const on = state.selected.size>0;
+  document.getElementById('bulk-pay').disabled=!on;
+  document.getElementById('bulk-pend').disabled=!on;
+  document.getElementById('bulk-cancel').disabled=!on;
+}
+async function patchTransacao(id, payload){
+  try{
+    const r = await fetch(`/admin/transacoes/${id}`,{
+      method:'PATCH',
+      headers:{'Content-Type':'application/json','x-admin-pin':getPin()},
+      body: JSON.stringify(payload)
+    });
+    if(!r.ok){ throw new Error(await r.text()); }
+    toast(`Transação ${id} atualizada.`, 'success');
+    await fetchTransacoes(state.page);
+    await fetchResumo();
+  }catch(err){ toast('Erro ao atualizar: '+err.message,'error'); }
+}
+async function bulk(action){
+  const ids = Array.from(state.selected);
+  if(ids.length===0) return;
+  const payloads={
+    pay:{status_pagamento:'pago',metodo_pagamento:'pix',observacoes:'liquidação manual'},
+    pend:{status_pagamento:'pendente',observacoes:'ajuste manual'},
+    cancel:{status_pagamento:'cancelado',observacoes:'cancelamento manual'}
+  };
+  const payload=payloads[action];
+  for(const id of ids){
+    try{
+      const r=await fetch(`/admin/transacoes/${id}`,{
+        method:'PATCH',
+        headers:{'Content-Type':'application/json','x-admin-pin':getPin()},
+        body:JSON.stringify(payload)
+      });
+      if(!r.ok) throw new Error(await r.text());
+    }catch(e){ toast(`Falha em ${id}`,'error'); }
+  }
+  toast('Transações atualizadas.','success');
+  await fetchTransacoes(state.page);
+  await fetchResumo();
+}
+// event listeners
+document.getElementById('save-pin').addEventListener('click',()=>{
+  setPin(document.getElementById('admin-pin').value.trim());
+  toast('PIN salvo','success');
 });
-document.getElementById('next').addEventListener('click', () => {
-  const lastPage = Math.floor((state.total-1) / state.limit);
-  if (state.page < lastPage) load(state.page + 1);
+
+document.getElementById('btn-buscar').addEventListener('click',()=>{fetchTransacoes(0);fetchResumo();});
+
+document.getElementById('btn-limpar').addEventListener('click',()=>{
+  document.getElementById('f-cpf').value='';
+  const {desde,ate}=defaultDates();
+  document.getElementById('f-desde').value=desde;
+  document.getElementById('f-ate').value=ate;
+  document.getElementById('f-status').value='';
+  document.getElementById('f-metodo').value='';
+  fetchTransacoes(0);fetchResumo();
 });
 
-document.getElementById('btn-csv').addEventListener('click', () => {
-  const q = readFilters();
-  const params = new URLSearchParams(Object.fromEntries(Object.entries(q).filter(([_,v])=>v)));
-  const pin = getPin();
-  // Abre em nova aba com o header via query fallback (?pin=...), e também tentamos header via fetch+blob se preferir
-  const url = `/admin/transacoes/csv?${params.toString()}`;
-  // Usamos fetch para mandar o header x-admin-pin
-  fetch(url, { headers: { 'x-admin-pin': pin } })
-    .then(r => r.blob())
-    .then(b => {
-      const a = document.createElement('a');
-      a.href = URL.createObjectURL(b);
-      a.download = 'transacoes.csv';
+document.getElementById('prev').addEventListener('click',()=>{
+  if(state.page>0) fetchTransacoes(state.page-1);
+});
+
+document.getElementById('next').addEventListener('click',()=>{
+  const last = Math.floor((state.total-1)/LIMIT);
+  if(state.page<last) fetchTransacoes(state.page+1);
+});
+
+document.getElementById('chk-all').addEventListener('change',e=>{
+  const on=e.target.checked;
+  document.querySelectorAll('#rows input[type="checkbox"]').forEach(c=>{
+    c.checked=on;
+    const id=Number(c.dataset.id);
+    if(on) state.selected.add(id); else state.selected.delete(id);
+  });
+  updateBulkButtons();
+});
+
+document.getElementById('rows').addEventListener('change',e=>{
+  if(e.target.matches('input[type="checkbox"]')){
+    const id=Number(e.target.dataset.id);
+    if(e.target.checked) state.selected.add(id); else state.selected.delete(id);
+    updateBulkButtons();
+  }
+});
+
+document.getElementById('rows').addEventListener('click',e=>{
+  const act=e.target.dataset.act;
+  if(!act) return;
+  const id=e.target.dataset.id;
+  if(act==='pagar') patchTransacao(id,{status_pagamento:'pago',metodo_pagamento:'pix',observacoes:'liquidação manual'});
+  if(act==='pendente') patchTransacao(id,{status_pagamento:'pendente',observacoes:'ajuste manual'});
+  if(act==='cancelar') patchTransacao(id,{status_pagamento:'cancelado',observacoes:'cancelamento manual'});
+});
+
+document.getElementById('bulk-pay').addEventListener('click',()=>bulk('pay'));
+document.getElementById('bulk-pend').addEventListener('click',()=>bulk('pend'));
+document.getElementById('bulk-cancel').addEventListener('click',()=>bulk('cancel'));
+
+document.getElementById('btn-csv').addEventListener('click',()=>{
+  const f = readFilters();
+  const url = `/admin/transacoes/csv?${qs(f)}`;
+  fetch(url,{headers:{'x-admin-pin':getPin()}})
+    .then(r=>r.blob())
+    .then(b=>{
+      const desde=f.desde||'inicio';
+      const ate=f.ate||'hoje';
+      const a=document.createElement('a');
+      a.href=URL.createObjectURL(b);
+      a.download=`transacoes_${desde}_a_${ate}.csv`;
       a.click();
       URL.revokeObjectURL(a.href);
-    })
-    .catch(e => alert('Falha ao baixar CSV: ' + e.message));
+    }).catch(()=>toast('Erro ao exportar','error'));
 });
 
-// carregamento inicial
-load(0).catch(e => console.error(e));
+function init(){
+  const {desde,ate}=defaultDates();
+  document.getElementById('f-desde').value=desde;
+  document.getElementById('f-ate').value=ate;
+  document.getElementById('admin-pin').value=getPin();
+  fetchResumo();
+  fetchTransacoes(0);
+}
+init();


### PR DESCRIPTION
## Summary
- add dark-themed admin panel for transactions with PIN storage and filters
- show KPI summary and paginated table with row and bulk actions
- allow CSV export and simple toasts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b77466a298832b8cc7792bd82ec526