### PR TITLE
feat: add admin transactions panel

### DIFF
--- a/public/transacoes-admin.html
+++ b/public/transacoes-admin.html
@@ -1,134 +1,122 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="pt-BR">
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Transações (Admin)</title>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>Painel de Transações | Clube de Vantagens</title>
   <style>
-    body{margin:0;font-family:system-ui,sans-serif;background:#111;color:#eee;}
-    .container{max-width:1200px;margin:0 auto;padding:20px;}
-    h1{margin-top:0;}
-    input,select,button{padding:8px;border-radius:4px;border:1px solid #555;background:#222;color:#eee;font-size:14px;}
-    button{cursor:pointer;}
-    button.primary{background:#2563eb;border-color:#2563eb;color:#fff;}
-    button[disabled]{opacity:.5;cursor:not-allowed;}
-    .card{background:#1e1e1e;border:1px solid #333;border-radius:8px;padding:16px;margin-top:16px;}
-    .grid{display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));}
-    table{width:100%;border-collapse:collapse;margin-top:12px;}
-    th,td{padding:8px;border-bottom:1px solid #333;text-align:left;}
-    th{background:#222;}
-    tr:nth-child(even){background:#1a1a1a;}
-    .pager{display:flex;align-items:center;gap:8px;margin-top:8px;}
-    .kpis{display:grid;gap:12px;margin-top:16px;}
-    .kpi{background:#222;padding:12px;border-radius:8px;text-align:center;}
-    .chip{padding:2px 6px;border-radius:4px;font-size:12px;text-transform:capitalize;color:#fff;}
-    .chip.pago{background:#16a34a;}
-    .chip.pendente{background:#d97706;}
-    .chip.cancelado{background:#dc2626;}
-    @media(max-width:700px){
-      .col-cliente,.col-desc,.col-metodo,.col-obs{display:none;}
-    }
-    .toast-box{position:fixed;bottom:1rem;right:1rem;display:grid;gap:.5rem;}
-    .toast{background:#333;color:#fff;padding:8px 12px;border-radius:4px;}
-    .toast--success{border-left:4px solid #16a34a;}
-    .toast--error{border-left:4px solid #dc2626;}
-    .toast--info{border-left:4px solid #2563eb;}
-    .actions{display:flex;gap:8px;flex-wrap:wrap;}
+    :root { --bg:#0f172a; --card:#111827; --muted:#334155; --text:#e5e7eb; --accent:#22c55e; --warn:#f59e0b; --danger:#ef4444; }
+    body{margin:0;background:var(--bg);color:var(--text);font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,'Helvetica Neue',Arial,'Noto Sans','Apple Color Emoji','Segoe UI Emoji';}
+    .wrap{max-width:1100px;margin:20px auto;padding:0 12px;}
+    .row{display:flex;gap:12px;flex-wrap:wrap;align-items:flex-end}
+    .card{background:var(--card);border:1px solid #1f2937;border-radius:14px;padding:16px}
+    h1{margin:8px 0 14px 0;font-size:20px}
+    label{font-size:12px;color:#94a3b8;display:block;margin-bottom:6px}
+    input,select{background:#0b1220;color:var(--text);border:1px solid #233047;border-radius:10px;padding:10px 12px;min-height:40px}
+    input[type="date"]{padding:8px 10px}
+    button{border:0;border-radius:10px;padding:10px 14px;cursor:pointer}
+    .btn{background:#1f2937;color:#d1d5db}
+    .btn.primary{background:#22c55e;color:#03210f;font-weight:600}
+    .btn.warn{background:var(--warn);color:#2b1a00}
+    .btn.danger{background:var(--danger);color:#220606}
+    .kpis{display:grid;grid-template-columns:repeat(6,1fr);gap:10px;margin:14px 0}
+    .kpi{background:#0b1220;border:1px solid #233047;border-radius:12px;padding:12px}
+    .kpi b{display:block;font-size:18px;margin-top:6px}
+    .table{width:100%;border-collapse:collapse}
+    .table th,.table td{border-bottom:1px solid #223049;padding:10px;text-align:left;font-size:14px}
+    .status{padding:4px 8px;border-radius:999px;font-size:12px}
+    .status.pago{background:#052e1a;color:#51ffa0;border:1px solid #174b34}
+    .status.pendente{background:#2a2305;color:#ffe68f;border:1px solid #4b3d17}
+    .status.cancelado{background:#3b0b0b;color:#ffaaaa;border:1px solid #5a1a1a}
+    .toolbar{display:flex;gap:8px;flex-wrap:wrap;margin:10px 0}
+    .muted{color:#9aa8be}
+    .right{margin-left:auto}
+    .pagination{display:flex;gap:8px;align-items:center}
+    .checkbox{width:18px;height:18px}
+    .pin{display:flex;gap:8px;align-items:flex-end}
+    .pin input{width:120px;text-align:center;font-weight:600;letter-spacing:2px}
+    .help{font-size:12px;color:#9aa8be;margin-top:6px}
+    @media (max-width:900px){ .kpis{grid-template-columns:repeat(2,1fr);} }
   </style>
 </head>
 <body>
-<div class="container">
-  <h1>Gestão de Transações</h1>
+  <div class="wrap">
+    <h1>Painel de Transações</h1>
 
-  <div class="card">
-    <label for="admin-pin">PIN Admin</label>
-    <div class="actions">
-      <input id="admin-pin" type="password" placeholder="****">
-      <button id="save-pin">Salvar PIN</button>
-    </div>
-  </div>
-
-  <div class="card">
-    <h2>Filtros</h2>
-    <div class="grid">
+    <div class="row card">
       <div>
-        <label>CPF</label>
-        <input id="f-cpf" placeholder="apenas números">
+        <label>PIN do Admin</label>
+        <div class="pin">
+          <input id="pin" type="password" placeholder="2468"/>
+          <button class="btn" id="btn-salvar-pin">Salvar PIN</button>
+        </div>
+        <div class="help">O PIN fica salvo no navegador e vai no header <code>x-admin-pin</code> em todas as requisições.</div>
       </div>
+    </div>
+
+    <div class="row card" style="margin-top:12px">
       <div>
-        <label>Desde</label>
-        <input type="date" id="f-desde">
+        <label>De</label>
+        <input type="date" id="f-desde"/>
       </div>
       <div>
         <label>Até</label>
-        <input type="date" id="f-ate">
+        <input type="date" id="f-ate"/>
+      </div>
+      <div>
+        <label>CPF (somente números)</label>
+        <input type="text" id="f-cpf" placeholder="ex.: 52998224725" maxlength="14"/>
       </div>
       <div>
         <label>Status</label>
         <select id="f-status">
-          <option value="">(todos)</option>
-          <option value="pendente">pendente</option>
+          <option value="">(qualquer)</option>
           <option value="pago">pago</option>
+          <option value="pendente">pendente</option>
           <option value="cancelado">cancelado</option>
         </select>
       </div>
       <div>
         <label>Método</label>
-        <select id="f-metodo">
-          <option value="">(todos)</option>
-          <option value="pix">pix</option>
-          <option value="credito">credito</option>
-          <option value="debito">debito</option>
-          <option value="dinheiro">dinheiro</option>
-        </select>
+        <input type="text" id="f-metodo" placeholder="pix/cartao/dinheiro"/>
+      </div>
+      <div>
+        <button class="btn primary" id="btn-buscar">Buscar</button>
+      </div>
+      <div class="right pagination">
+        <button class="btn" id="btn-prev">&laquo; Anterior</button>
+        <span id="pag-info" class="muted">Página 1</span>
+        <button class="btn" id="btn-next">Próxima &raquo;</button>
       </div>
     </div>
-    <div class="actions" style="margin-top:8px;">
-      <button id="btn-buscar" class="primary">Buscar</button>
-      <button id="btn-limpar">Limpar filtros</button>
-      <button id="btn-csv">Exportar CSV</button>
+
+    <div class="kpis" id="kpis">
+      <!-- preenchido via JS -->
+    </div>
+
+    <div class="toolbar">
+      <button class="btn primary" id="btn-massa-pagar">Pagar selecionadas</button>
+      <button class="btn warn" id="btn-massa-pendente">Pendente selecionadas</button>
+      <button class="btn danger" id="btn-massa-cancelar">Cancelar selecionadas</button>
+      <div class="right">
+        <button class="btn" id="btn-exportar">Exportar CSV</button>
+      </div>
+    </div>
+
+    <div class="card">
+      <table class="table" id="tabela">
+        <thead>
+          <tr>
+            <th><input type="checkbox" id="check-all" class="checkbox"/></th>
+            <th>ID</th><th>Data</th><th>CPF</th><th>Bruto</th><th>Desc.</th><th>Final</th><th>Status</th><th>Método</th><th>Ações</th>
+          </tr>
+        </thead>
+        <tbody id="tbody"></tbody>
+      </table>
+      <div class="help">Mostrando no máximo 20 por página, do mais novo para o mais antigo.</div>
     </div>
   </div>
 
-  <div class="card">
-    <h2>Resumo</h2>
-    <div class="kpis" id="kpis"></div>
-  </div>
-
-  <div class="card">
-    <div class="actions" style="justify-content:flex-end;margin-bottom:8px;">
-      <button id="bulk-pay" disabled>Pagar selecionadas</button>
-      <button id="bulk-pend" disabled>Marcar pendente</button>
-      <button id="bulk-cancel" disabled>Cancelar</button>
-    </div>
-    <table>
-      <thead>
-        <tr>
-          <th><input type="checkbox" id="chk-all"></th>
-          <th>ID</th>
-          <th>Data</th>
-          <th>CPF</th>
-          <th class="col-cliente">Cliente</th>
-          <th class="col-desc">% Desc</th>
-          <th>Bruto</th>
-          <th>Final</th>
-          <th>Status</th>
-          <th class="col-metodo">Método</th>
-          <th class="col-obs">Obs</th>
-          <th>Ações</th>
-        </tr>
-      </thead>
-      <tbody id="rows"></tbody>
-    </table>
-    <div class="pager">
-      <button id="prev">Anterior</button>
-      <span id="pageinfo"></span>
-      <button id="next">Próxima</button>
-    </div>
-  </div>
-
-</div>
-<div id="toasts" class="toast-box"></div>
-<script src="transacoes-admin.js"></script>
+  <script src="./transacoes-admin.js"></script>
 </body>
 </html>

--- a/public/transacoes-admin.js
+++ b/public/transacoes-admin.js
@@ -1,237 +1,199 @@
-const PIN_KEY = 'cv_admin_pin';
-const LIMIT = 20;
-const state = { page: 0, total: 0, selected: new Set() };
-
-function getPin(){
-  return localStorage.getItem(PIN_KEY) || '';
-}
-function setPin(v){
-  localStorage.setItem(PIN_KEY, v);
-}
-function toast(msg, type='info'){
-  const box = document.getElementById('toasts');
-  const el = document.createElement('div');
-  el.className = `toast toast--${type}`;
-  el.textContent = msg;
-  box.appendChild(el);
-  setTimeout(()=>el.remove(),3000);
-}
-function readFilters(){
-  return {
-    cpf: document.getElementById('f-cpf').value.replace(/\D/g,''),
-    desde: document.getElementById('f-desde').value,
-    ate: document.getElementById('f-ate').value,
-    status_pagamento: document.getElementById('f-status').value,
-    metodo_pagamento: document.getElementById('f-metodo').value,
+(() => {
+  const state = {
+    limit: 20,
+    offset: 0,
+    total: 0,
+    rows: [],
+    pin: localStorage.getItem('admin_pin') || '',
   };
-}
-function qs(obj){
-  const p = new URLSearchParams();
-  Object.entries(obj).forEach(([k,v])=>{ if(v) p.append(k,v); });
-  return p.toString();
-}
-function fmtMoney(n){
-  if(n==null) return '';
-  return Number(n).toLocaleString('pt-BR',{style:'currency',currency:'BRL'});
-}
-function defaultDates(){
-  const now = new Date();
-  const y = now.getFullYear();
-  const m = String(now.getMonth()+1).padStart(2,'0');
-  const d = String(now.getDate()).padStart(2,'0');
-  return { desde:`${y}-${m}-01`, ate:`${y}-${m}-${d}` };
-}
-async function fetchResumo(){
-  const f = readFilters();
-  delete f.cpf;
-  const r = await fetch(`/admin/transacoes/resumo?${qs(f)}`,{headers:{'x-admin-pin':getPin()}});
-  if(!r.ok){ toast('Erro ao carregar resumo','error'); return; }
-  const j = await r.json();
-  const k = document.getElementById('kpis');
-  k.innerHTML = `
-    <div class="kpi"><div>Transações</div><strong>${j.total||0}</strong></div>
-    <div class="kpi"><div>Soma Bruta</div><strong>${fmtMoney(j.somaBruta)}</strong></div>
-    <div class="kpi"><div>Soma Final</div><strong>${fmtMoney(j.somaFinal)}</strong></div>
-    <div class="kpi"><div>Desconto Total</div><strong>${fmtMoney(j.descontoTotal)}</strong></div>
-    <div class="kpi"><div>Desconto Médio (%)</div><strong>${Number(j.descontoMedioPercent||0).toFixed(2)}%</strong></div>
-    <div class="kpi"><div>Ticket Médio</div><strong>${fmtMoney(j.ticketMedio)}</strong></div>`;
-}
-async function fetchTransacoes(page=0){
-  state.page = page;
-  const f = readFilters();
-  const params = new URLSearchParams();
-  Object.entries(f).forEach(([k,v])=>{ if(v) params.append(k,v); });
-  params.append('limit', LIMIT);
-  params.append('offset', page*LIMIT);
-  const r = await fetch(`/admin/transacoes?${params.toString()}`,{headers:{'x-admin-pin':getPin()}});
-  if(!r.ok){ toast('Erro ao buscar','error'); return; }
-  const j = await r.json();
-  state.total = j.total || 0;
-  renderRows(j.rows||[]);
-}
-function renderRows(rows){
-  const tb = document.getElementById('rows');
-  tb.innerHTML='';
-  state.selected.clear();
-  document.getElementById('chk-all').checked=false;
-  if(rows.length===0){
-    const tr=document.createElement('tr');
-    tr.innerHTML = `<td colspan="12" style="text-align:center;">Sem resultados</td>`;
-    tb.appendChild(tr);
-  }else{
-    for(const r of rows){
-      const dt = r.created_at? new Date(r.created_at):null;
-      const desc = r.desconto_aplicado!=null? `${r.desconto_aplicado}%`:'';
-      const st = r.status_pagamento||'';
-      const tr=document.createElement('tr');
-      tr.innerHTML=`
-        <td><input type="checkbox" data-id="${r.id}"></td>
-        <td>${r.id}</td>
-        <td>${dt? dt.toLocaleDateString('pt-BR'):''}</td>
-        <td>${r.cpf||''}</td>
-        <td class="col-cliente">${r.cliente||r.nome||''}</td>
-        <td class="col-desc">${desc}</td>
-        <td>${fmtMoney(r.valor_original)}</td>
-        <td>${fmtMoney(r.valor_final)}</td>
-        <td><span class="chip ${st}">${st}</span></td>
-        <td class="col-metodo">${r.metodo_pagamento||''}</td>
-        <td class="col-obs">${r.observacoes||''}</td>
-        <td>
-          <div class="actions">
-            <button data-act="pagar" data-id="${r.id}">Pagar</button>
-            <button data-act="pendente" data-id="${r.id}">Pendente</button>
-            <button data-act="cancelar" data-id="${r.id}">Cancelar</button>
-          </div>
-        </td>`;
-      tb.appendChild(tr);
-    }
-  }
-  const totalPages = Math.max(1, Math.ceil(state.total / LIMIT));
-  document.getElementById('pageinfo').textContent = `Página ${state.page+1} de ${totalPages} (${state.total} registros)`;
-  updateBulkButtons();
-}
-function updateBulkButtons(){
-  const on = state.selected.size>0;
-  document.getElementById('bulk-pay').disabled=!on;
-  document.getElementById('bulk-pend').disabled=!on;
-  document.getElementById('bulk-cancel').disabled=!on;
-}
-async function patchTransacao(id, payload){
-  try{
-    const r = await fetch(`/admin/transacoes/${id}`,{
+
+  const el = (id) => document.getElementById(id);
+  const fmtBRL = (n) => (typeof n === 'number' ? n : Number(n||0)).toLocaleString('pt-BR',{style:'currency',currency:'BRL'});
+  const fmtDate = (s) => {
+    if(!s) return '';
+    const d = new Date(s);
+    return d.toLocaleString('pt-BR');
+  };
+  const qs = (o) => Object.entries(o).filter(([,v])=>v!=='' && v!=null)
+    .map(([k,v])=>`${encodeURIComponent(k)}=${encodeURIComponent(v)}`).join('&');
+
+  const getPin = () => state.pin || el('pin').value.trim();
+  const setPin = (pin) => { state.pin = pin; localStorage.setItem('admin_pin', pin); };
+
+  const apiGet = async (path, params={}) => {
+    const url = params && Object.keys(params).length ? `${path}?${qs(params)}` : path;
+    const r = await fetch(url, { headers: { 'x-admin-pin': getPin() }});
+    if (!r.ok) throw new Error(await r.text());
+    return r.json();
+  };
+  const apiPatch = async (path, body) => {
+    const r = await fetch(path, {
       method:'PATCH',
-      headers:{'Content-Type':'application/json','x-admin-pin':getPin()},
-      body: JSON.stringify(payload)
+      headers: { 'Content-Type': 'application/json', 'x-admin-pin': getPin() },
+      body: JSON.stringify(body || {})
     });
-    if(!r.ok){ throw new Error(await r.text()); }
-    toast(`Transação ${id} atualizada.`, 'success');
-    await fetchTransacoes(state.page);
-    await fetchResumo();
-  }catch(err){ toast('Erro ao atualizar: '+err.message,'error'); }
-}
-async function bulk(action){
-  const ids = Array.from(state.selected);
-  if(ids.length===0) return;
-  const payloads={
-    pay:{status_pagamento:'pago',metodo_pagamento:'pix',observacoes:'liquidação manual'},
-    pend:{status_pagamento:'pendente',observacoes:'ajuste manual'},
-    cancel:{status_pagamento:'cancelado',observacoes:'cancelamento manual'}
+    if (!r.ok) throw new Error(await r.text());
+    return r.json();
   };
-  const payload=payloads[action];
-  for(const id of ids){
-    try{
-      const r=await fetch(`/admin/transacoes/${id}`,{
-        method:'PATCH',
-        headers:{'Content-Type':'application/json','x-admin-pin':getPin()},
-        body:JSON.stringify(payload)
-      });
-      if(!r.ok) throw new Error(await r.text());
-    }catch(e){ toast(`Falha em ${id}`,'error'); }
+
+  function defaultPeriodo(){
+    const hoje = new Date();
+    const ate = hoje.toISOString().slice(0,10);
+    const dd = new Date(hoje); dd.setDate(dd.getDate()-7);
+    const desde = dd.toISOString().slice(0,10);
+    el('f-desde').value ||= desde;
+    el('f-ate').value ||= ate;
   }
-  toast('Transações atualizadas.','success');
-  await fetchTransacoes(state.page);
-  await fetchResumo();
-}
-// event listeners
-document.getElementById('save-pin').addEventListener('click',()=>{
-  setPin(document.getElementById('admin-pin').value.trim());
-  toast('PIN salvo','success');
-});
 
-document.getElementById('btn-buscar').addEventListener('click',()=>{fetchTransacoes(0);fetchResumo();});
+  async function carregarResumo(){
+    const p = filtros();
+    const j = await apiGet('/admin/transacoes/resumo', p);
+    renderKpis(j);
+  }
 
-document.getElementById('btn-limpar').addEventListener('click',()=>{
-  document.getElementById('f-cpf').value='';
-  const {desde,ate}=defaultDates();
-  document.getElementById('f-desde').value=desde;
-  document.getElementById('f-ate').value=ate;
-  document.getElementById('f-status').value='';
-  document.getElementById('f-metodo').value='';
-  fetchTransacoes(0);fetchResumo();
-});
+  async function carregarTabela(){
+    const p = { ...filtros(), limit: state.limit, offset: state.offset };
+    const j = await apiGet('/admin/transacoes', p);
+    state.rows = j.rows || [];
+    state.total = j.total || 0;
+    renderTabela();
+    renderPag();
+  }
 
-document.getElementById('prev').addEventListener('click',()=>{
-  if(state.page>0) fetchTransacoes(state.page-1);
-});
+  function filtros(){
+    return {
+      desde: el('f-desde').value,
+      ate: el('f-ate').value,
+      cpf: (el('f-cpf').value||'').replace(/\D+/g,''),
+      status: el('f-status').value,
+      metodo: el('f-metodo').value
+    };
+  }
 
-document.getElementById('next').addEventListener('click',()=>{
-  const last = Math.floor((state.total-1)/LIMIT);
-  if(state.page<last) fetchTransacoes(state.page+1);
-});
+  function renderKpis(j){
+    const k = el('kpis');
+    const porStatus = j.porStatus || {};
+    k.innerHTML = `
+      <div class="kpi"><span class="muted">Transações</span><b>${j.total}</b></div>
+      <div class="kpi"><span class="muted">Soma Bruta</span><b>${fmtBRL(j.somaBruta||0)}</b></div>
+      <div class="kpi"><span class="muted">Soma Final</span><b>${fmtBRL(j.somaFinal||0)}</b></div>
+      <div class="kpi"><span class="muted">Desconto Total</span><b>${fmtBRL(j.descontoTotal||0)}</b></div>
+      <div class="kpi"><span class="muted">Desc. Médio</span><b>${(j.descontoMedioPercent||0).toFixed(2)}%</b></div>
+      <div class="kpi"><span class="muted">Ticket Médio</span><b>${fmtBRL(j.ticketMedio||0)}</b></div>
+    `;
+  }
 
-document.getElementById('chk-all').addEventListener('change',e=>{
-  const on=e.target.checked;
-  document.querySelectorAll('#rows input[type="checkbox"]').forEach(c=>{
-    c.checked=on;
-    const id=Number(c.dataset.id);
-    if(on) state.selected.add(id); else state.selected.delete(id);
+  function statusBadge(s){
+    const cls = s === 'pago' ? 'pago' : s === 'cancelado' ? 'cancelado' : 'pendente';
+    return `<span class="status ${cls}">${s||'—'}</span>`;
+  }
+
+  function renderTabela(){
+    const tb = el('tbody');
+    tb.innerHTML = state.rows.map(r => `
+      <tr>
+        <td><input class="checkbox row-check" data-id="${r.id}" type="checkbox"/></td>
+        <td>${r.id}</td>
+        <td>${fmtDate(r.created_at)}</td>
+        <td>${r.cpf || '—'}</td>
+        <td>${fmtBRL(r.valor_original)}</td>
+        <td>${typeof r.desconto_aplicado === 'string' ? r.desconto_aplicado : (r.desconto_aplicado ?? '—')}</td>
+        <td>${fmtBRL(r.valor_final)}</td>
+        <td>${statusBadge(r.status_pagamento || 'pendente')}</td>
+        <td>${r.metodo_pagamento || '—'}</td>
+        <td>
+          <button class="btn primary" data-act="pagar" data-id="${r.id}">Pagar</button>
+          <button class="btn warn" data-act="pendente" data-id="${r.id}">Pendente</button>
+          <button class="btn danger" data-act="cancelar" data-id="${r.id}">Cancelar</button>
+        </td>
+      </tr>
+    `).join('');
+  }
+
+  function renderPag(){
+    const page = Math.floor(state.offset/state.limit)+1;
+    const pages = Math.max(1, Math.ceil(state.total/state.limit));
+    el('pag-info').textContent = `Página ${page} de ${pages}`;
+  }
+
+  async function buscar(){
+    state.offset = 0;
+    await Promise.all([carregarResumo(), carregarTabela()]);
+  }
+
+  async function mudarStatus(id, status){
+    const body = { status_pagamento: status };
+    if(status === 'pago') body.metodo_pagamento = 'pix';
+    body.observacoes = 'alterado via painel';
+    await apiPatch(`/admin/transacoes/${id}`, body);
+  }
+
+  async function massa(status){
+    const ids = [...document.querySelectorAll('.row-check:checked')].map(i => i.dataset.id);
+    if(ids.length===0){ alert('Selecione ao menos uma linha.'); return; }
+    for (const id of ids) {
+      try { await mudarStatus(id, status); } catch(e){ console.error(e); }
+    }
+    await buscar();
+  }
+
+  async function exportarCSV(){
+    const p = filtros();
+    const url = `/admin/transacoes/csv?${qs(p)}`;
+    const r = await fetch(url, { headers: { 'x-admin-pin': getPin() }});
+    if(!r.ok){ alert('Falha ao exportar CSV'); return; }
+    const blob = await r.blob();
+    const a = document.createElement('a');
+    const d = p.desde || 'inicio';
+    const atee = p.ate || 'hoje';
+    a.href = URL.createObjectURL(blob);
+    a.download = `transacoes_${d}_a_${atee}.csv`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  }
+
+  // Eventos
+  document.addEventListener('click', async (e) => {
+    const t = e.target;
+    if (t.id === 'btn-salvar-pin') {
+      setPin(el('pin').value.trim());
+      alert('PIN salvo!');
+      return;
+    }
+    if (t.id === 'btn-buscar') { await buscar(); return; }
+    if (t.id === 'btn-prev') { state.offset = Math.max(0, state.offset - state.limit); await carregarTabela(); return; }
+    if (t.id === 'btn-next') { 
+      const next = state.offset + state.limit;
+      if (next < state.total) { state.offset = next; await carregarTabela(); }
+      return;
+    }
+    if (t.id === 'btn-exportar') { await exportarCSV(); return; }
+    if (t.id === 'btn-massa-pagar') { await massa('pago'); return; }
+    if (t.id === 'btn-massa-pendente') { await massa('pendente'); return; }
+    if (t.id === 'btn-massa-cancelar') { await massa('cancelado'); return; }
+
+    // Ações por linha
+    if (t.dataset && t.dataset.act && t.dataset.id) {
+      const id = t.dataset.id;
+      const act = t.dataset.act;
+      const map = { pagar:'pago', pendente:'pendente', cancelar:'cancelado' };
+      try {
+        await mudarStatus(id, map[act]);
+        await buscar();
+      } catch(err){ console.error(err); alert('Falha ao atualizar.'); }
+    }
+
+    if (t.id === 'check-all'){
+      const on = t.checked;
+      document.querySelectorAll('.row-check').forEach(c => c.checked = on);
+    }
   });
-  updateBulkButtons();
-});
 
-document.getElementById('rows').addEventListener('change',e=>{
-  if(e.target.matches('input[type="checkbox"]')){
-    const id=Number(e.target.dataset.id);
-    if(e.target.checked) state.selected.add(id); else state.selected.delete(id);
-    updateBulkButtons();
-  }
-});
-
-document.getElementById('rows').addEventListener('click',e=>{
-  const act=e.target.dataset.act;
-  if(!act) return;
-  const id=e.target.dataset.id;
-  if(act==='pagar') patchTransacao(id,{status_pagamento:'pago',metodo_pagamento:'pix',observacoes:'liquidação manual'});
-  if(act==='pendente') patchTransacao(id,{status_pagamento:'pendente',observacoes:'ajuste manual'});
-  if(act==='cancelar') patchTransacao(id,{status_pagamento:'cancelado',observacoes:'cancelamento manual'});
-});
-
-document.getElementById('bulk-pay').addEventListener('click',()=>bulk('pay'));
-document.getElementById('bulk-pend').addEventListener('click',()=>bulk('pend'));
-document.getElementById('bulk-cancel').addEventListener('click',()=>bulk('cancel'));
-
-document.getElementById('btn-csv').addEventListener('click',()=>{
-  const f = readFilters();
-  const url = `/admin/transacoes/csv?${qs(f)}`;
-  fetch(url,{headers:{'x-admin-pin':getPin()}})
-    .then(r=>r.blob())
-    .then(b=>{
-      const desde=f.desde||'inicio';
-      const ate=f.ate||'hoje';
-      const a=document.createElement('a');
-      a.href=URL.createObjectURL(b);
-      a.download=`transacoes_${desde}_a_${ate}.csv`;
-      a.click();
-      URL.revokeObjectURL(a.href);
-    }).catch(()=>toast('Erro ao exportar','error'));
-});
-
-function init(){
-  const {desde,ate}=defaultDates();
-  document.getElementById('f-desde').value=desde;
-  document.getElementById('f-ate').value=ate;
-  document.getElementById('admin-pin').value=getPin();
-  fetchResumo();
-  fetchTransacoes(0);
-}
-init();
+  // Inicialização
+  window.addEventListener('load', async () => {
+    defaultPeriodo();
+    if (state.pin) el('pin').value = state.pin;
+    await buscar();
+  });
+})();


### PR DESCRIPTION
## Summary
- add static admin transactions panel with filters, KPIs, bulk actions and CSV export
- persist admin PIN and send x-admin-pin header on requests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b777c74e38832bb368bd026e46c588