### PR TITLE
feat: add batch transaction tools and configs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,6 +21,56 @@
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
       "envFile": "${workspaceFolder}/.env"
+    },
+    {
+      "name": "API: Dev (nodemon)",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "restart": true,
+      "envFile": "${workspaceFolder}/.env"
+    },
+    {
+      "name": "Jest: Watch (todos os testes)",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "test:watch"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "env": { "NODE_ENV": "test" }
+    },
+    {
+      "name": "Jest: Arquivo atual",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "test:file", "--", "${relativeFile}"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "env": { "NODE_ENV": "test" }
+    },
+    {
+      "name": "Jest: Todos (uma vez)",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "test"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "env": { "NODE_ENV": "test" }
+    }
+  ],
+  "compounds": [
+    {
+      "name": "API + Jest (watch)",
+      "configurations": ["API: Dev (nodemon)", "Jest: Watch (todos os testes)"],
+      "stopAll": true
     }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  "rest-client.environmentVariables": {
+    "$shared": {
+      "PIN": "2468"
+    },
+    "prod": {
+      "API": "https://clube-vantagens-api-production.up.railway.app"
+    },
+    "local": {
+      "API": "http://localhost:3000"
+    }
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,6 +8,10 @@
       "isBackground": true,
       "runOptions": { "runOn": "folderOpen" },
       "problemMatcher": []
-    }
+    },
+    { "label": "dev", "type": "npm", "script": "dev", "problemMatcher": [] },
+    { "label": "test:watch", "type": "npm", "script": "test:watch", "problemMatcher": [] },
+    { "label": "test:file (arquivo atual)", "type": "shell", "command": "npm run test:file -- ${file}", "problemMatcher": [] },
+    { "label": "tx:pago (últimos 3 dias)", "type": "shell", "command": "npm run tx:pago -- --desde=$(date -I -d '3 days ago') --ate=$(date -I)", "problemMatcher": [] }
   ]
 }

--- a/docs/admin-transacoes.http
+++ b/docs/admin-transacoes.http
@@ -1,0 +1,30 @@
+### Ambiente: mude para @prod ou @local no cabeçalho abaixo
+@host = {{API}}  // vindo do .vscode/settings.json
+@pin  = {{PIN}}
+
+### 1) Listagem paginada
+GET {{host}}/admin/transacoes?desde=2025-09-01&ate=2025-09-03&limit=10&offset=0
+x-admin-pin: {{pin}}
+
+### 2) Resumo geral
+GET {{host}}/admin/transacoes/resumo?desde=2025-09-01&ate=2025-09-03
+x-admin-pin: {{pin}}
+
+### 3) Resumo somente pagos
+GET {{host}}/admin/transacoes/resumo?desde=2025-09-01&ate=2025-09-03&status=pago
+x-admin-pin: {{pin}}
+
+### 4) Pegar o primeiro ID (use a resposta de #1)
+# copie o "id" e cole na variável abaixo:
+@id = 32
+
+### 5) Marcar como pago (idempotente)
+PATCH {{host}}/admin/transacoes/{{id}}
+x-admin-pin: {{pin}}
+content-type: application/json
+
+{
+  "status_pagamento": "pago",
+  "metodo_pagamento": "pix",
+  "observacoes": "via REST Client"
+}

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,9 @@
+{
+  "watch": ["controllers", "src", "server.js"],
+  "ext": "js,json",
+  "ignore": ["node_modules", ".git", "tests"],
+  "env": {
+    "NODE_ENV": "development",
+    "PORT": "3000"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,12 @@
     "migrate": "dbmate up",
     "test:ci": "cross-env NODE_ENV=test dotenv_config_path=.env.test node ./node_modules/jest/bin/jest.js --runInBand --reporters=default --ci",
     "audit:dup": "node scripts/audit-duplicates.cjs",
-    "smoke": "cross-env NODE_ENV=test ADMIN_PIN=2468 node tests/smoke.js"
+    "smoke": "cross-env NODE_ENV=test ADMIN_PIN=2468 node tests/smoke.js",
+    "test:file": "cross-env NODE_ENV=test dotenv_config_path=.env.test node ./node_modules/jest/bin/jest.js --runInBand --config jest.config.js",
+    "tx:mark": "node scripts/mark-transacoes.js",
+    "tx:pago": "node scripts/mark-transacoes.js --status=pago",
+    "tx:pendente": "node scripts/mark-transacoes.js --status=pendente",
+    "tx:cancelado": "node scripts/mark-transacoes.js --status=cancelado"
   },
   "keywords": [],
   "author": "",
@@ -37,6 +42,7 @@
     "cross-env": "^7.0.3",
     "dbmate": "^2.0.0",
     "jest": "^29.7.0",
+    "minimist": "^1.2.8",
     "morgan": "^1.10.0",
     "nodemon": "^3.1.10",
     "supertest": "^6.3.4"

--- a/scripts/mark-transacoes.js
+++ b/scripts/mark-transacoes.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+const fetch = require('node-fetch');
+const args = require('minimist')(process.argv.slice(2));
+const API = process.env.API || 'https://clube-vantagens-api-production.up.railway.app';
+const PIN = process.env.PIN || '2468';
+
+const desde = args.desde || new Date(Date.now() - 3*864e5).toISOString().slice(0,10);
+const ate   = args.ate   || new Date().toISOString().slice(0,10);
+const status = args.status || 'pago';
+const limit = Number(args.limit || 100);
+const offset = Number(args.offset || 0);
+const metodo = args.metodo || 'pix';
+const obsBase = args.obs || `ajuste em lote (${status})`;
+
+(async () => {
+  try {
+    const listUrl = `${API}/admin/transacoes?desde=${desde}&ate=${ate}&limit=${limit}&offset=${offset}`;
+    const listRes = await fetch(listUrl, { headers: { 'x-admin-pin': PIN }});
+    if (!listRes.ok) throw new Error(`List fail: ${listRes.status} ${await listRes.text()}`);
+    const list = await listRes.json();
+    const ids = (list.rows || []).map(r => r.id);
+    console.log(`Encontradas ${ids.length} transações no período ${desde}..${ate}.`);
+
+    let ok = 0, fail = 0;
+    for (const id of ids) {
+      const body = {
+        status_pagamento: status,
+        metodo_pagamento: metodo,
+        observacoes: `${obsBase} - id ${id}`
+      };
+      const res = await fetch(`${API}/admin/transacoes/${id}`, {
+        method: 'PATCH',
+        headers: {
+          'x-admin-pin': PIN,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify(body)
+      });
+      if (res.ok) { ok++; process.stdout.write('.'); }
+      else { fail++; process.stdout.write('x'); }
+    }
+    console.log(`\nFeito. OK=${ok} FAIL=${fail}`);
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+})();

--- a/tests/transacoes.int.test.js
+++ b/tests/transacoes.int.test.js
@@ -1,0 +1,56 @@
+const fetch = require('node-fetch');
+
+const API = process.env.API || 'https://clube-vantagens-api-production.up.railway.app';
+const PIN = process.env.PIN || '2468';
+
+const get = (path) => fetch(`${API}${path}`, { headers: { 'x-admin-pin': PIN }});
+const json = async (res) => ({ status: res.status, body: await res.json() });
+
+describe('Admin Transações (integração leve)', () => {
+  jest.setTimeout(20000);
+
+  test('lista no período', async () => {
+    const res = await get('/admin/transacoes?desde=2025-09-01&ate=2025-09-03&limit=5&offset=0');
+    const { body } = await json(res);
+    expect(res.status).toBe(200);
+    expect(body).toHaveProperty('ok', true);
+    expect(body).toHaveProperty('rows');
+  });
+
+  test('resumo geral no período', async () => {
+    const res = await get('/admin/transacoes/resumo?desde=2025-09-01&ate=2025-09-03');
+    const { body } = await json(res);
+    expect(res.status).toBe(200);
+    expect(body).toHaveProperty('ok', true);
+    expect(body).toHaveProperty('porStatus');
+  });
+
+  test('resumo pagos no período', async () => {
+    const res = await get('/admin/transacoes/resumo?desde=2025-09-01&ate=2025-09-03&status=pago');
+    const { body } = await json(res);
+    expect(res.status).toBe(200);
+    expect(body).toHaveProperty('ok', true);
+    expect(body.porStatus).toHaveProperty('pago');
+  });
+
+  test('PATCH idempotente em um item (não muda o status atual)', async () => {
+    // pega o primeiro id e mantém o mesmo status/metodo
+    const list = await get('/admin/transacoes?desde=2025-09-01&ate=2025-09-03&limit=1&offset=0').then(json);
+    const row = list.body.rows?.[0];
+    if (!row) return; // nada para testar
+
+    const payload = {
+      status_pagamento: row.status_pagamento || 'pago',
+      metodo_pagamento: row.metodo_pagamento || 'pix',
+      observacoes: 'noop via teste'
+    };
+    const patch = await fetch(`${API}/admin/transacoes/${row.id}`, {
+      method: 'PATCH',
+      headers: { 'x-admin-pin': PIN, 'content-type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    const j = await patch.json();
+    expect(patch.status).toBe(200);
+    expect(j).toHaveProperty('ok', true);
+  });
+});


### PR DESCRIPTION
## Summary
- add npm scripts and batch transaction marker
- wire up nodemon and VS Code configs for dev and tests
- include REST Client examples and light integration test

## Testing
- `npm install -D minimist` *(fails: 403 Forbidden)*
- `npm run test:file -- tests/transacoes.int.test.js` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68b77d7a5ad4832b80dbe7a56d8f6e70