### PR TITLE
feat(security): enable helmet/rate-limit and log invalid admin pin

### DIFF
--- a/middlewares/requireAdminPin.js
+++ b/middlewares/requireAdminPin.js
@@ -24,6 +24,11 @@ async function requireAdminPin(req, res, next) {
     }
 
     if (!data) {
+      console.warn('[PIN_INVALID]', {
+        route: req.originalUrl,
+        ip: req.ip,
+        timestamp: new Date().toISOString(),
+      });
       return res.status(401).json({ ok:false, error:'invalid_pin' });
     }
 

--- a/server.js
+++ b/server.js
@@ -1,10 +1,23 @@
 const express = require('express');
+const helmet = require('helmet');
+const rateLimit = require('express-rate-limit');
 const supabase = require('./services/supabase');
 
 const app = express();
 
 // body parser primeiro
 app.use(express.json());
+
+// segurança
+const RATE_LIMIT_WINDOW_MS = parseInt(process.env.RATE_LIMIT_WINDOW_MS, 10) || 15 * 60 * 1000;
+const RATE_LIMIT_MAX = parseInt(process.env.RATE_LIMIT_MAX, 10) || 300;
+app.use(helmet());
+app.use(
+  rateLimit({
+    windowMs: RATE_LIMIT_WINDOW_MS,
+    limit: RATE_LIMIT_MAX,
+  })
+);
 
 // CORS dinâmico
 const ALLOWED_ORIGIN = (process.env.ALLOWED_ORIGIN || '*')


### PR DESCRIPTION
## Summary
- add helmet and rate limiting middleware configured via env vars
- warn console for invalid admin PIN attempts with route, ip and timestamp

## Testing
- `npm test` *(fails: connect ENETUNREACH 66.33.22.41:443)*

------
https://chatgpt.com/codex/tasks/task_e_68b78e05da20832baf9909703d430a75