### PR TITLE
fix: tolerant boot and security middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "server.js",
   "scripts": {
+    "prestart": "node scripts/maybe-migrate.cjs",
     "start": "node server.js",
     "dev": "nodemon server.js",
     "test": "jest --runInBand",


### PR DESCRIPTION
## Summary
- add tolerant runtime migration script
- guard helmet and rate limiter requires, add basic CORS and health endpoint
- move helmet and express-rate-limit to dependencies and run migrations on prestart

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7a1c9a1c0832ba35f155de6615815