### PR TITLE
Add auto RZ handling for batch conference UI

### DIFF
--- a/public/admin/conferencia/app.js
+++ b/public/admin/conferencia/app.js
@@ -1,0 +1,156 @@
+// Camada de UI da conferência de lotes.
+// [Ajuste] O app agora escuta o evento 'rz:auto' para aplicar o valor gerado
+//          automaticamente no <select>, exibe o alerta visual e aplica o RZ
+//          salvo no store durante a inicialização.
+
+import store, { on } from './store/index.js';
+import { processarPlanilha } from './excel.js';
+
+let rzSelect;
+let rzAlert;
+let fileInput;
+
+let initialized = false;
+
+function ensureAutoOption(rz) {
+  if (!rzSelect) return;
+
+  const currentAuto = rzSelect.querySelector('option[data-auto-rz="1"]');
+  if (currentAuto && currentAuto.value !== rz) {
+    const duplicates = Array.from(rzSelect.options).filter(
+      (opt) => opt !== currentAuto && opt.value === currentAuto.value,
+    );
+    if (duplicates.length === 0) {
+      currentAuto.remove();
+    } else {
+      currentAuto.dataset.autoRz = '';
+    }
+  }
+
+  let option = Array.from(rzSelect.options).find((opt) => opt.value === rz);
+  if (!option) {
+    option = document.createElement('option');
+    option.value = rz;
+    option.textContent = rz;
+    option.dataset.autoRz = '1';
+    rzSelect.appendChild(option);
+  } else {
+    option.dataset.autoRz = '1';
+  }
+
+  if (rzSelect.value !== rz) {
+    option.selected = true;
+    rzSelect.value = rz;
+    rzSelect.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+}
+
+function removeAutoOption() {
+  if (!rzSelect) return;
+  const autoOption = rzSelect.querySelector('option[data-auto-rz="1"]');
+  if (!autoOption) return;
+
+  const duplicates = Array.from(rzSelect.options).filter(
+    (opt) => opt !== autoOption && opt.value === autoOption.value,
+  );
+
+  const wasSelected = autoOption.selected;
+
+  if (duplicates.length === 0) {
+    autoOption.remove();
+    if (wasSelected) {
+      const fallback = rzSelect.options[0];
+      if (fallback) {
+        rzSelect.value = fallback.value;
+        rzSelect.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+    }
+  } else {
+    delete autoOption.dataset.autoRz;
+  }
+}
+
+export function applyAutoRzSelection(rz) {
+  if (!rz) return;
+  ensureAutoOption(rz);
+  renderAutoRzAlert(rz);
+}
+
+function renderAutoRzAlert(rz) {
+  if (!rzAlert) return;
+  if (rz) {
+    rzAlert.classList.add('alert', 'alert--warn', 'is-visible');
+    rzAlert.removeAttribute('hidden');
+    rzAlert.textContent = '⚠️ Nenhuma coluna RZ encontrada, usando ';
+    const strong = document.createElement('strong');
+    strong.textContent = rz;
+    rzAlert.appendChild(strong);
+  } else {
+    rzAlert.classList.remove('is-visible');
+    rzAlert.setAttribute('hidden', 'hidden');
+    rzAlert.textContent = '';
+  }
+}
+
+async function handleFileChange(event) {
+  const file = event?.target?.files?.[0];
+  if (!file) return;
+
+  try {
+    await processarPlanilha(file);
+    if (store.state.rzAuto) {
+      applyAutoRzSelection(store.state.rzAuto);
+    } else {
+      renderAutoRzAlert('');
+      removeAutoOption();
+    }
+  } catch (err) {
+    console.error('[app] falha ao processar planilha', err);
+    renderAutoRzAlert('');
+  }
+}
+
+function registerEvents() {
+  if (fileInput) {
+    fileInput.addEventListener('change', handleFileChange);
+  }
+
+  // [Ajuste] Listener responsável por aplicar imediatamente o RZ automático.
+  on('rz:auto', (rz) => {
+    if (!rz) return;
+    applyAutoRzSelection(rz);
+  });
+
+  on('planilha:update', ({ rzAuto } = {}) => {
+    if (rzAuto) {
+      renderAutoRzAlert(rzAuto);
+    } else {
+      renderAutoRzAlert('');
+      removeAutoOption();
+    }
+  });
+}
+
+export function initApp() {
+  if (initialized) return;
+  initialized = true;
+
+  rzSelect = document.querySelector('#select-rz');
+  rzAlert = document.querySelector('[data-auto-rz-alert]');
+  fileInput = document.querySelector('[data-planilha-input]');
+
+  registerEvents();
+
+  if (store.state.rzAuto) {
+    applyAutoRzSelection(store.state.rzAuto);
+  } else {
+    renderAutoRzAlert('');
+    removeAutoOption();
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initApp);
+} else {
+  initApp();
+}

--- a/public/admin/conferencia/excel.js
+++ b/public/admin/conferencia/excel.js
@@ -1,0 +1,154 @@
+// Rotinas relacionadas ao parsing da planilha de lotes.
+// [Ajuste] parsePlanilha agora garante o retorno de { itens, rzs, rzAuto }
+//          e gera um RZ automático quando a coluna não existir. Além disso,
+//          processarPlanilha dispara o evento 'rz:auto' quando aplicamos o valor gerado.
+
+import store, { emit, setCurrentRZ, setPlanilhaData } from './store/index.js';
+
+const RZ_KEY = 'rz';
+
+const normalizeKey = (key = '') =>
+  key
+    .toString()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+
+const sanitizeCell = (value) => {
+  if (value == null) return '';
+  if (typeof value === 'string') return value.trim();
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  return value;
+};
+
+const normalizeRow = (row = {}) => {
+  const out = {};
+  Object.entries(row).forEach(([key, value]) => {
+    const normalizedKey = normalizeKey(key);
+    if (!normalizedKey) return;
+    out[normalizedKey] = sanitizeCell(value);
+  });
+  return out;
+};
+
+const isRowEmpty = (row = {}) =>
+  Object.keys(row).length === 0 || Object.values(row).every((value) => {
+    if (value == null) return true;
+    if (typeof value === 'string') return value.trim() === '';
+    return false;
+  });
+
+const getRzValue = (row = {}) => {
+  const raw = row[RZ_KEY];
+  if (raw == null) return '';
+  if (typeof raw === 'string') return raw.trim();
+  return raw.toString().trim();
+};
+
+const buildAutoRz = (fileName = '') => {
+  const baseName = fileName
+    .toString()
+    .replace(/\.[^/.]+$/, '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-zA-Z0-9]+/g, '-');
+
+  const clean = baseName.replace(/^-+|-+$/g, '').toUpperCase();
+  return `RZ-${clean || 'AUTO'}`;
+};
+
+const getFileName = (input, explicitName = '') => {
+  if (explicitName) return explicitName;
+  if (typeof input === 'object' && input && 'name' in input) return input.name;
+  return '';
+};
+
+async function loadRows(input, options = {}) {
+  if (Array.isArray(options.rows)) return options.rows;
+  if (Array.isArray(input)) return input;
+  if (!input) return [];
+
+  const xlsxLib =
+    options.xlsx ||
+    (typeof window !== 'undefined' ? window.XLSX : undefined);
+
+  if (!xlsxLib) {
+    throw new Error('Biblioteca XLSX não disponível para leitura da planilha.');
+  }
+
+  const arrayBuffer =
+    input instanceof ArrayBuffer ? input : await input.arrayBuffer();
+  const workbook =
+    options.workbook || xlsxLib.read(arrayBuffer, { type: 'array' });
+  const sheetName = options.sheetName || workbook.SheetNames[0];
+  if (!sheetName) return [];
+  const sheet = workbook.Sheets[sheetName];
+  if (!sheet) return [];
+
+  return xlsxLib.utils.sheet_to_json(sheet, { defval: '' });
+}
+
+export async function parsePlanilha(input, options = {}) {
+  const rows = await loadRows(input, options);
+  const nomeArquivo = getFileName(input, options.fileName);
+
+  const itens = rows
+    .map(normalizeRow)
+    .filter((row) => !isRowEmpty(row));
+
+  const possuiColunaRz = itens.some((row) => Object.prototype.hasOwnProperty.call(row, RZ_KEY));
+  const possuiValorRz = possuiColunaRz && itens.some((row) => getRzValue(row));
+
+  let rzAuto = '';
+  const rzs = new Set();
+
+  if (!possuiColunaRz || !possuiValorRz) {
+    rzAuto = buildAutoRz(nomeArquivo);
+    itens.forEach((row) => {
+      row[RZ_KEY] = rzAuto;
+    });
+    rzs.add(rzAuto);
+  } else {
+    itens.forEach((row) => {
+      const valor = getRzValue(row);
+      row[RZ_KEY] = valor;
+      if (valor) rzs.add(valor);
+    });
+  }
+
+  return {
+    itens,
+    rzs: Array.from(rzs),
+    rzAuto,
+  };
+}
+
+export async function processarPlanilha(input, options = {}) {
+  const { itens, rzs, rzAuto } = await parsePlanilha(input, options);
+
+  setPlanilhaData({ itens, rzs, rzAuto });
+
+  const previous = store.state.currentRZ;
+
+  if (rzAuto) {
+    setCurrentRZ(rzAuto, { auto: true });
+    emit('rz:auto', rzAuto);
+  } else {
+    const proximo = previous && rzs.includes(previous) ? previous : (rzs[0] || '');
+    setCurrentRZ(proximo, { auto: false });
+    // Limpa qualquer resquício de auto caso exista, mantendo listeners atualizados.
+    if (store.state.rzAuto) {
+      store.state.rzAuto = '';
+      emit('planilha:update', {
+        itens: store.state.itens,
+        rzs: store.state.rzs,
+        rzAuto: store.state.rzAuto,
+      });
+    }
+  }
+
+  return { itens, rzs, rzAuto };
+}

--- a/public/admin/conferencia/store/index.js
+++ b/public/admin/conferencia/store/index.js
@@ -1,0 +1,73 @@
+// Store simples para coordenar o estado da conferência de lotes.
+// [Ajuste] Este arquivo foi revisado para expor setCurrentRZ com suporte
+//          ao valor automático e para adicionar a função on(event, cb).
+
+const state = {
+  itens: [],
+  rzs: [],
+  currentRZ: '',
+  rzAuto: '',
+};
+
+const listeners = new Map();
+
+function emit(event, payload) {
+  const subs = listeners.get(event);
+  if (!subs) return;
+  subs.forEach((cb) => {
+    try {
+      cb(payload);
+    } catch (err) {
+      // Mantemos o erro visível para diagnóstico sem interromper os demais listeners.
+      console.error('[store] listener error for', event, err);
+    }
+  });
+}
+
+function on(event, callback) {
+  if (!listeners.has(event)) {
+    listeners.set(event, new Set());
+  }
+  const subs = listeners.get(event);
+  subs.add(callback);
+  return () => subs.delete(callback);
+}
+
+function setPlanilhaData({ itens = [], rzs = [], rzAuto = '' } = {}) {
+  state.itens = Array.isArray(itens) ? [...itens] : [];
+  state.rzs = Array.isArray(rzs) ? [...rzs] : [];
+  // [Ajuste] Sempre sincronizamos o valor automático armazenado no estado.
+  state.rzAuto = typeof rzAuto === 'string' ? rzAuto.trim() : (rzAuto ?? '').toString().trim();
+
+  // Ajusta o currentRZ apenas se ele não estiver presente na lista atual.
+  if (!state.rzs.includes(state.currentRZ) && !state.rzAuto) {
+    state.currentRZ = state.rzs[0] || '';
+  }
+
+  emit('planilha:update', { itens: state.itens, rzs: state.rzs, rzAuto: state.rzAuto });
+}
+
+function setCurrentRZ(rz, { auto = false } = {}) {
+  const value = typeof rz === 'string' ? rz.trim() : (rz ?? '').toString().trim();
+  state.currentRZ = value;
+
+  if (auto) {
+    // [Ajuste] Quando o valor é automático, mantemos cópia em state.rzAuto.
+    state.rzAuto = value;
+  } else if (state.rzAuto && value !== state.rzAuto) {
+    // Limpa o auto-RZ caso o usuário selecione manualmente outro valor.
+    state.rzAuto = '';
+  }
+
+  emit('rz:change', state.currentRZ);
+}
+
+export { state, emit, on, setPlanilhaData, setCurrentRZ };
+
+export default {
+  state,
+  emit,
+  on,
+  setPlanilhaData,
+  setCurrentRZ,
+};


### PR DESCRIPTION
## Summary
- add conference store helper that exposes setCurrentRZ with automatic tracking and event subscriptions
- ensure Excel parser always returns { itens, rzs, rzAuto } and emits an rz:auto event when generating an automatic code
- update UI app to subscribe to rz:auto, preselect the generated value, and show the visual alert

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d28ab5ec58832bbf6786ba80e62345